### PR TITLE
feat(builder): thread extra_lines_to_cut_ids to OverFlowGraph

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.2.1.post1] - 2026-05-07
+
+### Added
+
+- **`extra_lines_to_cut_ids` plumbing** (`graph_analysis/builder.py`, `pypowsybl_backend/overflow_analysis.py`, `graph_analysis/visualization.py`, `main.py`, PR #89): `build_overflow_graph` (and its grid2op / pypowsybl wrappers) now accept an optional `extra_lines_to_cut_ids` parameter. Operator-supplied indices are appended to `Grid2opSimulation.ltc` / `AlphaDeespAdapter.ltc` so the cut still happens, and forwarded as `extra_lines_to_cut=…` to `OverFlowGraph` so the new `is_extra_cut` tag flows through (and the visualization keeps these edges out of the Overloads / Monitored layers). Implements ExpertAgent's `additionalLinesToCut` semantic. `run_analysis_step2_graph` reads `context["extra_lines_to_cut_ids"]` (default `[]`); `make_overflow_graph_visualization` accepts the parameter for plumbing completeness.
+
+### Compatibility
+
+- Defaults to an empty list / `None` everywhere — existing callers see no behaviour change. Step1 populates `context["extra_lines_to_cut_ids"] = []`; step2 callers (e.g. CoStudy4Grid) can override before invoking `run_analysis_step2_graph`. Extras already present in `overloaded_line_ids` are silently de-duplicated.
+
+---
+
 ## [0.2.1] - 2026-05-05
 
 ### Added

--- a/expert_op4grid_recommender/__init__.py
+++ b/expert_op4grid_recommender/__init__.py
@@ -15,7 +15,7 @@ corrective measures to alleviate line overloads.
 
 import logging
 
-__version__ = "0.2.1"
+__version__ = "0.2.1.post1"
 
 _logger = logging.getLogger(__name__)
 

--- a/expert_op4grid_recommender/graph_analysis/builder.py
+++ b/expert_op4grid_recommender/graph_analysis/builder.py
@@ -26,7 +26,8 @@ def inhibit_swapped_flows(df_of_g):
 def build_overflow_graph(env, obs_overloaded, overloaded_line_ids, non_connected_reconnectable_lines,
                          lines_non_reconnectable, timestep, do_consolidate_graph=True,
                          inhibit_swapped_flow_reversion=True, node_renaming=True,
-                         param_options=PARAM_OPTIONS_EXPERT_OP, use_dc=False):
+                         param_options=PARAM_OPTIONS_EXPERT_OP, use_dc=False,
+                         extra_lines_to_cut_ids=None):
     """
     Constructs and refines an overflow graph based on a Grid2Op simulation state.
 
@@ -72,10 +73,23 @@ def build_overflow_graph(env, obs_overloaded, overloaded_line_ids, non_connected
               distribution graph object derived from the refined `g_overflow`.
             - node_name_mapping (dict): A dictionary mapping original node indices to substation names.
     """
+    # ``extra_lines_to_cut_ids`` are operator-supplied line indices that
+    # should be cut in the simulation (so the recommender finds actions
+    # that prevent flow increase on them) but NOT classified as
+    # overloads in the visualization.  ExpertAgent's
+    # ``additionalLinesToCut`` semantic.  They are appended to ``ltc``
+    # for the simulation and forwarded as ``extra_lines_to_cut`` to the
+    # OverFlowGraph so it can stamp ``is_extra_cut`` and skip
+    # ``is_overload`` / ``is_monitored`` for those edges.
+    extras = list(extra_lines_to_cut_ids or [])
+    seen = set(overloaded_line_ids)
+    extras = [idx for idx in extras if idx not in seen]
+    full_ltc = list(overloaded_line_ids) + extras
+
     overflow_sim = Grid2opSimulation(
         obs_overloaded, env.action_space, env.observation_space,
         param_options=param_options, debug=False,
-        ltc=overloaded_line_ids, plot=True, simu_step=timestep
+        ltc=full_ltc, plot=True, simu_step=timestep
     )
     df_of_g = overflow_sim.get_dataframe()
     df_of_g["line_name"] = obs_overloaded.name_line
