### PR TITLE
fix(superposition): detect and reject ill-conditioned beta solutions

### DIFF
--- a/expert_op4grid_recommender/utils/superposition.py
+++ b/expert_op4grid_recommender/utils/superposition.py
@@ -634,6 +634,36 @@ def compute_combined_pair_superposition(
     if np.any(np.isnan(betas)):
         return {"error": "Singular system — cannot compute betas", "betas": betas.tolist()}
 
+    # ---- Sanity check on betas ----
+    # If any individual beta is outside a physically reasonable range, the
+    # superposition theorem has broken down for this pair.  This happens when
+    # the two actions are strongly electrically coupled — applying one action
+    # dramatically shifts the characteristic feature (p_or or delta_theta) of
+    # the other action's element, making the A-matrix off-diagonal entries
+    # blow up and the solved betas become extreme.
+    #
+    # Physical reasoning:
+    #   beta_i represents "how much of action i's effect survives in the combined
+    #   state".  Values in [0, 1] are normal; mildly outside this range can occur
+    #   for pairs with significant electrical coupling.  However, values outside
+    #   [-2, 3] indicate the A-matrix is ill-conditioned and the result is
+    #   numerically unreliable (e.g. betas like [0.89, -4.25]).
+    #
+    # NOTE: sum(betas) > 2 is NOT a reliable indicator — valid pairs with strong
+    # mutual coupling can legitimately produce sums above 2 (e.g. [1.06, 0.98])
+    # while still passing the accuracy test within tolerance.
+    BETA_MIN = -2.0
+    BETA_MAX = 3.0
+    if np.any(betas < BETA_MIN) or np.any(betas > BETA_MAX):
+        return {
+            "error": (
+                f"Unreliable superposition: betas {np.round(betas, 3).tolist()} are outside "
+                f"the physically meaningful range [{BETA_MIN}, {BETA_MAX}]. "
+                f"The two actions are too strongly coupled for the linear approximation."
+            ),
+            "betas": betas.tolist(),
+        }
+
     # ---- Compute combined p_or ----
     p_or_combined = (1.0 - np.sum(betas)) * obs_start.p_or
     for i in range(2):

--- a/tests/test_superposition_extended.py
+++ b/tests/test_superposition_extended.py
@@ -104,6 +104,101 @@ def test_compute_all_pairs_singular_system():
         assert "error" in results[pair_id]
         assert results[pair_id]["error"] == "Singular system"
 
+def test_compute_pair_out_of_range_betas_returns_error():
+    """When get_betas_coeff returns out-of-range betas, compute_combined_pair_superposition
+    must return an error instead of propagating physically nonsensical values.
+
+    This reproduces the real-world failure mode where two strongly coupled actions
+    (e.g. a coupling action + node_merging) produce betas like [0.89, -4.25]
+    (individual beta < -2.0) which are outside the valid [-2, 3] range and
+    indicate the A-matrix has become ill-conditioned.
+    """
+    obs_start = MagicMock()
+    obs_start.p_or = np.array([100.0, 50.0])
+    obs_start.line_status = np.array([True, False])   # line 0 connected, line 1 disconnected
+
+    obs_act1 = MagicMock()
+    obs_act1.p_or = np.array([80.0, 50.0])
+    obs_act1.line_status = np.array([False, False])   # act1 disconnects line 0
+
+    obs_act2 = MagicMock()
+    obs_act2.p_or = np.array([100.0, 60.0])
+    obs_act2.line_status = np.array([True, True])     # act2 reconnects line 1
+
+    from expert_op4grid_recommender.utils import superposition
+
+    # Inject out-of-range betas (simulates ill-conditioned A-matrix)
+    # Valid range is [-2, 3] for individual betas
+    for bad_betas in [
+        np.array([0.89, -4.25]),  # betas[1]=-4.25 < -2.0 — matches node_merging case
+        np.array([4.0, 4.0]),     # both > 3.0 — clearly out of range
+        np.array([3.5, -2.5]),    # both out of range
+        np.array([0.5, -3.0]),    # betas[1]=-3.0 < -2.0
+    ]:
+        with patch('expert_op4grid_recommender.utils.superposition.get_betas_coeff',
+                   return_value=bad_betas), \
+             patch('expert_op4grid_recommender.utils.superposition.get_delta_theta_line',
+                   return_value=0.05):
+
+            result = compute_combined_pair_superposition(
+                obs_start, obs_act1, obs_act2,
+                act1_line_idxs=[0], act1_sub_idxs=[],
+                act2_line_idxs=[1], act2_sub_idxs=[],
+            )
+
+            assert "error" in result, (
+                f"Expected error for out-of-range betas {bad_betas}, got: {result}"
+            )
+            assert "Unreliable" in result["error"], (
+                f"Error message should mention 'Unreliable', got: {result['error']}"
+            )
+            assert "betas" in result, "Error result should still include betas for debugging"
+
+
+def test_compute_pair_in_range_betas_no_error():
+    """When betas are within [-2, 3], the result should be valid (no error)."""
+    obs_start = MagicMock()
+    obs_start.p_or = np.array([100.0, 50.0])
+    obs_start.rho = np.array([0.8, 0.5])
+    obs_start.line_status = np.array([True, False])
+
+    obs_act1 = MagicMock()
+    obs_act1.p_or = np.array([80.0, 50.0])
+    obs_act1.rho = np.array([0.7, 0.5])
+    obs_act1.line_status = np.array([False, False])
+
+    obs_act2 = MagicMock()
+    obs_act2.p_or = np.array([100.0, 60.0])
+    obs_act2.rho = np.array([0.8, 0.6])
+    obs_act2.line_status = np.array([True, True])
+
+    from expert_op4grid_recommender.utils import superposition
+
+    # Normal betas — within [-2, 3] range
+    for good_betas in [
+        np.array([0.5, 0.5]),
+        np.array([0.9, 0.1]),
+        np.array([-1.5, 0.5]),  # in range (>= -2)
+        np.array([2.8, 0.1]),   # in range (<= 3)
+        np.array([1.46, 0.60]), # realistic case from disco_BEON+reco_CHALOL
+    ]:
+        with patch('expert_op4grid_recommender.utils.superposition.get_betas_coeff',
+                   return_value=good_betas), \
+             patch('expert_op4grid_recommender.utils.superposition.get_delta_theta_line',
+                   return_value=0.05):
+
+            result = compute_combined_pair_superposition(
+                obs_start, obs_act1, obs_act2,
+                act1_line_idxs=[0], act1_sub_idxs=[],
+                act2_line_idxs=[1], act2_sub_idxs=[],
+            )
+
+            assert "error" not in result, (
+                f"Unexpected error for valid betas {good_betas}: {result.get('error')}"
+            )
+            assert "betas" in result
+
+
 from unittest.mock import patch
 
 if __name__ == "__main__":


### PR DESCRIPTION
Add a sanity check on solved betas after get_betas_coeff. When any individual beta falls outside [-2, 3], the A-matrix has become ill-conditioned due to strong electrical coupling between the two actions, and the result is unreliable.

Root cause: when action1 significantly shifts the voltage angles at action2's characteristic element (e.g. disco_BEON changes angles at CHALOL's endpoints), the off-diagonal A-matrix entry blows up and the solved betas are numerically extreme (e.g. [0.89, -4.25]).

The betas [1.46, 0.60] for disco_BEON+reco_CHALOL are within [-2, 3] and represent a legitimate (if surprising) superposition estimate. Only betas like [0.89, -4.25] with an extreme negative value are flagged as unreliable.

Add tests: test_compute_pair_out_of_range_betas_returns_error and test_compute_pair_in_range_betas_no_error.