### PR TITLE
fix(superposition): fix degenerate A-matrix for disconnected-line pai…

### DIFF
--- a/expert_op4grid_recommender/utils/superposition.py
+++ b/expert_op4grid_recommender/utils/superposition.py
@@ -223,16 +223,22 @@ def get_betas_coeff(delta_theta_unit_acts, delta_theta_start,
 
     # Build the A matrix
     a = np.zeros((n, n))
-    threshold = 1e-6
+    # p_or threshold: must be physically meaningful (not numerical noise).
+    # Disconnected lines in pypowsybl have p_or ~ 1e-5 MW (noise). Using a
+    # threshold of 1.0 MW ensures we only use p_or when the line is actually
+    # carrying significant flow. Below this, delta_theta is more reliable.
+    p_or_threshold = 1.0
+    dt_threshold = 1e-6
     for j in range(n):
         for i in range(n):
             if i == j:
                 a[j][i] = 1.0
             else:
-                # Use p_or if both are non-zero, otherwise use delta_theta
-                if abs(p_or_start[j]) > threshold:
+                # Use p_or if the start flow is physically significant,
+                # otherwise fall back to delta_theta.
+                if abs(p_or_start[j]) > p_or_threshold:
                     a[j][i] = 1.0 - p_or_unit_acts[i][j] / p_or_start[j]
-                elif abs(delta_theta_start[j]) > threshold:
+                elif abs(delta_theta_start[j]) > dt_threshold:
                     a[j][i] = 1.0 - delta_theta_unit_acts[i][j] / delta_theta_start[j]
                 else:
                     a[j][i] = 1.0  # No coupling info available
@@ -558,6 +564,65 @@ def compute_combined_pair_superposition(
         idls.append(act2_line_idxs[0])
     else:
         idls.append(act2_sub_idxs[0])
+
+    # ---- No-op detection ----
+    # If an action has no effect on the grid topology/state, the off-diagonal
+    # column for that action in the A-matrix collapses to zero, forcing the
+    # other beta to 1 regardless of the pair partner.
+    #
+    # For line actions: use line_status (topology) directly — this is robust
+    # even for lines with near-zero flow (lightly loaded but connected lines).
+    #
+    # For sub actions: use delta_theta between the two buses as the indicator
+    # of whether the topology actually changed (split/merge happened).
+    noop_dt_threshold = 1e-6   # radians — below this, angles are indistinguishable
+    noop_rel_tol = 0.01        # 1% relative change required to be "not a no-op"
+
+    unit_act_obs = [obs_act1, obs_act2]
+    for act_idx, (act_is_line, line_idxs, sub_idxs, ind_sub, is_ref) in enumerate([
+        (act1_is_line, act1_line_idxs, act1_sub_idxs, ind_sub_act1, is_start_ref_act1),
+        (act2_is_line, act2_line_idxs, act2_sub_idxs, ind_sub_act2, is_start_ref_act2),
+    ]):
+        obs_act_n = unit_act_obs[act_idx]
+
+        if act_is_line:
+            # For a line action, check whether the connection status changed.
+            # This is topology-based and works regardless of the flow magnitude
+            # (handles lightly-loaded lines correctly, unlike a flow threshold).
+            line_idx = line_idxs[0]
+            status_start = bool(obs_start.line_status[line_idx])
+            status_after = bool(obs_act_n.line_status[line_idx])
+            changed = (status_start != status_after)
+        else:
+            # For a sub action, check whether the substation topology actually
+            # changed. Use delta_theta between the two buses as the indicator:
+            # - reference topology (single bus): delta_theta = 0 always
+            # - split topology (two buses): delta_theta ≠ 0
+            # If is_ref=True (start is single-bus), the action should have split it
+            # (making delta_theta non-zero in obs_act_n).
+            # If is_ref=False (start is already split), the action should merge it
+            # (making delta_theta ≈ 0 in obs_act_n).
+            sub_idx = sub_idxs[0]
+            dt_start = delta_theta_start_list[act_idx]
+            dt_own = delta_theta_unit_act_list[act_idx][act_idx]
+            if abs(dt_start) > noop_dt_threshold:
+                changed = abs(dt_own - dt_start) / abs(dt_start) > noop_rel_tol
+            elif abs(dt_own) > noop_dt_threshold:
+                # dt_start was zero (single-bus) but dt_own is non-zero: split happened
+                changed = True
+            else:
+                changed = False  # Both near-zero — no topology change
+
+        if not changed:
+            act_name = f"action{act_idx + 1}"
+            elem_desc = (f"line {line_idxs[0]}" if act_is_line else f"sub {sub_idxs[0]}")
+            return {
+                "error": (
+                    f"No-op action detected: {act_name}'s characteristic element "
+                    f"({elem_desc}) shows no topology change in obs_start. "
+                    f"Action has no effect."
+                )
+            }
 
     # ---- Compute betas ----
     betas = get_betas_coeff(

--- a/tests/test_superposition.py
+++ b/tests/test_superposition.py
@@ -9,23 +9,23 @@ def test_compute_all_pairs_superposition_simplified_dict():
     # Mock environment and observations
     env = MagicMock()
     env.name_line = ["LINE1", "LINE2", "LINE3"]
-    
+
     obs_start = MagicMock()
     obs_start.rho = np.array([1.1, 0.5, 0.5]) # Overload on LINE1
     obs_start.p_or = np.array([100.0, 50.0, 50.0])
-    
+
     # Mock unitary actions
     aid1 = "reco_LINE2"
     aid2 = "reco_LINE3"
-    
+
     obs_act1 = MagicMock()
     obs_act1.rho = np.array([1.0, 0.5, 0.5])
     obs_act1.p_or = np.array([90.0, 50.0, 50.0])
-    
+
     obs_act2 = MagicMock()
     obs_act2.rho = np.array([1.0, 0.5, 0.5])
     obs_act2.p_or = np.array([90.0, 50.0, 50.0])
-    
+
     detailed_actions = {
         aid1: {
             "action": MagicMock(),
@@ -38,60 +38,65 @@ def test_compute_all_pairs_superposition_simplified_dict():
             "description_unitaire": "Close LINE3"
         }
     }
-    
+
     classifier = MagicMock(spec=ActionClassifier)
     classifier.identify_action_type.return_value = "close_line"
     classifier._action_space = MagicMock()
-    
-    # Mock identify_action_elements to return something
+
     from expert_op4grid_recommender.utils import superposition
-    superposition._identify_action_elements = MagicMock(return_value=([1], [])) # Act1 affects LINE2
-    
-    # Specifically for this test, we mock the elements for each call
+
     def mock_identify(action, action_id, *args):
         if action_id == aid1: return ([1], [])
         if action_id == aid2: return ([2], [])
         return ([], [])
-    superposition._identify_action_elements.side_effect = mock_identify
 
-    # Mock compute_combined_pair_superposition to avoid real linear solving in this unit test
-    superposition.compute_combined_pair_superposition = MagicMock(return_value={
-        "betas": [0.5, 0.5],
-        "p_or_combined": [80.0, 50.0, 50.0]
-    })
+    # Save originals and restore them after the test so other tests are not affected
+    orig_identify = superposition._identify_action_elements
+    orig_compute = superposition.compute_combined_pair_superposition
+    try:
+        superposition._identify_action_elements = MagicMock(side_effect=mock_identify)
+        # Mock compute_combined_pair_superposition to avoid real linear solving
+        superposition.compute_combined_pair_superposition = MagicMock(return_value={
+            "betas": [0.5, 0.5],
+            "p_or_combined": [80.0, 50.0, 50.0]
+        })
 
-    results = compute_all_pairs_superposition(
-        obs_start=obs_start,
-        detailed_actions=detailed_actions,
-        classifier=classifier,
-        env=env,
-        lines_overloaded_ids=[0], # LINE1
-        lines_we_care_about=["LINE1", "LINE2", "LINE3"],
-        pre_existing_rho={i: 0.5 for i in range(3)},
-        dict_action={}
-    )
-    
-    assert len(results) == 1
-    pair_id = f"{aid1}+{aid2}"
-    assert pair_id in results
-    
-    res = results[pair_id]
-    
-    # Check present keys
-    assert "betas" in res
-    assert "max_rho" in res
-    assert "max_rho_line" in res
-    assert "is_rho_reduction" in res
-    assert "description" in res
-    assert "action1_id" in res
-    assert "action2_id" in res
-    
-    # Check keys that MUST be removed
-    assert "p_or_combined" not in res
-    assert "rho_after" not in res
-    assert "rho_before" not in res
+        results = compute_all_pairs_superposition(
+            obs_start=obs_start,
+            detailed_actions=detailed_actions,
+            classifier=classifier,
+            env=env,
+            lines_overloaded_ids=[0],  # LINE1
+            lines_we_care_about=["LINE1", "LINE2", "LINE3"],
+            pre_existing_rho={i: 0.5 for i in range(3)},
+            dict_action={}
+        )
 
-    print("\n[Test] Simplified dictionary verified successfully.")
+        assert len(results) == 1
+        pair_id = f"{aid1}+{aid2}"
+        assert pair_id in results
+
+        res = results[pair_id]
+
+        # Check present keys
+        assert "betas" in res
+        assert "max_rho" in res
+        assert "max_rho_line" in res
+        assert "is_rho_reduction" in res
+        assert "description" in res
+        assert "action1_id" in res
+        assert "action2_id" in res
+
+        # Check keys that MUST be removed
+        assert "p_or_combined" not in res
+        assert "rho_after" not in res
+        assert "rho_before" not in res
+
+        print("\n[Test] Simplified dictionary verified successfully.")
+    finally:
+        superposition._identify_action_elements = orig_identify
+        superposition.compute_combined_pair_superposition = orig_compute
+
 
 if __name__ == "__main__":
     test_compute_all_pairs_superposition_simplified_dict()

--- a/tests/test_superposition_action_types.py
+++ b/tests/test_superposition_action_types.py
@@ -255,7 +255,7 @@ class TestDiverseActionTypeSuperposition(unittest.TestCase):
         self.assertLessEqual(max_diff, self.tol)
 
     def test_node_splitting_line_disconnection_combination_sup_theorem(self):
-        """Line action + node splitting: compute_combined_pair_superposition matches target."""
+        """Line disconnection + node splitting: compute_combined_pair_superposition matches target."""
         self.env.set_id(self.chronic_id)
         self.env.reset()
 
@@ -264,7 +264,7 @@ class TestDiverseActionTypeSuperposition(unittest.TestCase):
 
         obs_start, *_ = self.env.step(self.env.action_space())
 
-        act_line = self.env.action_space({"set_line_status": [(id_l1, +1)]})
+        act_line = self.env.action_space({"set_line_status": [(id_l1, -1)]})  # disconnect
         act_split = self.env.action_space({"set_bus": {"substations_id": [(5, (1, 1, 2, 2, 1, 2, 2))]}})
 
         obs1 = obs_start.simulate(act_line, time_step=0)[0]
@@ -711,6 +711,61 @@ class TestDiverseActionTypeSuperposition(unittest.TestCase):
         from expert_op4grid_recommender.utils.superposition import _get_theta_node
         theta_bus2 = _get_theta_node(obs, id_sub, bus=2)
         self.assertEqual(theta_bus2, 0.0, "Bus 2 of a single-bus sub should have theta == 0")
+
+
+    def test_noop_line_action_returns_error(self):
+        """Reconnecting an already-connected line is a no-op; superposition must return an error.
+
+        No-op detection uses line_status (topology) directly, not flow magnitude.
+        This is robust for lightly-loaded lines that may have near-zero flow while
+        still being connected.
+        """
+        self.env.set_id(self.chronic_id)
+        self.env.reset()
+
+        id_l1 = 3   # line 3 is connected in obs_start
+        id_sub = 5
+
+        obs_start, *_ = self.env.step(self.env.action_space())
+
+        # Verify line is connected in obs_start
+        self.assertTrue(obs_start.line_status[id_l1],
+                        "Line id_l1 should be connected in obs_start")
+
+        # Line 3 is already connected → set_line_status(+1) is a no-op
+        act_noop_reco = self.env.action_space({"set_line_status": [(id_l1, +1)]})
+        act_split = self.env.action_space({"set_bus": {"substations_id": [(5, (1, 1, 2, 2, 1, 2, 2))]}})
+
+        obs_noop = obs_start.simulate(act_noop_reco, time_step=0)[0]
+        obs_split = obs_start.simulate(act_split, time_step=0)[0]
+
+        # Verify the no-op didn't change the line status
+        self.assertEqual(obs_start.line_status[id_l1], obs_noop.line_status[id_l1],
+                         "No-op reco should not change line_status")
+
+        # Pair: noop reco (act1=line) + node splitting (act2=sub)
+        result = compute_combined_pair_superposition(
+            obs_start,
+            obs_noop,    # obs_act1: reconnect already-connected line (no-op)
+            obs_split,   # obs_act2: node splitting
+            act1_line_idxs=[id_l1], act1_sub_idxs=[],
+            act2_line_idxs=[], act2_sub_idxs=[id_sub],
+        )
+        self.assertIn("error", result,
+                      "No-op line action should trigger error, not produce spurious betas")
+        self.assertIn("No-op", result["error"])
+
+        # Pair: node splitting (act1=sub) + noop reco (act2=line) — reversed
+        result_rev = compute_combined_pair_superposition(
+            obs_start,
+            obs_split,   # obs_act1: node splitting
+            obs_noop,    # obs_act2: reconnect already-connected line (no-op)
+            act1_line_idxs=[], act1_sub_idxs=[id_sub],
+            act2_line_idxs=[id_l1], act2_sub_idxs=[],
+        )
+        self.assertIn("error", result_rev,
+                      "No-op line action (as act2) should trigger error too")
+        self.assertIn("No-op", result_rev["error"])
 
 
 if __name__ == "__main__":

--- a/tests/test_superposition_extended.py
+++ b/tests/test_superposition_extended.py
@@ -35,12 +35,18 @@ def test_compute_pair_multiple_elements():
     # Verify that it uses the first element when multiple are provided
     obs_start = MagicMock()
     obs_start.p_or = np.array([100.0, 50.0])
-    
+    # Line 0 disconnected (status False), line 1 connected (status True)
+    obs_start.line_status = np.array([False, True])
+
     obs_act1 = MagicMock()
     obs_act1.p_or = np.array([90.0, 50.0])
-    
+    # act1 reconnects line 0: status flips to True
+    obs_act1.line_status = np.array([True, True])
+
     obs_act2 = MagicMock()
-    obs_act2.p_or = np.array([100.0, 40.0]) 
+    obs_act2.p_or = np.array([100.0, 40.0])
+    # act2 acts on line 1 (disconnects it): status flips to False
+    obs_act2.line_status = np.array([False, False])
     
     # We need to mock get_delta_theta_line and other helper functions 
     # if we want to test the full logic, but compute_combined_pair_superposition 


### PR DESCRIPTION
…rs and no-op actions

- Raise p_or threshold in get_betas_coeff from 1e-6 to 1.0 MW: pypowsybl returns ~7e-5 MW noise for disconnected lines which was being used as a denominator, amplifying noise into the A-matrix off-diagonal entries and forcing betas[0]=1 for all pairs involving a disconnected line action. Below 1 MW, delta_theta is used instead (more reliable for near-zero flows).

- Replace flow-based no-op detection with topology-based detection:
  - Line actions: compare obs_start.line_status vs obs_actN.line_status — robust for lightly-loaded connected lines that have near-zero flow.
  - Sub actions: compare delta_theta before/after — checks whether the bus split/merge actually changed the topology.

- Fix test_superposition.py: module-level mock of compute_combined_pair_superposition was not restored, leaking into subsequent tests. Wrap in try/finally to always restore originals.

- Fix test_superposition_extended.py: add line_status arrays to MagicMock observations so the topology-based no-op check gets real boolean values.

- Fix test_superposition_action_types.py: test_node_splitting_line_disconnection was reconnecting an already-connected line (+1 on connected line = no-op). Changed to disconnection (-1) to match the test name and intent. Add test_noop_line_action_returns_error: explicitly covers no-op detection using line_status, with both action orderings (act1 and act2).