@@ -83,7 +97,9 @@ def build_overflow_graph(env, obs_overloaded, overloaded_line_ids, non_connected
     if inhibit_swapped_flow_reversion:
         df_of_g = inhibit_swapped_flows(df_of_g)
 
-    g_overflow = OverFlowGraph(overflow_sim.topo, overloaded_line_ids, df_of_g, float_precision="%.0f")
+    g_overflow = OverFlowGraph(overflow_sim.topo, full_ltc, df_of_g,
+                               float_precision="%.0f",
+                               extra_lines_to_cut=extras)
     node_name_mapping = {i: name for i, name in enumerate(obs_overloaded.name_sub)}
 
     if node_renaming:

--- a/expert_op4grid_recommender/graph_analysis/visualization.py
+++ b/expert_op4grid_recommender/graph_analysis/visualization.py
@@ -78,7 +78,8 @@ def make_overflow_graph_visualization(env, overflow_sim, g_overflow, hubs, obs_s
                                       lines_swapped, custom_layout=None, lines_we_care_about=None,
                                       monitoring_factor_thermal_limits=1.0,
                                       lines_constrained_path=None, nodes_constrained_path=None,
-                                      lines_red_loops=None, nodes_red_loops=None):
+                                      lines_red_loops=None, nodes_red_loops=None,
+                                      extra_lines_to_cut_ids=None):
     """
     Generates and saves a visualization of the overflow graph with various annotations.
 

--- a/expert_op4grid_recommender/main.py
+++ b/expert_op4grid_recommender/main.py
@@ -130,14 +130,16 @@ def compute_baseline_simulation_grid2op(obs, timestep, act_defaut, act_reco_main
     return compute_baseline_simulation(obs, timestep, act_defaut, act_reco_maintenance, overload_ids)
 
 
-def build_overflow_graph_grid2op(env, obs_simu_defaut, lines_overloaded_ids_kept, 
+def build_overflow_graph_grid2op(env, obs_simu_defaut, lines_overloaded_ids_kept,
                                   non_connected_reconnectable_lines, lines_non_reconnectable,
-                                  timestep, do_consolidate_graph,use_dc=False):
+                                  timestep, do_consolidate_graph,use_dc=False,
+                                  extra_lines_to_cut_ids=None):
     """Build overflow graph using Grid2Op/alphaDeesp."""
     from expert_op4grid_recommender.graph_analysis.builder import build_overflow_graph
     return build_overflow_graph(env, obs_simu_defaut, lines_overloaded_ids_kept,
                                  non_connected_reconnectable_lines, lines_non_reconnectable,
-                                 timestep, do_consolidate_graph=do_consolidate_graph,use_dc=use_dc)
+                                 timestep, do_consolidate_graph=do_consolidate_graph,use_dc=use_dc,
+                                 extra_lines_to_cut_ids=extra_lines_to_cut_ids)
 
 
 # =============================================================================
@@ -209,13 +211,15 @@ def compute_baseline_simulation_pypowsybl(obs, timestep, act_defaut, act_reco_ma
 
 def build_overflow_graph_pypowsybl_wrapper(env, obs_simu_defaut, lines_overloaded_ids_kept,
                                            non_connected_reconnectable_lines, lines_non_reconnectable,
-                                           timestep, do_consolidate_graph,use_dc=False, fast_mode=True):
+                                           timestep, do_consolidate_graph,use_dc=False, fast_mode=True,
+                                           extra_lines_to_cut_ids=None):
     """Wrapper for pypowsybl overflow graph builder with correct signature."""
     from expert_op4grid_recommender.pypowsybl_backend.overflow_analysis import build_overflow_graph_pypowsybl as _build
     return _build(env, obs_simu_defaut, lines_overloaded_ids_kept,
                   non_connected_reconnectable_lines, lines_non_reconnectable,
-                  timestep, do_consolidate_graph=do_consolidate_graph, 
-                  use_dc=use_dc, param_options={"fast_mode": fast_mode})
+                  timestep, do_consolidate_graph=do_consolidate_graph,
+                  use_dc=use_dc, param_options={"fast_mode": fast_mode},
+                  extra_lines_to_cut_ids=extra_lines_to_cut_ids)
 
 
 # =============================================================================
@@ -462,6 +466,15 @@ def run_analysis_step1(analysis_date: Optional[datetime],
         "pre_existing_rho": pre_existing_rho,
         "lines_overloaded_names": lines_overloaded_names,
         "non_connected_reconnectable_lines": non_connected_reconnectable_lines,
+        # Operator-supplied extras (line indices) that should be cut in
+        # the overflow graph alongside the detected overloads but
+        # NOT classified as overloads in the viewer.  Step 2 callers
+        # (e.g. CoStudy4Grid) populate this when narrowing the context
+        # before ``run_analysis_step2_graph``; left empty here so the
+        # legacy single-step / no-extras path keeps its current
+        # behaviour.  Plumbed through to ``build_overflow_graph`` in
+        # Step 2 graph generation.
+        "extra_lines_to_cut_ids": [],
         "dict_action": dict_action,
         "is_bare_env": is_bare_env,
         "is_pypowsybl": is_pypowsybl,
@@ -500,10 +513,13 @@ def run_analysis_step2_graph(context: Dict[str, Any]) -> Dict[str, Any]:
     custom_layout = context["custom_layout"]
     chronic_name = context["chronic_name"]
     non_connected_reconnectable_lines = context["non_connected_reconnectable_lines"]
-    
+    # Operator-supplied extras — see step1 `context["extra_lines_to_cut_ids"]`.
+    # Defaulted to an empty list when missing so older callers keep working.
+    extra_lines_to_cut_ids = context.get("extra_lines_to_cut_ids") or []
+
     is_pypowsybl = context["is_pypowsybl"]
     actual_fast_mode = context["actual_fast_mode"]
-    
+
     check_simu_overloads = context["check_simu_overloads"]
     switch_to_dc = context["switch_to_dc"]
     build_overflow_graph = context["build_overflow_graph"]
@@ -532,12 +548,14 @@ def run_analysis_step2_graph(context: Dict[str, Any]) -> Dict[str, Any]:
         if is_pypowsybl:
             df_of_g, overflow_sim, g_overflow, hubs, g_distribution_graph, node_name_mapping = build_overflow_graph(
                 env, obs_simu_defaut, lines_overloaded_ids_kept, non_connected_reconnectable_lines, lines_non_reconnectable,
-                current_timestep, do_consolidate_graph=config.DO_CONSOLIDATE_GRAPH,use_dc=use_dc, fast_mode=actual_fast_mode
+                current_timestep, do_consolidate_graph=config.DO_CONSOLIDATE_GRAPH,use_dc=use_dc, fast_mode=actual_fast_mode,
+                extra_lines_to_cut_ids=extra_lines_to_cut_ids,
             )
         else:
             df_of_g, overflow_sim, g_overflow, hubs, g_distribution_graph, node_name_mapping = build_overflow_graph(
                 env, obs_simu_defaut, lines_overloaded_ids_kept, non_connected_reconnectable_lines, lines_non_reconnectable,
                 current_timestep, do_consolidate_graph=config.DO_CONSOLIDATE_GRAPH,use_dc=use_dc,
+                extra_lines_to_cut_ids=extra_lines_to_cut_ids,
             )
 
     # Visualize graph (only if enabled in config)
@@ -591,6 +609,7 @@ def run_analysis_step2_graph(context: Dict[str, Any]) -> Dict[str, Any]:
                 nodes_constrained_path=nodes_constrained_path,
                 lines_red_loops=lines_red_loops,
                 nodes_red_loops=nodes_red_loops,
+                extra_lines_to_cut_ids=extra_lines_to_cut_ids,
             )
     else:
         print("Skipping visualization (DO_VISUALIZATION=False)")

--- a/expert_op4grid_recommender/pypowsybl_backend/overflow_analysis.py
+++ b/expert_op4grid_recommender/pypowsybl_backend/overflow_analysis.py
@@ -640,14 +640,15 @@ class OverflowGraphBuilder:
 
 
 def build_overflow_graph_pypowsybl(env: 'SimulationEnvironment',
-                                    obs: 'PypowsyblObservation', 
+                                    obs: 'PypowsyblObservation',
                                     overloaded_line_ids: List[int],
                                     non_connected_reconnectable_lines: List[str],
                                     lines_non_reconnectable: List[str],
                                     timestep: int,
                                     do_consolidate_graph: bool = True,
                                     use_dc: bool = False,
-                                    param_options: Optional[Dict] = None):
+                                    param_options: Optional[Dict] = None,
+                                    extra_lines_to_cut_ids: Optional[List[int]] = None):
     """
     Build overflow graph using pure pypowsybl.
     
