### PR TITLE
feat(superposition): action-type-aware hybrid rho estimation

### DIFF
--- a/expert_op4grid_recommender/utils/superposition.py
+++ b/expert_op4grid_recommender/utils/superposition.py
@@ -392,7 +392,8 @@ def _identify_action_elements(action, action_id: str, dict_action: dict,
 # Rho estimation from superposed active power
 # =============================================================================
 
-def _estimate_rho_from_p(p_or_combined, p_ex_combined, obs_start):
+def _estimate_rho_from_p(p_or_combined, p_ex_combined, obs_start,
+                         obs_act1=None, obs_act2=None):
     """Estimate rho (loading) from superposed active power flows.
 
     Instead of superposing rho directly (which introduces bias from the
@@ -405,10 +406,16 @@ def _estimate_rho_from_p(p_or_combined, p_ex_combined, obs_start):
     obs_start and the combined state, which is much weaker than assuming
     rho itself superposes linearly.
 
+    For lines where |P_start| < threshold (e.g. disconnected lines), the
+    function attempts a fallback using action observations (obs_act1, obs_act2)
+    to derive the conversion factor.
+
     Args:
         p_or_combined: Superposed active power at origin (MW), array
         p_ex_combined: Superposed active power at extremity (MW), array
         obs_start: Base observation (for rho and p_or/p_ex reference values)
+        obs_act1: Optional observation after action 1 (for fallback on disconnected lines)
+        obs_act2: Optional observation after action 2 (for fallback on disconnected lines)
 
     Returns:
         rho_combined: Estimated loading array per line
@@ -452,12 +459,38 @@ def _estimate_rho_from_p(p_or_combined, p_ex_combined, obs_start):
 
     # Origin extremity: rho_or = |P_or_combined| * (rho_or_start / |P_or_start|)
     safe_or = abs_p_or_start > p_threshold
-    factor_or = np.where(safe_or, rho_or_start / abs_p_or_start, 0.0)
+    with np.errstate(divide='ignore', invalid='ignore'):
+        factor_or = np.where(safe_or, rho_or_start / abs_p_or_start, 0.0)
+
+    # Fallback for origin: use action observations for lines where |P_or_start| < threshold
+    needs_fallback_or = ~safe_or
+    for obs_act in [obs_act1, obs_act2]:
+        if obs_act is None or not np.any(needs_fallback_or):
+            break
+        abs_p_act = np.abs(obs_act.p_or)
+        act_usable = needs_fallback_or & (abs_p_act > p_threshold)
+        if np.any(act_usable):
+            factor_or = np.where(act_usable, obs_act.rho / abs_p_act, factor_or)
+            needs_fallback_or = needs_fallback_or & ~act_usable
+
     rho_or_est = np.abs(p_or_combined) * factor_or
 
     # Extremity side: rho_ex = |P_ex_combined| * (rho_ex_start / |P_ex_start|)
     safe_ex = abs_p_ex_start > p_threshold
-    factor_ex = np.where(safe_ex, rho_ex_start / abs_p_ex_start, 0.0)
+    with np.errstate(divide='ignore', invalid='ignore'):
+        factor_ex = np.where(safe_ex, rho_ex_start / abs_p_ex_start, 0.0)
+
+    # Fallback for extremity: use action observations for lines where |P_ex_start| < threshold
+    needs_fallback_ex = ~safe_ex
+    for obs_act in [obs_act1, obs_act2]:
+        if obs_act is None or not np.any(needs_fallback_ex):
+            break
+        abs_p_act_ex = np.abs(obs_act.p_ex)
+        act_usable_ex = needs_fallback_ex & (abs_p_act_ex > p_threshold)
+        if np.any(act_usable_ex):
+            factor_ex = np.where(act_usable_ex, obs_act.rho / abs_p_act_ex, factor_ex)
+            needs_fallback_ex = needs_fallback_ex & ~act_usable_ex
+
     rho_ex_est = np.abs(p_ex_combined) * factor_ex
 
     if MAX_RHO_BOTH_EXTREMITIES:
@@ -465,16 +498,85 @@ def _estimate_rho_from_p(p_or_combined, p_ex_combined, obs_start):
     else:
         rho_combined = rho_or_est
 
-    # For lines where both factors were unreliable (both |P| < threshold),
-    # fall back to direct rho superposition as a last resort.
+    # For lines where both factors were unreliable (both |P| < threshold)
+    # AND the fallback also didn't resolve them, set rho to 0.
     # This only affects lines with negligible flow, which won't be the
     # max_rho line anyway.
-    both_unreliable = ~safe_or & ~safe_ex
+    both_unreliable = needs_fallback_or & needs_fallback_ex
     if np.any(both_unreliable):
         # These lines have near-zero flow — rho is essentially 0
         rho_combined[both_unreliable] = 0.0
 
     return rho_combined
+
+
+def _compute_delta_theta_all_lines(obs):
+    """Compute delta_theta for every line (works for both connected and disconnected).
+
+    For connected lines, uses obs.theta_or - obs.theta_ex directly.
+    For disconnected lines, falls back to get_delta_theta_line which reconstructs
+    the angle difference from bus angles of other connected elements.
+
+    Args:
+        obs: Observation with theta_or, theta_ex, line_status attributes
+
+    Returns:
+        numpy array of delta_theta per line (radians)
+    """
+    dt = obs.theta_or - obs.theta_ex  # vectorized, correct for connected lines
+    # For disconnected lines, theta_or/theta_ex are 0 → dt=0 (wrong)
+    # Fix using get_delta_theta_line which looks up bus angles
+    disconnected = ~obs.line_status.astype(bool)
+    for i in np.where(disconnected)[0]:
+        dt[i] = get_delta_theta_line(obs, int(i))
+    return dt
+
+
+def _estimate_rho_from_delta_theta(dt_combined, obs_start, obs_act1, obs_act2):
+    """Estimate rho from superposed delta_theta, using action obs as fallback.
+
+    For reconnection/merging actions, delta_theta is the natural base quantity
+    (as used in beta computation). This function converts superposed delta_theta
+    to rho using per-line conversion factors rho/|delta_theta|.
+
+    Primary factor comes from obs_start (for lines connected there).
+    For disconnected lines in obs_start, falls back to action observations.
+
+    Args:
+        dt_combined: Superposed delta_theta per line (radians), array
+        obs_start: Base observation
+        obs_act1: Observation after applying action 1
+        obs_act2: Observation after applying action 2
+
+    Returns:
+        rho_combined: Estimated loading array per line
+    """
+    from expert_op4grid_recommender.config import MAX_RHO_BOTH_EXTREMITIES
+
+    dt_threshold = 1e-4  # radians
+    rho_start = obs_start.rho
+
+    # Primary factor: from obs_start (for lines connected there)
+    dt_start = _compute_delta_theta_all_lines(obs_start)
+    abs_dt_start = np.abs(dt_start)
+    safe = abs_dt_start > dt_threshold
+    with np.errstate(divide='ignore', invalid='ignore'):
+        factor = np.where(safe & (rho_start > 0), rho_start / abs_dt_start, 0.0)
+
+    # Fallback: for disconnected lines in obs_start, use action observations
+    needs_fallback = ~safe | (rho_start == 0)
+    for obs_act in [obs_act1, obs_act2]:
+        if not np.any(needs_fallback):
+            break
+        dt_act = _compute_delta_theta_all_lines(obs_act)
+        abs_dt_act = np.abs(dt_act)
+        rho_act = obs_act.rho
+        act_usable = needs_fallback & (abs_dt_act > dt_threshold) & (rho_act > 0)
+        if np.any(act_usable):
+            factor = np.where(act_usable, rho_act / abs_dt_act, factor)
+            needs_fallback = needs_fallback & ~act_usable
+
+    return np.abs(dt_combined) * factor
 
 
 # =============================================================================
@@ -736,7 +838,7 @@ def compute_all_pairs_superposition(
         lines_we_care_about,
         pre_existing_rho: Dict[int, float],
         dict_action: Optional[Dict] = None,
-        use_p_based_rho: bool = True,
+        use_p_based_rho: bool = False,
 ) -> Dict[str, Dict]:
     """Compute superposition theorem for all pairs of converged prioritized actions.
 
@@ -749,10 +851,11 @@ def compute_all_pairs_superposition(
         lines_we_care_about: Set/list of line names we monitor
         pre_existing_rho: Dict of line_idx -> pre-existing rho values
         dict_action: Full action dictionary (for action type classification)
-        use_p_based_rho: If True (default), derive rho from superposed p_or/p_ex
-            using per-line power-factor ratios — eliminates the max() convexity
-            bias and reduces reactive power non-superposition bias. If False, use
-            the lighter but more approximate direct superposition of rho arrays.
+        use_p_based_rho: If True, derive rho from superposed p_or/p_ex
+            using per-line power-factor ratios. If False (default), use
+            direct superposition of rho arrays — empirically more accurate
+            because the P-based conversion factor breaks down when lines
+            change connection status or voltage/power-factor shift significantly.
 
     Returns:
         Dict of "action1_id+action2_id" -> result dict with betas, p_or_combined,
@@ -839,14 +942,39 @@ def compute_all_pairs_superposition(
 
         # ---- Compute combined rho ----
         if use_p_based_rho:
-            # Accurate method: derive rho from superposed p_or/p_ex using
-            # per-line power-factor ratios from obs_start. Eliminates the
-            # max() convexity bias (E1) and reduces reactive power bias (E2).
-            p_or_combined = np.array(result["p_or_combined"])
-            p_ex_combined = np.array(result["p_ex_combined"])
-            rho_combined = _estimate_rho_from_p(
-                p_or_combined, p_ex_combined, obs_start
-            )
+            # Detect if either action involves reconnection or node merging
+            # (where delta_theta is the natural base quantity for estimation)
+            use_delta_theta = False
+            for aid, (line_idxs, sub_idxs) in [(aid1, action_elements[aid1]),
+                                                 (aid2, action_elements[aid2])]:
+                if line_idxs:
+                    # Line action: reconnection if line was disconnected in obs_start
+                    if not obs_start.line_status[line_idxs[0]]:
+                        use_delta_theta = True
+                elif sub_idxs:
+                    # Sub action: node merging if sub was split in obs_start
+                    if not _is_sub_reference_topology(obs_start, sub_idxs[0]):
+                        use_delta_theta = True
+
+            if use_delta_theta:
+                # Delta-theta-based: for reconnection/merging pairs
+                dt_start_all = _compute_delta_theta_all_lines(obs_start)
+                dt_act1_all = _compute_delta_theta_all_lines(obs_act1)
+                dt_act2_all = _compute_delta_theta_all_lines(obs_act2)
+                betas = np.array(result["betas"])
+                dt_combined = ((1.0 - np.sum(betas)) * dt_start_all
+                               + betas[0] * dt_act1_all
+                               + betas[1] * dt_act2_all)
+                rho_combined = _estimate_rho_from_delta_theta(
+                    dt_combined, obs_start, obs_act1, obs_act2
+                )
+            else:
+                # P-based: for disconnection/splitting pairs (with action-obs fallback)
+                p_or_combined = np.array(result["p_or_combined"])
+                p_ex_combined = np.array(result["p_ex_combined"])
+                rho_combined = _estimate_rho_from_p(
+                    p_or_combined, p_ex_combined, obs_start, obs_act1, obs_act2
+                )
         else:
             # Approximate method: superpose rho arrays directly.
             # Lighter but biased: ignores per-extremity asymmetry and

--- a/tests/test_superposition.py
+++ b/tests/test_superposition.py
@@ -66,7 +66,7 @@ def test_compute_all_pairs_superposition_simplified_dict():
     try:
         superposition._identify_action_elements = MagicMock(side_effect=mock_identify)
         # Mock compute_combined_pair_superposition to avoid real linear solving.
-        # Must include p_ex_combined so use_p_based_rho=True (default) can use it.
+        # Include p_ex_combined for completeness (needed when use_p_based_rho=True).
         superposition.compute_combined_pair_superposition = MagicMock(return_value={
             "betas": [0.5, 0.5],
             "p_or_combined": [80.0, 50.0, 50.0],

--- a/tests/test_superposition_rho_estimation.py
+++ b/tests/test_superposition_rho_estimation.py
@@ -10,8 +10,11 @@
 Unit tests for the improved rho estimation in the superposition module.
 
 Covers:
-- _estimate_rho_from_p(): per-extremity power-factor ratio method
+- _estimate_rho_from_p(): per-extremity power-factor ratio method (with action-obs fallback)
+- _compute_delta_theta_all_lines(): delta_theta computation for all lines
+- _estimate_rho_from_delta_theta(): delta_theta-based rho estimation
 - use_p_based_rho parameter in compute_all_pairs_superposition()
+- Action-type-aware routing: delta_theta for reconnection/merging, P for disconnection/splitting
 - p_ex_combined key in compute_combined_pair_superposition() results
 """
 
@@ -21,6 +24,8 @@ from unittest.mock import MagicMock, patch
 
 from expert_op4grid_recommender.utils.superposition import (
     _estimate_rho_from_p,
+    _compute_delta_theta_all_lines,
+    _estimate_rho_from_delta_theta,
     compute_combined_pair_superposition,
     compute_all_pairs_superposition,
 )
@@ -275,6 +280,7 @@ class TestUsePBasedRho:
         obs_start._limit_or.values = np.array([100.0, 100.0, 100.0])
         obs_start._limit_ex = MagicMock()
         obs_start._limit_ex.values = np.array([100.0, 100.0, 100.0])
+        obs_start.line_status = np.array([True, True, True])  # all connected → P-based path
 
         obs_act1 = MagicMock()
         obs_act1.rho = np.array([1.0, 0.4, 0.6])
@@ -378,14 +384,301 @@ class TestUsePBasedRho:
         # max_rho is from eligible lines (no pre-existing overloads → all eligible)
         assert abs(res["max_rho"] - float(np.max(expected_rho))) < 0.01
 
-    def test_default_is_p_based_rho_true(self):
-        """Default value of use_p_based_rho must be True (accurate method)."""
+    def test_default_is_p_based_rho_false(self):
+        """Default value of use_p_based_rho must be False (direct rho method)."""
         import inspect
         sig = inspect.signature(compute_all_pairs_superposition)
         default = sig.parameters["use_p_based_rho"].default
-        assert default is True, (
-            f"use_p_based_rho default should be True, got {default!r}"
+        assert default is False, (
+            f"use_p_based_rho default should be False, got {default!r}"
         )
+
+
+# =============================================================================
+# Tests for _estimate_rho_from_p action-observation fallback
+# =============================================================================
+
+class TestEstimateRhoFromPFallback:
+
+    def test_fallback_to_action_obs_for_disconnected_lines(self):
+        """When |P_start| < threshold on a line, use action obs for the factor."""
+        # Line 0: disconnected in start (p=0), reconnected in act1 (p=80)
+        obs_start = _obs_no_limits(p_or=[0.0, 100.0], p_ex=[0.0, -100.0], rho=[0.0, 1.0])
+
+        obs_act1 = MagicMock(spec=["p_or", "p_ex", "rho"])
+        obs_act1.p_or = np.array([80.0, 100.0])
+        obs_act1.p_ex = np.array([-80.0, -100.0])
+        obs_act1.rho = np.array([0.8, 1.0])
+
+        p_or_combined = np.array([60.0, 50.0])
+        p_ex_combined = np.array([-60.0, -50.0])
+        result = _estimate_rho_from_p(p_or_combined, p_ex_combined, obs_start,
+                                       obs_act1=obs_act1)
+        # Line 0: fallback factor_or = obs_act1.rho/|obs_act1.p_or| = 0.8/80 = 0.01
+        #          rho_or_est = 60 * 0.01 = 0.6
+        assert result[0] == pytest.approx(0.6, rel=1e-6)
+        # Line 1: normal factor = 1.0/100 = 0.01 → 50 * 0.01 = 0.5
+        assert result[1] == pytest.approx(0.5, rel=1e-6)
+
+    def test_no_fallback_obs_provided_still_works(self):
+        """Without action obs, disconnected lines still get rho=0 (no crash)."""
+        obs_start = _obs_no_limits(p_or=[0.0, 100.0], p_ex=[0.0, -100.0], rho=[0.0, 1.0])
+        p_or_combined = np.array([60.0, 50.0])
+        p_ex_combined = np.array([-60.0, -50.0])
+        result = _estimate_rho_from_p(p_or_combined, p_ex_combined, obs_start)
+        assert result[0] == pytest.approx(0.0)
+        assert result[1] == pytest.approx(0.5, rel=1e-6)
+
+
+# =============================================================================
+# Tests for _compute_delta_theta_all_lines
+# =============================================================================
+
+class TestComputeDeltaThetaAllLines:
+
+    def test_connected_lines_use_theta_diff(self):
+        """Connected lines: dt = theta_or - theta_ex."""
+        obs = MagicMock()
+        obs.theta_or = np.array([0.1, 0.2, 0.3])
+        obs.theta_ex = np.array([0.05, 0.15, 0.28])
+        obs.line_status = np.array([True, True, True])
+        dt = _compute_delta_theta_all_lines(obs)
+        np.testing.assert_allclose(dt, [0.05, 0.05, 0.02], rtol=1e-6)
+
+    def test_disconnected_lines_use_get_delta_theta_line(self):
+        """Disconnected lines fall back to get_delta_theta_line."""
+        obs = MagicMock()
+        obs.theta_or = np.array([0.1, 0.0])  # line 1 disconnected → theta=0
+        obs.theta_ex = np.array([0.05, 0.0])
+        obs.line_status = np.array([True, False])
+
+        with patch("expert_op4grid_recommender.utils.superposition.get_delta_theta_line",
+                   return_value=0.07) as mock_dt:
+            dt = _compute_delta_theta_all_lines(obs)
+            mock_dt.assert_called_once_with(obs, 1)
+        np.testing.assert_allclose(dt, [0.05, 0.07], rtol=1e-6)
+
+
+# =============================================================================
+# Tests for _estimate_rho_from_delta_theta
+# =============================================================================
+
+class TestEstimateRhoFromDeltaTheta:
+
+    def test_basic_factor_computation(self):
+        """factor = rho_start / |dt_start|, then rho = |dt_combined| * factor."""
+        obs_start = MagicMock()
+        obs_start.rho = np.array([1.0, 0.5])
+        obs_start.theta_or = np.array([0.1, 0.2])
+        obs_start.theta_ex = np.array([0.0, 0.1])
+        obs_start.line_status = np.array([True, True])
+
+        obs_act1 = MagicMock()
+        obs_act1.rho = np.array([0.8, 0.4])
+        obs_act1.theta_or = np.array([0.08, 0.18])
+        obs_act1.theta_ex = np.array([0.0, 0.1])
+        obs_act1.line_status = np.array([True, True])
+
+        obs_act2 = MagicMock()
+        obs_act2.rho = np.array([0.9, 0.45])
+        obs_act2.theta_or = np.array([0.09, 0.19])
+        obs_act2.theta_ex = np.array([0.0, 0.1])
+        obs_act2.line_status = np.array([True, True])
+
+        # dt_start = [0.1, 0.1]; factor = [1.0/0.1, 0.5/0.1] = [10, 5]
+        dt_combined = np.array([0.08, 0.12])
+        result = _estimate_rho_from_delta_theta(dt_combined, obs_start, obs_act1, obs_act2)
+        # rho = |dt_combined| * factor = [0.08*10, 0.12*5] = [0.8, 0.6]
+        np.testing.assert_allclose(result, [0.8, 0.6], rtol=1e-6)
+
+    def test_fallback_for_disconnected_lines(self):
+        """Lines with |dt_start| < threshold use action obs for the factor."""
+        obs_start = MagicMock()
+        obs_start.rho = np.array([0.0, 0.5])  # line 0 disconnected → rho=0
+        obs_start.theta_or = np.array([0.0, 0.2])  # line 0 disconnected → theta=0
+        obs_start.theta_ex = np.array([0.0, 0.1])
+        obs_start.line_status = np.array([False, True])
+
+        obs_act1 = MagicMock()
+        obs_act1.rho = np.array([0.8, 0.4])
+        obs_act1.theta_or = np.array([0.1, 0.18])
+        obs_act1.theta_ex = np.array([0.02, 0.1])
+        obs_act1.line_status = np.array([True, True])
+
+        obs_act2 = MagicMock()
+        obs_act2.rho = np.array([0.0, 0.45])
+        obs_act2.theta_or = np.array([0.0, 0.19])
+        obs_act2.theta_ex = np.array([0.0, 0.1])
+        obs_act2.line_status = np.array([False, True])
+
+        with patch("expert_op4grid_recommender.utils.superposition.get_delta_theta_line") as mock_dt:
+            # For disconnected lines in obs_start and obs_act2, return small values
+            def side_effect(obs, idx):
+                if obs is obs_start and idx == 0:
+                    return 0.0  # disconnected in start → tiny dt
+                if obs is obs_act2 and idx == 0:
+                    return 0.0  # disconnected in act2 too
+                return 0.0
+            mock_dt.side_effect = side_effect
+
+            dt_combined = np.array([0.06, 0.08])
+            result = _estimate_rho_from_delta_theta(dt_combined, obs_start, obs_act1, obs_act2)
+
+        # Line 0: obs_start dt=0 (needs fallback).
+        #   obs_act1: dt = 0.1 - 0.02 = 0.08 (connected), factor = 0.8/0.08 = 10
+        #   rho = |0.06| * 10 = 0.6
+        # Line 1: obs_start dt = 0.2 - 0.1 = 0.1, factor = 0.5/0.1 = 5
+        #   rho = |0.08| * 5 = 0.4
+        np.testing.assert_allclose(result, [0.6, 0.4], rtol=1e-6)
+
+
+# =============================================================================
+# Tests for action-type detection in compute_all_pairs_superposition
+# =============================================================================
+
+class TestActionTypeDetection:
+    """Tests that the rho computation block correctly routes to delta_theta
+    or P-based estimation based on action types."""
+
+    def _make_env_and_obs(self, line_status=None):
+        env = MagicMock()
+        env.name_line = ["L0", "L1", "L2"]
+
+        obs_start = MagicMock()
+        obs_start.rho = np.array([1.2, 0.4, 0.6])
+        obs_start.p_or = np.array([120.0, 40.0, 60.0])
+        obs_start.p_ex = np.array([-120.0, -40.0, -60.0])
+        obs_start.a_or = np.array([120.0, 40.0, 60.0])
+        obs_start.a_ex = np.array([120.0, 40.0, 60.0])
+        obs_start._limit_or = MagicMock()
+        obs_start._limit_or.values = np.array([100.0, 100.0, 100.0])
+        obs_start._limit_ex = MagicMock()
+        obs_start._limit_ex.values = np.array([100.0, 100.0, 100.0])
+        obs_start.theta_or = np.array([0.1, 0.2, 0.3])
+        obs_start.theta_ex = np.array([0.05, 0.15, 0.25])
+        if line_status is not None:
+            obs_start.line_status = np.array(line_status)
+        else:
+            obs_start.line_status = np.array([True, True, True])
+
+        obs_act1 = MagicMock()
+        obs_act1.rho = np.array([1.0, 0.4, 0.6])
+        obs_act1.p_or = np.array([100.0, 40.0, 60.0])
+        obs_act1.p_ex = np.array([-100.0, -40.0, -60.0])
+        obs_act1.theta_or = np.array([0.08, 0.2, 0.3])
+        obs_act1.theta_ex = np.array([0.05, 0.15, 0.25])
+        obs_act1.line_status = np.array([True, True, True])
+
+        obs_act2 = MagicMock()
+        obs_act2.rho = np.array([1.0, 0.4, 0.6])
+        obs_act2.p_or = np.array([100.0, 40.0, 60.0])
+        obs_act2.p_ex = np.array([-100.0, -40.0, -60.0])
+        obs_act2.theta_or = np.array([0.1, 0.18, 0.3])
+        obs_act2.theta_ex = np.array([0.05, 0.15, 0.25])
+        obs_act2.line_status = np.array([True, True, True])
+
+        aid1, aid2 = "act1", "act2"
+        detailed_actions = {
+            aid1: {"action": MagicMock(), "observation": obs_act1, "description_unitaire": "A1"},
+            aid2: {"action": MagicMock(), "observation": obs_act2, "description_unitaire": "A2"},
+        }
+        return env, obs_start, obs_act1, obs_act2, detailed_actions, aid1, aid2
+
+    def _run_pairs_with_detection(self, env, obs_start, detailed_actions, aid1, aid2,
+                                   line_idxs1, sub_idxs1, line_idxs2, sub_idxs2):
+        from expert_op4grid_recommender.utils import superposition
+
+        classifier = MagicMock(spec=ActionClassifier)
+        classifier._action_space = MagicMock()
+
+        def mock_identify(action, action_id, *args):
+            if action_id == aid1: return (line_idxs1, sub_idxs1)
+            if action_id == aid2: return (line_idxs2, sub_idxs2)
+            return ([], [])
+
+        orig_identify = superposition._identify_action_elements
+        orig_compute = superposition.compute_combined_pair_superposition
+        try:
+            superposition._identify_action_elements = MagicMock(side_effect=mock_identify)
+            superposition.compute_combined_pair_superposition = MagicMock(return_value={
+                "betas": [0.5, 0.5],
+                "p_or_combined": [80.0, 40.0, 60.0],
+                "p_ex_combined": [-80.0, -40.0, -60.0],
+                "is_islanded": False,
+                "disconnected_mw": 0.0,
+            })
+
+            with patch("expert_op4grid_recommender.utils.superposition._estimate_rho_from_delta_theta",
+                       wraps=_estimate_rho_from_delta_theta) as mock_dt, \
+                 patch("expert_op4grid_recommender.utils.superposition._estimate_rho_from_p",
+                       wraps=_estimate_rho_from_p) as mock_p:
+                results = compute_all_pairs_superposition(
+                    obs_start=obs_start,
+                    detailed_actions=detailed_actions,
+                    classifier=classifier,
+                    env=env,
+                    lines_overloaded_ids=[0],
+                    lines_we_care_about=["L0", "L1", "L2"],
+                    pre_existing_rho={},
+                    dict_action={},
+                    use_p_based_rho=True,
+                )
+                return results, mock_dt, mock_p
+        finally:
+            superposition._identify_action_elements = orig_identify
+            superposition.compute_combined_pair_superposition = orig_compute
+
+    def test_reconnection_action_uses_delta_theta(self):
+        """Line reconnection (line disconnected in obs_start) routes to delta_theta."""
+        env, obs_start, obs_act1, obs_act2, detailed_actions, aid1, aid2 = \
+            self._make_env_and_obs(line_status=[True, False, True])
+        # aid1 is a line action on L1 (index 1) which is disconnected → reconnection
+        results, mock_dt, mock_p = self._run_pairs_with_detection(
+            env, obs_start, detailed_actions, aid1, aid2,
+            line_idxs1=[1], sub_idxs1=[], line_idxs2=[2], sub_idxs2=[],
+        )
+        mock_dt.assert_called_once()
+        mock_p.assert_not_called()
+
+    def test_disconnection_action_uses_p_based(self):
+        """Line disconnection (line connected in obs_start) routes to P-based."""
+        env, obs_start, obs_act1, obs_act2, detailed_actions, aid1, aid2 = \
+            self._make_env_and_obs(line_status=[True, True, True])
+        # Both actions are on connected lines → disconnection
+        results, mock_dt, mock_p = self._run_pairs_with_detection(
+            env, obs_start, detailed_actions, aid1, aid2,
+            line_idxs1=[1], sub_idxs1=[], line_idxs2=[2], sub_idxs2=[],
+        )
+        mock_dt.assert_not_called()
+        mock_p.assert_called_once()
+
+    def test_node_merging_uses_delta_theta(self):
+        """Node merging (sub not in reference topology) routes to delta_theta."""
+        env, obs_start, obs_act1, obs_act2, detailed_actions, aid1, aid2 = \
+            self._make_env_and_obs()
+        # aid1 is a sub action (merging: sub is split → not reference topology)
+        with patch("expert_op4grid_recommender.utils.superposition._is_sub_reference_topology",
+                   return_value=False):
+            results, mock_dt, mock_p = self._run_pairs_with_detection(
+                env, obs_start, detailed_actions, aid1, aid2,
+                line_idxs1=[], sub_idxs1=[0], line_idxs2=[1], sub_idxs2=[],
+            )
+        mock_dt.assert_called_once()
+        mock_p.assert_not_called()
+
+    def test_node_splitting_uses_p_based(self):
+        """Node splitting (sub in reference topology) routes to P-based."""
+        env, obs_start, obs_act1, obs_act2, detailed_actions, aid1, aid2 = \
+            self._make_env_and_obs()
+        # aid1 is a sub action (splitting: sub is merged → reference topology)
+        with patch("expert_op4grid_recommender.utils.superposition._is_sub_reference_topology",
+                   return_value=True):
+            results, mock_dt, mock_p = self._run_pairs_with_detection(
+                env, obs_start, detailed_actions, aid1, aid2,
+                line_idxs1=[], sub_idxs1=[0], line_idxs2=[1], sub_idxs2=[],
+            )
+        mock_dt.assert_not_called()
+        mock_p.assert_called_once()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Implement delta_theta-based rho estimation for reconnection/merging actions while keeping P-based estimation for disconnection/splitting. This addresses the root cause of inaccurate P-based estimates for reconnected lines.

New functions:
- _compute_delta_theta_all_lines(obs): compute delta_theta for all lines
- _estimate_rho_from_delta_theta(...): delta_theta-based rho estimation
- Updated _estimate_rho_from_p with action-observation fallback

Action-type detection in compute_all_pairs_superposition:
- Line reconnection (line_status[idx] == False in obs_start) → delta_theta
- Node merging (not _is_sub_reference_topology in obs_start) → delta_theta
- Line disconnection / node splitting → P-based (with fallback)

Tests: Added 6 new test methods covering factor computation, disconnected line fallback, and action-type routing for all 4 action types.