@@ -681,7 +682,15 @@ def build_overflow_graph_pypowsybl(env: 'SimulationEnvironment',
     params = param_options or PARAM_OPTIONS_EXPERT_OP
     # Keep the fast_mode extraction flexible
     fast_mode = params.get("fast_mode", True) if isinstance(params, dict) else True
-    
+
+    # Operator-supplied extras: cut in the simulation alongside the
+    # detected overloads but tagged ``is_extra_cut`` in the overflow
+    # graph so the visualization keeps them out of the Overloads layer.
+    extras = list(extra_lines_to_cut_ids or [])
+    seen = set(overloaded_line_ids)
+    extras = [idx for idx in extras if idx not in seen]
+    full_ltc = list(overloaded_line_ids) + extras
+
     # Create alphaDeesp-compatible adapter (replaces Grid2opSimulation)
     overflow_sim = AlphaDeespAdapter(
         obs=obs,
@@ -689,26 +698,27 @@ def build_overflow_graph_pypowsybl(env: 'SimulationEnvironment',
         observation_space=None,  # Not needed for our use case
         param_options=params,
         debug=False,
-        ltc=overloaded_line_ids,
+        ltc=full_ltc,
         plot=False,
         simu_step=timestep,
         use_dc=use_dc,
         fast_mode=fast_mode
     )
-    
+
     # Get flow changes DataFrame
     df_of_g = overflow_sim.get_dataframe()
     df_of_g["line_name"] = obs.name_line
-    
+
     # Apply flow swap correction - this negates delta_flows for lines where
     # new_flows_swapped=True, making them negative (blue) instead of positive (red)
     df_of_g = _inhibit_swapped_flows(df_of_g)
-    
+
     # Build topology info for alphaDeesp
     topo = overflow_sim.topo
-    
+
     # Use alphaDeesp's OverFlowGraph to construct graph with proper color attributes
-    g_overflow = OverFlowGraph(topo, overloaded_line_ids, df_of_g, float_precision="%.0f")
+    g_overflow = OverFlowGraph(topo, full_ltc, df_of_g, float_precision="%.0f",
+                               extra_lines_to_cut=extras)
     
     # Node name mapping
     node_name_mapping = {i: name for i, name in enumerate(obs.name_sub)}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "expert_op4grid_recommender"
-version = "0.2.1"
+version = "0.2.1.post1"
 authors = [
     { name="RTE", email="rte@rte-france.com" },
 ]

--- a/tests/test_extra_lines_to_cut_ids.py
+++ b/tests/test_extra_lines_to_cut_ids.py
@@ -1,0 +1,464 @@
+# Copyright (c) 2025-2026, RTE (https://www.rte-france.com)
+# See AUTHORS.txt
+# This Source Code Form is subject to the terms of the Mozilla Public License, version 2.0.
+# If a copy of the MPL was not distributed with this file,
+# you can obtain one at http://mozilla.org/MPL/2.0/.
+# SPDX-License-Identifier: MPL-2.0
+"""Unit tests for the ``extra_lines_to_cut_ids`` plumbing.
+
+These tests verify that operator-supplied extra line indices are:
+
+1. Appended to ``ltc`` when ``Grid2opSimulation`` (or its pypowsybl
+   counterpart) is constructed, so the cut still happens.
+2. Forwarded as ``extra_lines_to_cut`` to the ``OverFlowGraph`` so it
+   can stamp ``is_extra_cut`` and skip the overload classification.
+3. De-duplicated against ``overloaded_line_ids`` (an extra that is
+   already an overload should not be doubled).
+4. Defaulted to an empty list when ``None`` is passed.
+5. Read from ``context["extra_lines_to_cut_ids"]`` by
+   ``run_analysis_step2_graph`` and propagated through to
+   ``build_overflow_graph``.
+
+The actual flow simulation is mocked out — these are pure plumbing
+tests that don't require a real Grid2Op or pypowsybl environment.
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import networkx as nx
+import numpy as np
+import pandas as pd
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _empty_flow_dataframe():
+    """A minimal flow dataframe matching what ``Grid2opSimulation.get_dataframe``
+    returns — empty rows but with the expected columns so
+    ``inhibit_swapped_flows`` can run without errors.
+    """
+    return pd.DataFrame({
+        "new_flows_swapped": pd.Series([], dtype=bool),
+        "delta_flows": pd.Series([], dtype=float),
+        "idx_or": pd.Series([], dtype=int),
+        "idx_ex": pd.Series([], dtype=int),
+    })
+
+
+def _make_sim_mock():
+    sim = MagicMock()
+    sim.get_dataframe.return_value = _empty_flow_dataframe()
+    sim.topo = MagicMock()
+    return sim
+
+
+def _make_overflow_graph_mock():
+    g_overflow = MagicMock()
+    g_overflow.g = nx.DiGraph()
+    return g_overflow
+
+
+def _make_distribution_mock():
+    dist = MagicMock()
+    # Empty red components so consolidate_graph branch is skipped.
+    dist.g_only_red_components.nodes = []
+    dist.constrained_path.full_n_constrained_path.return_value = []
+    dist.get_hubs.return_value = []
+    return dist
+
+
+# ---------------------------------------------------------------------------
+# graph_analysis.builder.build_overflow_graph
+# ---------------------------------------------------------------------------
+
+
+@patch("expert_op4grid_recommender.graph_analysis.builder.Structured_Overload_Distribution_Graph")
+@patch("expert_op4grid_recommender.graph_analysis.builder.OverFlowGraph")
+@patch("expert_op4grid_recommender.graph_analysis.builder.Grid2opSimulation")
+def test_builder_appends_extras_to_ltc_and_forwards_to_overflow_graph(
+    MockSim, MockOFG, MockSODG
+):
+    """Extras must be appended to ``ltc`` and forwarded as
+    ``extra_lines_to_cut`` to ``OverFlowGraph``."""
+    from expert_op4grid_recommender.graph_analysis.builder import (
+        build_overflow_graph,
+    )
+
+    MockSim.return_value = _make_sim_mock()
+    MockOFG.return_value = _make_overflow_graph_mock()
+    MockSODG.return_value = _make_distribution_mock()
+
+    env = MagicMock()
+    obs = MagicMock()
+    obs.name_line = np.array([])
+    obs.name_sub = np.array(["sub0", "sub1"])
+
+    build_overflow_graph(
+        env,
+        obs,
+        overloaded_line_ids=[0, 1],
+        non_connected_reconnectable_lines=[],
+        lines_non_reconnectable=[],
+        timestep=0,
+        do_consolidate_graph=False,
+        node_renaming=False,
+        extra_lines_to_cut_ids=[2, 3],
+    )
+
+    # Grid2opSimulation must receive the union as ``ltc``.
+    sim_kwargs = MockSim.call_args.kwargs
+    assert sim_kwargs["ltc"] == [0, 1, 2, 3]
+
+    # OverFlowGraph must receive only the extras as ``extra_lines_to_cut``,
+    # and the full union as its second positional ``ltc`` argument.
+    ofg_args, ofg_kwargs = MockOFG.call_args
+    # ltc positional argument (index 1) is the full list.
+    assert list(ofg_args[1]) == [0, 1, 2, 3]
+    assert ofg_kwargs["extra_lines_to_cut"] == [2, 3]
+
+
+@patch("expert_op4grid_recommender.graph_analysis.builder.Structured_Overload_Distribution_Graph")
+@patch("expert_op4grid_recommender.graph_analysis.builder.OverFlowGraph")
+@patch("expert_op4grid_recommender.graph_analysis.builder.Grid2opSimulation")
+def test_builder_dedupes_extras_already_in_overloads(MockSim, MockOFG, MockSODG):
+    """If an extra is already in ``overloaded_line_ids`` it must not be
+    duplicated in either ``ltc`` or ``extra_lines_to_cut``."""
+    from expert_op4grid_recommender.graph_analysis.builder import (
+        build_overflow_graph,
+    )
+
+    MockSim.return_value = _make_sim_mock()
+    MockOFG.return_value = _make_overflow_graph_mock()
+    MockSODG.return_value = _make_distribution_mock()
+
+    env = MagicMock()
+    obs = MagicMock()
+    obs.name_line = np.array([])
+    obs.name_sub = np.array(["sub0", "sub1"])
+
+    build_overflow_graph(
+        env,
+        obs,
+        overloaded_line_ids=[1, 5],
+        non_connected_reconnectable_lines=[],
+        lines_non_reconnectable=[],
+        timestep=0,
+        do_consolidate_graph=False,
+        node_renaming=False,
+        # 1 is already an overload → must be filtered out
+        extra_lines_to_cut_ids=[1, 7],
+    )
+
+    sim_kwargs = MockSim.call_args.kwargs
+    assert sim_kwargs["ltc"] == [1, 5, 7]
+
+    ofg_args, ofg_kwargs = MockOFG.call_args
+    assert list(ofg_args[1]) == [1, 5, 7]
+    assert ofg_kwargs["extra_lines_to_cut"] == [7]
+
+
+@patch("expert_op4grid_recommender.graph_analysis.builder.Structured_Overload_Distribution_Graph")
+@patch("expert_op4grid_recommender.graph_analysis.builder.OverFlowGraph")
+@patch("expert_op4grid_recommender.graph_analysis.builder.Grid2opSimulation")
+def test_builder_extras_none_defaults_to_empty(MockSim, MockOFG, MockSODG):
+    """``extra_lines_to_cut_ids=None`` must behave like ``[]`` — no
+    extras forwarded, ``ltc`` unchanged."""
+    from expert_op4grid_recommender.graph_analysis.builder import (
+        build_overflow_graph,
+    )
+
+    MockSim.return_value = _make_sim_mock()
+    MockOFG.return_value = _make_overflow_graph_mock()
+    MockSODG.return_value = _make_distribution_mock()
+
+    env = MagicMock()
+    obs = MagicMock()
+    obs.name_line = np.array([])
+    obs.name_sub = np.array(["sub0", "sub1"])
+
+    build_overflow_graph(
+        env,
+        obs,
+        overloaded_line_ids=[0, 1],
+        non_connected_reconnectable_lines=[],
+        lines_non_reconnectable=[],
+        timestep=0,
+        do_consolidate_graph=False,
+        node_renaming=False,
+        extra_lines_to_cut_ids=None,
+    )
+
+    sim_kwargs = MockSim.call_args.kwargs
+    assert sim_kwargs["ltc"] == [0, 1]
+
+    ofg_args, ofg_kwargs = MockOFG.call_args
+    assert list(ofg_args[1]) == [0, 1]
+    assert ofg_kwargs["extra_lines_to_cut"] == []
+
+
+@patch("expert_op4grid_recommender.graph_analysis.builder.Structured_Overload_Distribution_Graph")
+@patch("expert_op4grid_recommender.graph_analysis.builder.OverFlowGraph")
+@patch("expert_op4grid_recommender.graph_analysis.builder.Grid2opSimulation")
+def test_builder_default_kwarg_is_empty(MockSim, MockOFG, MockSODG):
+    """Calling without ``extra_lines_to_cut_ids`` at all keeps legacy
+    behavior (no extras forwarded)."""
+    from expert_op4grid_recommender.graph_analysis.builder import (
+        build_overflow_graph,
+    )
+
+    MockSim.return_value = _make_sim_mock()
+    MockOFG.return_value = _make_overflow_graph_mock()
+    MockSODG.return_value = _make_distribution_mock()
+
+    env = MagicMock()
+    obs = MagicMock()
+    obs.name_line = np.array([])
+    obs.name_sub = np.array(["sub0", "sub1"])
+
+    build_overflow_graph(
+        env,
+        obs,
+        overloaded_line_ids=[42],
+        non_connected_reconnectable_lines=[],
+        lines_non_reconnectable=[],
+        timestep=0,
+        do_consolidate_graph=False,
+        node_renaming=False,
+    )
+
+    sim_kwargs = MockSim.call_args.kwargs
+    assert sim_kwargs["ltc"] == [42]
+    ofg_kwargs = MockOFG.call_args.kwargs
+    assert ofg_kwargs["extra_lines_to_cut"] == []
+
+
+# ---------------------------------------------------------------------------
+# pypowsybl_backend.overflow_analysis.build_overflow_graph_pypowsybl
+# ---------------------------------------------------------------------------
+
+
+@patch("expert_op4grid_recommender.pypowsybl_backend.overflow_analysis.AlphaDeespAdapter")
+def test_pypowsybl_builder_appends_extras_and_forwards_to_overflow_graph(
+    MockAdapter,
+):
+    """Same plumbing assertions as the grid2op variant, but for the
+    pypowsybl ``build_overflow_graph_pypowsybl`` entrypoint."""
+    # The pypowsybl variant imports ``OverFlowGraph`` and
+    # ``Structured_Overload_Distribution_Graph`` lazily inside the
+    # function body, so we patch the alphaDeesp module directly.
+    with patch(
+        "alphaDeesp.core.graphsAndPaths.OverFlowGraph"
+    ) as MockOFG, patch(
+        "alphaDeesp.core.graphsAndPaths.Structured_Overload_Distribution_Graph"
+    ) as MockSODG:
+        from expert_op4grid_recommender.pypowsybl_backend.overflow_analysis import (
+            build_overflow_graph_pypowsybl,
+        )
+
+        adapter = MagicMock()
+        adapter.get_dataframe.return_value = _empty_flow_dataframe()
+        adapter.topo = MagicMock()
+        MockAdapter.return_value = adapter
+
+        MockOFG.return_value = _make_overflow_graph_mock()
+        MockSODG.return_value = _make_distribution_mock()
+
+        env = MagicMock()
+        obs = MagicMock()
+        obs.name_line = np.array([])
+        obs.name_sub = np.array(["sub0", "sub1"])
+
+        build_overflow_graph_pypowsybl(
+            env,
+            obs,
+            overloaded_line_ids=[0, 1],
+            non_connected_reconnectable_lines=[],
+            lines_non_reconnectable=[],
+            timestep=0,
+            do_consolidate_graph=False,
+            extra_lines_to_cut_ids=[1, 4],  # 1 is duplicate, 4 is new
+        )
+
+        # AlphaDeespAdapter (drop-in replacement for Grid2opSimulation)
+        # must receive deduplicated full ltc.
+        adapter_kwargs = MockAdapter.call_args.kwargs
+        assert adapter_kwargs["ltc"] == [0, 1, 4]
+
+        # OverFlowGraph must receive only the *new* extras and the full
+        # union as its ltc positional argument.
+        ofg_args, ofg_kwargs = MockOFG.call_args
+        assert list(ofg_args[1]) == [0, 1, 4]
+        assert ofg_kwargs["extra_lines_to_cut"] == [4]
+
+
+@patch("expert_op4grid_recommender.pypowsybl_backend.overflow_analysis.AlphaDeespAdapter")
+def test_pypowsybl_builder_extras_none_defaults_to_empty(MockAdapter):
+    """``extra_lines_to_cut_ids=None`` is a no-op for the pypowsybl
+    variant too."""
+    with patch(
+        "alphaDeesp.core.graphsAndPaths.OverFlowGraph"
+    ) as MockOFG, patch(
+        "alphaDeesp.core.graphsAndPaths.Structured_Overload_Distribution_Graph"
+    ) as MockSODG:
+        from expert_op4grid_recommender.pypowsybl_backend.overflow_analysis import (
+            build_overflow_graph_pypowsybl,
+        )
+
+        adapter = MagicMock()
+        adapter.get_dataframe.return_value = _empty_flow_dataframe()
+        adapter.topo = MagicMock()
+        MockAdapter.return_value = adapter
+
+        MockOFG.return_value = _make_overflow_graph_mock()
+        MockSODG.return_value = _make_distribution_mock()
+
+        env = MagicMock()
+        obs = MagicMock()
+        obs.name_line = np.array([])
+        obs.name_sub = np.array(["sub0", "sub1"])
+
+        build_overflow_graph_pypowsybl(
+            env,
+            obs,
+            overloaded_line_ids=[7],
+            non_connected_reconnectable_lines=[],
+            lines_non_reconnectable=[],
+            timestep=0,
+            do_consolidate_graph=False,
+            extra_lines_to_cut_ids=None,
+        )
+
+        adapter_kwargs = MockAdapter.call_args.kwargs
+        assert adapter_kwargs["ltc"] == [7]
+        ofg_kwargs = MockOFG.call_args.kwargs
+        assert ofg_kwargs["extra_lines_to_cut"] == []
+
+
+# ---------------------------------------------------------------------------
+# main.run_analysis_step2_graph context plumbing
+# ---------------------------------------------------------------------------
+
+
+def _make_step2_context(extra_lines_to_cut_ids, is_pypowsybl=False):
+    """Builds the minimal context dict that ``run_analysis_step2_graph``
+    expects, with all heavyweight bits replaced by mocks."""
+    captured = {}
+
+    def fake_build_overflow_graph(*args, **kwargs):
+        captured["args"] = args
+        captured["kwargs"] = kwargs
+        # Mimic the 6-tuple return signature of the real function.
+        return (
+            pd.DataFrame({
+                "new_flows_swapped": pd.Series([], dtype=bool),
+                "line_name": pd.Series([], dtype=str),
+            }),
+            MagicMock(),  # overflow_sim
+            MagicMock(g=nx.DiGraph()),  # g_overflow
+            [],  # hubs
+            MagicMock(),  # g_distribution_graph
+            {},  # node_name_mapping
+        )
+
+    env = MagicMock()
+    env.action_space = MagicMock()
+    obs = MagicMock()
+    obs_simu_defaut = MagicMock()
+    obs_simu_defaut.name_line = np.array(["L0"])
+
+    context = {
+        "backend": "grid2op" if not is_pypowsybl else "pypowsybl",
+        "env": env,
+        "obs": obs,
+        "obs_simu_defaut": obs_simu_defaut,
+        "analysis_date": None,
+        "current_timestep": 0,
+        "current_lines_defaut": ["LX"],
+        "lines_overloaded_ids": [0],
+        "lines_overloaded_ids_kept": [0],
+        "maintenance_to_reco_at_t": [],
+        "act_reco_maintenance": MagicMock(),
+        "lines_non_reconnectable": [],
+        "lines_we_care_about": [],
+        "classifier": MagicMock(),
+        "custom_layout": None,
+        "chronic_name": "test",
+        "pre_existing_rho": 0.0,
+        "lines_overloaded_names": ["L0"],
+        "non_connected_reconnectable_lines": [],
+        "dict_action": {},
+        "is_bare_env": True,
+        "is_pypowsybl": is_pypowsybl,
+        "actual_fast_mode": True,
+        # backend-specific function mocks
+        "check_simu_overloads": MagicMock(return_value=(True, False)),
+        "switch_to_dc": MagicMock(return_value=(env, obs, obs_simu_defaut)),
+        "build_overflow_graph": fake_build_overflow_graph,
+        "get_env_first_obs": MagicMock(),
+        "simulate_contingency": MagicMock(),
+        "create_default_action": MagicMock(),
+        "check_rho_reduction": MagicMock(),
+        "compute_baseline": MagicMock(),
+    }
+    if extra_lines_to_cut_ids is not None:
+        context["extra_lines_to_cut_ids"] = extra_lines_to_cut_ids
+    return context, captured
+
+
+def test_run_analysis_step2_graph_forwards_extras_from_context():
+    """The step2 graph builder must read ``context["extra_lines_to_cut_ids"]``
+    and pass it through to the (injected) ``build_overflow_graph``."""
+    from expert_op4grid_recommender import config
+    from expert_op4grid_recommender.main import run_analysis_step2_graph
+
+    context, captured = _make_step2_context(
+        extra_lines_to_cut_ids=[10, 20]
+    )
+
+    # Disable visualization & test data saving so the function returns
+    # immediately after the build_overflow_graph call.
+    with patch.object(config, "DO_VISUALIZATION", False), \
+         patch.object(config, "DO_SAVE_DATA_FOR_TEST", False):
+        run_analysis_step2_graph(context)
+
+    assert captured["kwargs"].get("extra_lines_to_cut_ids") == [10, 20]
+
+
+def test_run_analysis_step2_graph_missing_key_defaults_to_empty():
+    """When the legacy single-step path doesn't populate the key,
+    ``run_analysis_step2_graph`` must fall back to ``[]`` — no extras
+    forwarded."""
+    from expert_op4grid_recommender import config
+    from expert_op4grid_recommender.main import run_analysis_step2_graph
+
+    context, captured = _make_step2_context(extra_lines_to_cut_ids=None)
+    # Ensure key is genuinely absent (not just None).
+    context.pop("extra_lines_to_cut_ids", None)
+
+    with patch.object(config, "DO_VISUALIZATION", False), \
+         patch.object(config, "DO_SAVE_DATA_FOR_TEST", False):
+        run_analysis_step2_graph(context)
+
+    assert captured["kwargs"].get("extra_lines_to_cut_ids") == []
+
+
+def test_run_analysis_step2_graph_pypowsybl_path_forwards_extras():
+    """The pypowsybl branch (``is_pypowsybl=True``) of step2 graph also
+    passes the extras through (as a kwarg, alongside ``fast_mode``)."""
+    from expert_op4grid_recommender import config
+    from expert_op4grid_recommender.main import run_analysis_step2_graph
+
+    context, captured = _make_step2_context(
+        extra_lines_to_cut_ids=[5], is_pypowsybl=True
+    )
+
+    with patch.object(config, "DO_VISUALIZATION", False), \
+         patch.object(config, "DO_SAVE_DATA_FOR_TEST", False):
+        run_analysis_step2_graph(context)
+
+    assert captured["kwargs"].get("extra_lines_to_cut_ids") == [5]


### PR DESCRIPTION
## Summary
- Thread an operator-supplied `extra_lines_to_cut_ids` parameter through `build_overflow_graph` (and its grid2op / pypowsybl wrappers), forwarding it to both `Grid2opSimulation.ltc` (so the cut still happens) and `OverFlowGraph(extra_lines_to_cut=…)` (so the tag flows through).
- `run_analysis_step2_graph` now reads `context["extra_lines_to_cut_ids"]` (default `[]`), populated optionally by step1 callers (e.g. CoStudy4Grid) when narrowing the context.
- `make_overflow_graph_visualization` accepts the parameter for plumbing completeness.

## Behavior
Extras are appended to `ltc` for the simulation but tagged `is_extra_cut` in the OverFlowGraph so the visualization keeps them out of the Overloads / Monitored layers — matching ExpertAgent's `additionalLinesToCut` semantic. Defaults to empty list, preserving legacy single-step / no-extras behavior.

## Files changed (+68/-22)
- `expert_op4grid_recommender/graph_analysis/builder.py`
- `expert_op4grid_recommender/graph_analysis/visualization.py`
- `expert_op4grid_recommender/main.py`
- `expert_op4grid_recommender/pypowsybl_backend/overflow_analysis.py`

## Test plan
- [ ] Existing tests pass (`pytest`) — no behavior change when `extra_lines_to_cut_ids` is empty/None
- [ ] Manual run with `extra_lines_to_cut_ids` populated: verify extras appear cut in simulation but are not classified as overloads in the graph viewer
- [ ] Verify both grid2op and pypowsybl backends honor the parameter

🤖 Generated with [Claude Code](https://claude.com/claude-code)