### PR TITLE
Optimize manoeuvre module: indexing, memoization, and refactoring

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,29 @@ jobs:
           # Modify the pytest command here
           command: pytest -m "not slow" # This tells pytest to exclude tests marked 'slow'
 
+  quality:
+    # Analyse statique (sans dépendances lourdes : ruff/interrogate/radon
+    # parsent le code, ne l'importent pas). Scopé au module `manoeuvre`, maintenu
+    # propre ; le reste du dépôt n'est pas encore couvert (dette à résorber).
+    docker:
+      - image: cimg/python:3.12
+    steps:
+      - checkout
+      - run:
+          name: Install quality tools
+          command: pip install ruff interrogate radon
+      - run:
+          name: Lint (ruff) — module manoeuvre
+          command: ruff check expert_op4grid_recommender/manoeuvre scripts/manoeuvre_ihm.py tests/manoeuvre
+      - run:
+          name: Docstrings (interrogate) — module manoeuvre
+          command: interrogate expert_op4grid_recommender/manoeuvre
+      - run:
+          name: Complexité (radon, indicatif — non bloquant)
+          command: radon cc expert_op4grid_recommender/manoeuvre -a -s
+
 workflows:
   sample:
     jobs:
       - build-and-test
+      - quality

--- a/docs/manoeuvre_module.md
+++ b/docs/manoeuvre_module.md
@@ -3,7 +3,9 @@
 > **Package** : `expert_op4grid_recommender.manoeuvre`
 > **Origine** : Portage Python de la bibliothèque C++ `libTOPO` (projet TOPO Apogee, RTE)
 > **Backend reseau** : pypowsybl (topologie NODE_BREAKER)
-> **Statut** : Etapes 1.1 et 1.2 implementees ; etapes 1.3+ a venir
+> **Statut** : Etapes 1.1 a 1.6 + phase 2 (sequencement) implementees ; IHM de test
+> disponible. Campagne d'optimisation a iso-comportement : voir
+> [`manoeuvre_optimisations.md`](manoeuvre_optimisations.md).
 
 ---
 

--- a/docs/manoeuvre_optimisations.md
+++ b/docs/manoeuvre_optimisations.md
@@ -127,7 +127,20 @@ A/B sur fixtures (moyenne sur N analyses, `networkx` réel) :
   `_placement_automatique` (intrinsèque) ; la franchir demanderait un placement
   non exhaustif (heuristique/branch‑and‑bound), qui **pourrait** changer la
   sortie — non entrepris pour préserver l'iso‑comportement.
-- Items de la revue non traités (hors périmètre de cette campagne) : éclatement
-  d'`algo.py` en sous‑modules, externalisation du front‑end de l'IHM,
-  gestionnaire de contexte `applied(state)` côté IHM, câblage `ruff`/`radon`
-  dans la CI.
+
+### Qualité — également traité
+
+- **#9 — constantes nommées + imports remontés** (`algo.py`, `manoeuvre_ihm.py`) :
+  poids de coût et garde‑fous combinatoires extraits en constantes documentées ;
+  `itertools`/`Counter`/`re` remontés en tête de module.
+- **#10 — qualité en CI** : job `quality` (CircleCI) — `ruff` (lint, **bloquant**),
+  `interrogate` (docstrings ≥ 80 %, **bloquant**), `radon` (complexité,
+  indicatif). **Scopé au module `manoeuvre`** (maintenu propre) ; configuration
+  dans `pyproject.toml` (`[tool.ruff]`, `[tool.interrogate]`). Le reste du dépôt
+  (~300 violations `ruff`) reste à résorber avant d'élargir le périmètre.
+
+### Items de la revue encore ouverts
+
+Éclatement d'`algo.py` en sous‑modules ; externalisation du front‑end de l'IHM ;
+gestionnaire de contexte `applied(state)` côté IHM ; load flow paresseux + cache
+graphe dans l'IHM ; élargissement du gate `ruff` au dépôt entier.

--- a/docs/manoeuvre_optimisations.md
+++ b/docs/manoeuvre_optimisations.md
@@ -1,0 +1,133 @@
+# Module Manœuvre — Revue de code & campagne d'optimisation
+
+> Rapport de la revue critique (architecture / qualité / performance) du module
+> `manoeuvre` et de son IHM, des **filets de sécurité** posés avant refactor, et
+> des **refactors à iso‑comportement** réalisés, avec les **gains mesurés**.
+>
+> Doc connexes : [`manoeuvre_module.md`](manoeuvre_module.md) ·
+> [`manoeuvre_regles.md`](manoeuvre_regles.md) ·
+> [`manoeuvre_ihm.md`](manoeuvre_ihm.md) ·
+> [`../expert_op4grid_recommender/manoeuvre/CLAUDE.md`](../expert_op4grid_recommender/manoeuvre/CLAUDE.md)
+
+---
+
+## 1. Méthode
+
+Chaque refactor a suivi la même discipline :
+
+1. **Diagnostic mesuré** : profilage (`cProfile`) plutôt que lecture statique
+   seule — à deux reprises le profil a corrigé l'intuition.
+2. **Filet de sécurité d'abord** : tests posés et **verts sur le code actuel**
+   *avant* de toucher au code, de sorte que tout écart de comportement soit
+   détecté immédiatement.
+3. **Refactor à iso‑comportement**, validé par les filets (notamment des
+   *goldens* comparés **octet pour octet**), puis commité isolément.
+4. **Gain mesuré** en A/B (commit pré‑refactor vs après).
+
+---
+
+## 2. Diagnostic initial (revue critique)
+
+### Architecture
+- `algo.py` est un module « god » (~2 250 lignes, 40+ fonctions, 4 points
+  d'entrée) mêlant placement, séquencement, vérification et helpers bas niveau.
+- **Pas d'index** : `_is_open` / `_set_switch` / `_eq_node` retrouvaient un
+  organe/nœud par **scan linéaire** du graphe (82 sites d'appel).
+- `_inter_sjb_couplers` **recalculé ~10×/analyse** (all‑pairs SJB + retraits
+  d'arêtes), alors qu'il ne dépend que de la topologie.
+- IHM : god‑file mêlant Flask, rendu pypowsybl, parsing SVG et ~600 lignes de
+  HTML/JS embarqué ; franchit la frontière privée (`_sectionneurs_sous_charge_…`).
+
+### Qualité
+- Modes d'échec **silencieux** (`_set_switch` no‑op, `_is_open`→True sur id
+  inconnu).
+- Vérificateurs rejouant chacun la séquence (3–4 rejeux).
+- Constantes magiques de coût/seuils non nommées ; imports locaux dispersés.
+
+### Performance
+- **O(E) dans des boucles combinatoires** : `_placement_automatique` énumère
+  k^(nb SJB) affectations en testant `nx.is_connected` à répétition.
+- Reconstructions de graphes et **recalculs de chemins structurels** dans des
+  boucles chaudes.
+
+---
+
+## 3. Filets de sécurité (posés avant tout refactor)
+
+| Filet | Fichier | Rôle |
+|---|---|---|
+| **Déterminisme** | `algo.py` (`a5c7de6`) | Canonicalisation de l'ordre d'émission (itérations d'ensembles triées) — **prérequis** pour qu'un golden d'ordre exact soit stable d'un process à l'autre (`PYTHONHASHSEED`). |
+| **T1 — Golden** | `tests/manoeuvre/test_golden_sequences.py` | Caractérisation de bout en bout sur `scenarios/*.json` × {smooth, aggressive} (24 goldens) : séquence ordonnée exacte + vérifications + écarts + partition. Régénération consciente via `UPDATE_GOLDENS=1`. |
+| **T2 — Vérificateurs exacts** | `tests/manoeuvre/test_verificateurs_exact.py` | Égalité de liste exacte (alignement, indices d'infraction, dédup) + idempotence + non‑mutation du graphe. |
+| **T3 — Contrat lookups** | `tests/manoeuvre/test_lookup_helpers.py` | Contrat de `_is_open`/`_set_switch`/`_eq_node` (id inconnu, validité sur copie, « tout switch_id émis existe »). |
+| **T4 — Invariants couplers** | `tests/manoeuvre/test_couplers_memoisation.py` | Préconditions du cache : invariance à l'état des organes, idempotence, non‑mutation de `poste.graph` par le pipeline. |
+
+> Le golden a immédiatement révélé une **nondéterminisme réelle** (ordre de blocs
+> de dé‑énergisation dépendant du hash) — d'où le fix `a5c7de6` *avant* les
+> refactors.
+
+---
+
+## 4. Refactors réalisés (à iso‑comportement)
+
+| # | Commit | Diagnostic | Action | Garantie |
+|---|---|---|---|---|
+| **#1** | `bda3234` | scans O(E) des lookups | index `switch_id→arête` / `equipment_id→nœud` mémoïsés sur `G.graph` (valides sur copies : coordonnées topologiques) | contrat id‑inconnu préservé (T3) |
+| **#2** | `90cd0c2` | `_inter_sjb_couplers` recalculé ~10× | mémoïsation sur le poste (invariant à l'état — T4) | goldens inchangés |
+| **#3** | `ba67820` | 3 rejeux des vérificateurs | passe unique `_rejeu_securite` + agrégateur `_verifier_regles` ; fonctions publiques = délégateurs | sortie exacte (T1+T2) |
+| **P1** | `b37ed42` | `nx.is_connected` recalculé ~k^n fois | connexité **mémoïsée** par sous‑ensemble + hoist de l'invariant `currently_closed` | même ordre, même tie‑break |
+| **P1+** | `ff6a14f` | énumération k^n filtrée sur la connexité | génération **directe** des partitions connexes × bijections ; **tie‑break lex‑min** reproduisant `product` | ensemble de candidats identique → coût min identique ; sortie prouvée identique |
+| **Q1** | `12de96b` | garde‑fou d'index `number_of_edges()` O(E) ; `_edges_of_switches` O(E) ; `disconnectors_vers_barre` recalculé 27 k× | garde O(1) (`number_of_nodes`) ; index ; **mémoïsation** du chemin SA structurel sur la cellule | structurel/invariant → sortie identique |
+
+### Note méthodologique
+Pour **P1** comme pour **Q1**, le **profil a corrigé la lecture statique** :
+- la « recherche combinatoire » était bien le coût dominant des gros postes
+  (P1), mais le hotspot transverse réel n'était **pas** les reconstructions de
+  graphes (`_equipotentiel`…), négligeables au profilage, **mais** le
+  recalcul d'un **plus‑court‑chemin structurel** (`disconnectors_vers_barre`)
+  appelé des dizaines de milliers de fois (Q1) ;
+- le garde‑fou O(E) introduit par **#1** lui‑même (`number_of_edges()`) annulait
+  une partie de son bénéfice — corrigé en Q1.
+
+---
+
+## 5. Gains mesurés
+
+A/B sur fixtures (moyenne sur N analyses, `networkx` réel) :
+
+| Cas | pré‑#1 | post #1‑#3 | P1 | P1+ | Q1 |
+|---|---|---|---|---|---|
+| **SSAVOP3** (8 SJB, 62 manœuvres) | 1201 ms | 1184 ms | 200 ms | 76 ms | **44 ms** |
+| **PALUNP3** (4 SJB) | 22,9 ms | 17,2 ms | 15 ms | 20 ms | **10,5 ms** |
+| **Corpus** (12 scénarios × 2 modes) | — | — | — | 349,6 ms | **232,7 ms** |
+
+- **SSAVOP3 : ~27×** (1201 → 44 ms) — porté par P1/P1+ (placement) puis Q1.
+- **Corpus : ~1,5×** sur le seul Q1 (mémoïsation du chemin SA, transverse).
+- **PALUNP3 : ~2,2×** — porté par les lookups O(1) (#1 + garde Q1).
+
+---
+
+## 6. Garanties d'iso‑comportement
+
+- **Goldens octet‑pour‑octet** sur 12 scénarios × 2 modes, **stables sur ≥ 3
+  graines de hash** — rejoués après *chaque* refactor.
+- **P1+** : l'énumération par partitions connexes explore **le même ensemble de
+  candidats** que `itertools.product` filtré (donc même coût minimal) ; un
+  **tie‑break lex‑min** reproduit le choix de `product` même en cas d'égalité de
+  coût hors corpus → équivalence **prouvée sur toute entrée**, pas seulement
+  constatée.
+- Mémoïsations (#2, Q1) : portées par des **invariants vérifiés par tests**
+  (indépendance à l'état des organes, non‑mutation des structures).
+
+---
+
+## 7. Reste à faire / limites
+
+- Le coût résiduel des gros postes est l'**énumération combinatoire** de
+  `_placement_automatique` (intrinsèque) ; la franchir demanderait un placement
+  non exhaustif (heuristique/branch‑and‑bound), qui **pourrait** changer la
+  sortie — non entrepris pour préserver l'iso‑comportement.
+- Items de la revue non traités (hors périmètre de cette campagne) : éclatement
+  d'`algo.py` en sous‑modules, externalisation du front‑end de l'IHM,
+  gestionnaire de contexte `applied(state)` côté IHM, câblage `ruff`/`radon`
+  dans la CI.

--- a/expert_op4grid_recommender/manoeuvre/CLAUDE.md
+++ b/expert_op4grid_recommender/manoeuvre/CLAUDE.md
@@ -94,6 +94,47 @@ Le `fixture_loader.py` contient les fonctions de chargement :
 Les tests unitaires (`test_graph_cellules.py`) utilisent le reseau standard
 `pp.network.create_four_substations_node_breaker_network()`, cible `S1VL2`.
 
+### Filets de regression (refactors a iso-comportement)
+
+Poses avant la campagne d'optimisation (cf. `docs/manoeuvre_optimisations.md`),
+ces tests garantissent l'invariance du comportement :
+
+- `test_golden_sequences.py` — **golden** de bout en bout : sequence ordonnee
+  exacte + verifications + ecarts + partition, pour chaque `scenarios/*.json` x
+  {smooth, aggressive}. Reference dans `tests/manoeuvre/goldens/`.
+  **Regenerer consciemment** apres un changement de comportement assume :
+  `UPDATE_GOLDENS=1 pytest tests/manoeuvre/test_golden_sequences.py`.
+- `test_verificateurs_exact.py` — sorties exactes des verificateurs du
+  sectionneur (alignement, indices, dedup, idempotence, non-mutation).
+- `test_lookup_helpers.py` — contrat de `_is_open`/`_set_switch`/`_eq_node`
+  (id inconnu, validite sur copie de graphe).
+- `test_couplers_memoisation.py` — invariance a l'etat des couplers, purete,
+  non-mutation de `poste.graph` par le pipeline.
+
+## Performance & invariants internes
+
+Plusieurs chemins chauds sont **memoises** ; toute modification doit preserver
+ces invariants (sinon les goldens cassent). Detail et gains :
+`docs/manoeuvre_optimisations.md`.
+
+- **Index lookups** (`_switch_edge_index`, `_equipment_node_index`) : caches
+  `G.graph` construits en une passe ; coordonnees **topologiques** (valides sur
+  les copies). Garde-fou **O(1)** sur `number_of_nodes()` — ne **jamais**
+  rebrancher sur `number_of_edges()` (O(aretes), annule le gain).
+- **Couplers** (`_inter_sjb_couplers`) : memoise sur le poste — invariant a
+  l'etat ouvert/ferme des organes (ne lit que la topologie + le tronconnement).
+- **Verificateurs** : une **passe de rejeu unique** (`_rejeu_securite`) ; les
+  fonctions publiques sont de minces delegateurs.
+- **Placement** (`_placement_automatique`) : enumeration par **partitions
+  connexes** (`_assignations_connexes`) + connexite memoisee + tie-break
+  **lex-min** reproduisant l'ancienne enumeration `itertools.product`.
+- **Chemins SA** (`CelluleDepart.disconnectors_vers_barre`) : memoise par SJB
+  (sous-graphe de cellule fige -> resultat structurel invariant).
+
+Invariant cle exploite partout : **`poste.graph` n'est jamais mute
+structurellement** ; le sequenceur travaille sur des **copies** et ne bascule
+que l'attribut `open`.
+
 ## Etat algo (phase 2)
 
 `determiner_topo_complete_cible(poste, topo_cible)` traite :

--- a/expert_op4grid_recommender/manoeuvre/algo.py
+++ b/expert_op4grid_recommender/manoeuvre/algo.py
@@ -943,6 +943,61 @@ def _ecarts_detailles(
 # (ré-aiguillages + manœuvres de couplers, sectionnements pénalisés).
 # ---------------------------------------------------------------------------
 
+def _assignations_connexes(sjb_nodes, k, est_connexe):
+    """Génère les affectations SJB->nœud (tuples de longueur n) où **chaque nœud
+    reçoit un groupe de SJB connexe non vide**, couvrant toutes les SJB.
+
+    Équivalent **en ensemble** à ``itertools.product(range(k), repeat=n)`` filtré
+    sur « tous les nœuds non vides et connexes », mais généré **par construction**
+    (partitions en k blocs connexes × bijections bloc->nœud) plutôt qu'en filtrant
+    k^n affectations. Le coût minimal exploré est donc identique ; seul l'ordre
+    d'énumération (et donc le tie-breaking en cas d'égalité) diffère.
+
+    ``est_connexe(frozenset[int]) -> bool`` : prédicat de connexité (mémoïsé).
+    """
+    import itertools
+    n = len(sjb_nodes)
+    pos = {s: i for i, s in enumerate(sjb_nodes)}
+
+    # Sous-ensembles connexes non vides, groupés par leur plus petite SJB (indice).
+    connexes_par_ancre: dict[int, list[frozenset]] = {}
+    for r in range(1, n + 1):
+        for combo in itertools.combinations(sjb_nodes, r):
+            fs = frozenset(combo)
+            if est_connexe(fs):
+                ancre = min(pos[s] for s in fs)
+                connexes_par_ancre.setdefault(ancre, []).append(fs)
+
+    # Partitions en exactement k blocs connexes, ancrées sur la plus petite SJB
+    # non couverte -> chaque partition (non ordonnée) générée une seule fois.
+    partitions: list[list[frozenset]] = []
+
+    def _rec(remaining: frozenset, blocks: list):
+        if not remaining:
+            if len(blocks) == k:
+                partitions.append(blocks)
+            return
+        if len(blocks) >= k:
+            return
+        ancre = min(pos[s] for s in remaining)
+        for block in connexes_par_ancre.get(ancre, ()):
+            if (block <= remaining
+                    and len(remaining) - len(block) >= (k - len(blocks) - 1)):
+                _rec(remaining - block, blocks + [block])
+
+    _rec(frozenset(sjb_nodes), [])
+
+    # Affectation des blocs aux nœuds : toutes les bijections (nœuds distinguables
+    # — départs distincts, donc coûts distincts selon le nœud porteur du bloc).
+    for blocks in partitions:
+        for perm in itertools.permutations(range(k)):
+            assign = [0] * n
+            for block, node in zip(blocks, perm):
+                for s in block:
+                    assign[pos[s]] = node
+            yield tuple(assign)
+
+
 def _placement_automatique(
     poste: PosteTopologique,
     topo_cible: TopologieNodale,
@@ -1062,7 +1117,7 @@ def _placement_automatique(
     # uniquement si elle est possible (k ≤ nb SJB) et tient dans le garde-fou.
     best = None  # (cost, assign tuple)
     if k <= len(sjb_nodes) and k ** len(sjb_nodes) <= 500_000:
-        for assign in itertools.product(range(k), repeat=len(sjb_nodes)):
+        for assign in _assignations_connexes(sjb_nodes, k, _groupe_connexe):
             node_sjbs: dict[int, set[int]] = {i: set() for i in range(k)}
             for j, ni in enumerate(assign):
                 node_sjbs[ni].add(sjb_nodes[j])
@@ -1098,7 +1153,12 @@ def _placement_automatique(
                     if cp.is_sectionnement:
                         sect += 1
             cost = 5 * reaig + cpl + 4 * sect
-            if best is None or cost < best[0]:
+            # Tie-break **lex-min** sur ``assign`` : reproduit exactement le choix
+            # de l'ancienne énumération ``itertools.product`` (premier min-coût en
+            # ordre lexicographique). La sortie est donc strictement identique,
+            # quel que soit l'ordre d'énumération des partitions connexes.
+            if (best is None or cost < best[0]
+                    or (cost == best[0] and assign < best[1])):
                 best = (cost, assign)
 
     full_placement = None

--- a/expert_op4grid_recommender/manoeuvre/algo.py
+++ b/expert_op4grid_recommender/manoeuvre/algo.py
@@ -69,7 +69,9 @@ Limites connues (documentées, cf. doc C++) :
 
 from __future__ import annotations
 
+import itertools
 import logging
+from collections import Counter
 from dataclasses import dataclass, field
 from typing import Literal, Optional
 
@@ -84,6 +86,22 @@ from .topologie import (
 from .troncons import Troncon
 
 logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Paramètres de la recherche de placement (phases 2.2-2.4)
+# ---------------------------------------------------------------------------
+# Poids du coût d'une affectation nœud -> SJB. Un **ré-aiguillage** (déplacer un
+# départ d'une barre à l'autre, manœuvre lourde) est plus cher qu'une simple
+# manœuvre de **coupler** ; **ouvrir un sectionnement** (organe hors charge,
+# dé-énergisation préalable) est pénalisé plus qu'ouvrir un couplage (DJ).
+POIDS_REAIGUILLAGE = 5
+POIDS_MANOEUVRE_COUPLER = 1
+POIDS_OUVERTURE_SECTIONNEMENT = 4
+
+# Garde-fous combinatoires : au-delà, on bascule sur une heuristique (placement
+# best-effort borné, puis glouton) plutôt que d'énumérer toutes les affectations.
+MAX_COMBINAISONS_PLACEMENT = 500_000        # affectation complète (~k^nb_SJB)
+MAX_COMBINAISONS_BEST_EFFORT = 2_000_000    # placement partiel (~(k+1)^nb_SJB)
 
 
 # ---------------------------------------------------------------------------
@@ -495,7 +513,6 @@ def _organes_internes_2bornes(poste: PosteTopologique) -> set[str]:
     bornes (typiquement une self/réactance dont les deux côtés sont câblés chacun
     sur une barre) apparaît dans deux cellules de départ. Ces organes sont laissés
     en place (ni ré-aiguillés ni signalés en écart)."""
-    from collections import Counter
     occ: Counter = Counter()
     for c in poste.cellules.cellules_depart:
         for eq in {c.equipment_id} | set(c.shared_equipment_ids):
@@ -953,7 +970,6 @@ def _assignations_connexes(sjb_nodes, k, est_connexe):
 
     ``est_connexe(frozenset[int]) -> bool`` : prédicat de connexité (mémoïsé).
     """
-    import itertools
     n = len(sjb_nodes)
     pos = {s: i for i, s in enumerate(sjb_nodes)}
 
@@ -1013,8 +1029,6 @@ def _placement_automatique(
     -------
     (placement, faisable, message, noeuds_non_places)
     """
-    import itertools
-
     G = poste.graph
     barre_par = poste.tronconnement.barre_par_busbar
     sjb_nodes = sorted(barre_par)
@@ -1114,7 +1128,7 @@ def _placement_automatique(
     # Recherche exhaustive d'une affectation **complète** (tous les nœuds placés),
     # uniquement si elle est possible (k ≤ nb SJB) et tient dans le garde-fou.
     best = None  # (cost, assign tuple)
-    if k <= len(sjb_nodes) and k ** len(sjb_nodes) <= 500_000:
+    if k <= len(sjb_nodes) and k ** len(sjb_nodes) <= MAX_COMBINAISONS_PLACEMENT:
         for assign in _assignations_connexes(sjb_nodes, k, _groupe_connexe):
             node_sjbs: dict[int, set[int]] = {i: set() for i in range(k)}
             for j, ni in enumerate(assign):
@@ -1150,7 +1164,9 @@ def _placement_automatique(
                     cpl += 1
                     if cp.is_sectionnement:
                         sect += 1
-            cost = 5 * reaig + cpl + 4 * sect
+            cost = (POIDS_REAIGUILLAGE * reaig
+                    + POIDS_MANOEUVRE_COUPLER * cpl
+                    + POIDS_OUVERTURE_SECTIONNEMENT * sect)
             # Tie-break **lex-min** sur ``assign`` : reproduit exactement le choix
             # de l'ancienne énumération ``itertools.product`` (premier min-coût en
             # ordre lexicographique). La sortie est donc strictement identique,
@@ -1249,8 +1265,6 @@ def _diagnostic_infaisabilite(
     2. *Organe interne à 2 bornes* (self/réactance ``LINE_SIDE1``+``LINE_SIDE2``)
        présent sur plusieurs nœuds alors qu'il n'atteint qu'une seule section.
     """
-    from collections import Counter
-
     def _names(sset) -> str:
         return "{" + ", ".join(str(sjb_id.get(s, s)) for s in sorted(sset)) + "}"
 
@@ -1305,15 +1319,13 @@ def _placement_best_effort(
         ``placement`` = ``[(departs, sjb_ids)]`` des nœuds réalisés ;
         ``noeuds_non_places`` = liste des départs des nœuds non réalisés.
     """
-    import itertools
-
     k = len(nodes)
     n_sjb = len(sjb_nodes)
     if k == 0:
         return [], []
 
     # Garde-fou : chaque SJB → un nœud OU « inutilisée » (k+1 choix par SJB).
-    if (k + 1) ** n_sjb > 2_000_000:
+    if (k + 1) ** n_sjb > MAX_COMBINAISONS_BEST_EFFORT:
         return _placement_greedy(nodes, R, sjb_nodes, sjb_id)
 
     # Connexité d'un groupe de SJB : **mémoïsée** (cf. ``_placement_automatique``).
@@ -1666,7 +1678,6 @@ def determiner_manoeuvres_avec_sections(
             groupe_sjb[s] = gid
 
     # Référence = groupe portant le plus de départs cibles (le « tronc »)
-    from collections import Counter
     poids = Counter(groupe_sjb[s] for s in target_sjb.values() if s in groupe_sjb)
     ref_group = poids.most_common(1)[0][0] if poids else None
     ref_sjbs = {s for s, g in groupe_sjb.items() if g == ref_group}

--- a/expert_op4grid_recommender/manoeuvre/algo.py
+++ b/expert_op4grid_recommender/manoeuvre/algo.py
@@ -1312,12 +1312,51 @@ def _placement_greedy(
     return placement, non_places
 
 
+def _switch_edge_index(G: nx.Graph) -> dict[str, tuple[int, int]]:
+    """Index ``switch_id -> (u, v)`` mémoïsé sur le graphe (``G.graph``).
+
+    Construit en une passe au premier accès, puis réutilisé en O(1) — il
+    remplace les anciens scans linéaires de ``_is_open`` / ``_set_switch``.
+
+    Validité : la coordonnée ``(u, v)`` d'un switch est **topologique**, donc
+    stable tant que la structure du graphe ne change pas. Le séquenceur ne fait
+    que basculer l'attribut ``open`` (jamais ajouter/retirer d'arête), et
+    ``G.copy()`` préserve nœuds et arêtes : l'index reste valide sur les graphes
+    dérivés (copies de travail, ``cible_graph`` du même réseau). Le nombre
+    d'arêtes sert de garde-fou : toute modification structurelle force une
+    reconstruction.
+    """
+    cache = G.graph.get("_switch_edge_index")
+    if cache is None or cache[0] != G.number_of_edges():
+        mapping = {d["switch_id"]: (u, v)
+                   for u, v, d in G.edges(data=True)
+                   if d.get("switch_id") is not None}
+        cache = (G.number_of_edges(), mapping)
+        G.graph["_switch_edge_index"] = cache
+    return cache[1]
+
+
+def _equipment_node_index(G: nx.Graph) -> dict[str, int]:
+    """Index ``equipment_id -> node`` mémoïsé sur le graphe (cf.
+    ``_switch_edge_index`` ; garde-fou sur le nombre de nœuds)."""
+    cache = G.graph.get("_equipment_node_index")
+    if cache is None or cache[0] != G.number_of_nodes():
+        mapping = {d["equipment_id"]: n
+                   for n, d in G.nodes(data=True)
+                   if d.get("equipment_id") is not None}
+        cache = (G.number_of_nodes(), mapping)
+        G.graph["_equipment_node_index"] = cache
+    return cache[1]
+
+
 def _set_switch(G: nx.Graph, switch_id: str, open_: bool) -> None:
-    """Modifie l'état d'un switch (par son id) dans le graphe simulé."""
-    for u, v, d in G.edges(data=True):
-        if d.get("switch_id") == switch_id:
-            d["open"] = open_
-            return
+    """Modifie l'état d'un switch (par son id) dans le graphe simulé.
+
+    No-op silencieux si l'id est inconnu (contrat historique, cf.
+    ``tests/manoeuvre/test_lookup_helpers.py``)."""
+    edge = _switch_edge_index(G).get(switch_id)
+    if edge is not None:
+        G.edges[edge]["open"] = open_
 
 
 # ===========================================================================
@@ -2031,17 +2070,17 @@ def _optimiser_sequence(
 
 
 def _is_open(G: nx.Graph, switch_id: str) -> bool:
-    for _, _, d in G.edges(data=True):
-        if d.get("switch_id") == switch_id:
-            return bool(d.get("open", False))
-    return True
+    """État d'un switch (True = ouvert). Un id inconnu est considéré **ouvert**
+    (contrat historique)."""
+    edge = _switch_edge_index(G).get(switch_id)
+    if edge is None:
+        return True
+    return bool(G.edges[edge].get("open", False))
 
 
 def _eq_node(G: nx.Graph, eq_id: str) -> Optional[int]:
-    for n, d in G.nodes(data=True):
-        if d.get("equipment_id") == eq_id:
-            return n
-    return None
+    """Nœud de connectivité d'un équipement (ou ``None`` si inconnu)."""
+    return _equipment_node_index(G).get(eq_id)
 
 
 def _sa_path_to_sjb(cell: CelluleDepart, sjb_node: int) -> list[str]:

--- a/expert_op4grid_recommender/manoeuvre/algo.py
+++ b/expert_op4grid_recommender/manoeuvre/algo.py
@@ -476,8 +476,7 @@ def _sequence_detaillee_aggressive(
     res.topo_obtenue = TopologieNodale.from_graph(G, vl)
     res.is_verified = res.topo_cible.meme_topologie(res.topo_obtenue)
     res.ecarts = (_ecarts_detailles(poste, G, cible_graph, cible_busbar)
-                  + _verifier_securite_sectionneurs(poste, manoeuvres)
-                  + _verifier_sectionneurs_hors_charge(poste, manoeuvres))
+                  + _verifier_regles(poste, manoeuvres, un_seul=False))
     res.is_verified_detaillee = res.is_verified and not res.ecarts
     if not res.is_verified:
         res.message = (
@@ -679,9 +678,7 @@ def _sequence_detaillee_multibarres(
     res.is_verified = topo_cible.meme_topologie(res.topo_obtenue)
     res.is_changed = bool(res.manoeuvres)
     res.ecarts = (_ecarts_detailles(poste, G, cible_graph, cible_busbar)
-                  + _verifier_securite_sectionneurs(poste, res.manoeuvres)
-                  + _verifier_un_seul_hors_tension(poste, res.manoeuvres)
-                  + _verifier_sectionneurs_hors_charge(poste, res.manoeuvres))
+                  + _verifier_regles(poste, res.manoeuvres, un_seul=True))
     res.is_verified_detaillee = res.is_verified and not res.ecarts
     if res.is_verified_detaillee:
         res.message = ("Topologie détaillée cible atteinte et vérifiée "
@@ -853,9 +850,7 @@ def determiner_manoeuvres_cible_detaillee(
     res.is_verified = topo_cible.meme_topologie(res.topo_obtenue)
     res.is_changed = bool(res.manoeuvres)
     res.ecarts = (_ecarts_detailles(poste, G, cible_graph, cible_busbar)
-                  + _verifier_securite_sectionneurs(poste, res.manoeuvres)
-                  + _verifier_un_seul_hors_tension(poste, res.manoeuvres)
-                  + _verifier_sectionneurs_hors_charge(poste, res.manoeuvres))
+                  + _verifier_regles(poste, res.manoeuvres, un_seul=True))
     res.is_verified_detaillee = res.is_verified and not res.ecarts
     if degradation:
         # Dégradation gracieuse (option 4) : cible partiellement atteinte.
@@ -1852,8 +1847,7 @@ def determiner_manoeuvres_avec_sections(
     res.is_changed = bool(manoeuvres)
     # Sûreté des sectionneurs : signaler toute ouverture restée sous tension
     # (sectionnements de barre) ou tout sectionneur manœuvré sous charge.
-    res.ecarts += _verifier_securite_sectionneurs(poste, manoeuvres)
-    res.ecarts += _verifier_sectionneurs_hors_charge(poste, manoeuvres)
+    res.ecarts += _verifier_regles(poste, manoeuvres, un_seul=False)
     res.message = (
         "Topologie cible atteinte et vérifiée."
         if res.is_verified
@@ -1916,83 +1910,131 @@ def _ouvrages_energises_sur(
     return out
 
 
-def _verifier_securite_sectionneurs(
+def _rejeu_securite(
     poste: PosteTopologique, manoeuvres: list[Manoeuvre]
-) -> list[str]:
-    """Rejoue la séquence depuis l'état initial et vérifie la **règle du
-    sectionneur** : à chaque ouverture d'un sectionnement de barre, au moins un
-    côté doit être hors tension (ou les deux côtés rester reliés par un chemin
-    parallèle). Retourne la liste des écarts (sectionneurs ouverts sous tension)."""
-    sect_ids: dict[str, tuple[int, int]] = {}
-    for cp in _inter_sjb_couplers(poste):
-        if cp.is_sectionnement:
-            for sid in cp.switch_ids:
-                sect_ids[sid] = (cp.sjb_a, cp.sjb_b)
-    if not sect_ids:
-        return []
+) -> tuple[list[str], list[Optional[str]], list[str]]:
+    """**Passe de rejeu unique** des règles du sectionneur (au lieu de trois
+    rejeux séparés). Rejoue la séquence une seule fois depuis l'état initial et
+    calcule en parallèle les trois diagnostics, en partageant le graphe « live »
+    construit au plus une fois par étape.
 
+    Returns
+    -------
+    (securite, sous_charge_par_man, un_seul)
+        - ``securite`` : sectionnements de barre ouverts **sous tension** (deux
+          côtés énergisés) — règle stricte du sectionneur de barre ;
+        - ``sous_charge_par_man`` : liste **alignée** sur ``manoeuvres`` ; message
+          d'infraction si la manœuvre ouvre un sectionneur (DISCONNECTOR) sous
+          charge, sinon ``None`` ;
+        - ``un_seul`` : moments où **plus d'un** ouvrage est hors tension par
+          ré-aiguillage (boucle longue) simultanément (R10ter, mode smooth).
+    """
+    couplers = _inter_sjb_couplers(poste)
     cells = poste.cellules
     all_sjb = set(poste.tronconnement.barre_par_busbar)
+
+    # Sectionnements de barre : sid -> (SJB a, SJB b) (règle stricte).
+    sect_pairs: dict[str, tuple[int, int]] = {}
+    for cp in couplers:
+        if cp.is_sectionnement:
+            for sid in cp.switch_ids:
+                sect_pairs[sid] = (cp.sjb_a, cp.sjb_b)
+    sect_id_set = set(sect_pairs)
+
+    # Tous les sectionneurs (DISCONNECTOR) : sid -> arête (« sous charge »).
+    disc: dict[str, tuple[int, int]] = {}
+    for u, v, d in poste.graph.edges(data=True):
+        sid = d.get("switch_id")
+        if sid and d.get("kind") == SwitchKind.DISCONNECTOR:
+            disc[sid] = (u, v)
+    equip = {n for n, d in poste.graph.nodes(data=True) if d.get("equipment_id")}
+
+    # DJ de départ (hors couplage) : sid -> équipement (« un seul HS »).
+    coupling_sids = {s for cp in couplers for s in cp.switch_ids}
+    dj_eq: dict[str, str] = {}
+    for c in cells.cellules_depart:
+        for b in c.breakers:
+            if b.switch_id not in coupling_sids:
+                dj_eq[b.switch_id] = c.equipment_id
+
+    securite: list[str] = []
+    sous_charge: list[Optional[str]] = []
+    un_seul: list[str] = []
+    temp_parking: set[str] = set()
+
     G = poste.graph.copy()
-    ecarts: list[str] = []
     for m in manoeuvres:
-        if (m.action == "OPEN" and m.switch_id in sect_ids
-                and not _is_open(G, m.switch_id)):
-            a, b = sect_ids[m.switch_id]
+        opening = (m.action == "OPEN" and not _is_open(G, m.switch_id))
+        H = None  # graphe « live » privé du switch, construit au plus une fois
+
+        # --- sectionneur sous charge (tout DISCONNECTOR), aligné sur la séquence
+        msg: Optional[str] = None
+        if opening and m.switch_id in disc:
             H = _live_graph_sans(G, [m.switch_id])
-            relies = a in H and b in H and nx.has_path(H, a, b)
-            if not relies:
+            u, v = disc[m.switch_id]
+            if not (u in H and v in H and nx.has_path(H, u, v)):
+                cu = nx.node_connected_component(H, u) if u in H else {u}
+                cv = nx.node_connected_component(H, v) if v in H else {v}
+                if (cu & equip) and (cv & equip):
+                    if m.switch_id in sect_id_set:
+                        msg = ("sectionneur de barre manœuvré sous charge — mettre "
+                               "la section de barre hors tension (ré-aiguiller ses "
+                               "départs sur l'autre section) avant d'ouvrir ce "
+                               "sectionnement")
+                    else:
+                        msg = ("sectionneur manœuvré sous charge — dé-énergiser la "
+                               "branche par son disjoncteur avant d'ouvrir ce "
+                               "sectionneur")
+        sous_charge.append(msg)
+
+        # --- sectionnement de barre ouvert sous tension (règle stricte) --------
+        if opening and m.switch_id in sect_pairs:
+            if H is None:
+                H = _live_graph_sans(G, [m.switch_id])
+            a, b = sect_pairs[m.switch_id]
+            if not (a in H and b in H and nx.has_path(H, a, b)):
                 side_a = (nx.node_connected_component(H, a)
                           if a in H else {a}) & all_sjb
                 side_b = (nx.node_connected_component(H, b)
                           if b in H else {b}) & all_sjb
                 if (_ouvrages_energises_sur(G, cells, side_a, H)
                         and _ouvrages_energises_sur(G, cells, side_b, H)):
-                    ecarts.append(
+                    securite.append(
                         f"sectionneur {m.switch_id} ouvert sous tension "
                         "(deux côtés énergisés)")
+
+        # --- un seul ouvrage hors tension par ré-aiguillage (boucle longue) ----
+        eq = dj_eq.get(m.switch_id)
+        if eq is not None:
+            longue = (m.type_boucle == "LONGUE"
+                      or "boucle longue" in (m.raison or ""))
+            if m.action == "OPEN" and longue:
+                temp_parking.add(eq)
+            elif m.action == "CLOSE":
+                temp_parking.discard(eq)
+            if len(temp_parking) > 1:
+                un_seul.append(
+                    "plus d'un ouvrage hors tension simultanément (ré-aiguillage) : "
+                    + ", ".join(sorted(temp_parking)))
+
         _set_switch(G, m.switch_id, m.action == "OPEN")
-    return ecarts
+
+    return securite, sous_charge, list(dict.fromkeys(un_seul))
+
+
+def _verifier_securite_sectionneurs(
+    poste: PosteTopologique, manoeuvres: list[Manoeuvre]
+) -> list[str]:
+    """Sectionnements de barre ouverts sous tension (cf. ``_rejeu_securite``)."""
+    return _rejeu_securite(poste, manoeuvres)[0]
 
 
 def _verifier_un_seul_hors_tension(
     poste: PosteTopologique, manoeuvres: list[Manoeuvre]
 ) -> list[str]:
-    """Règle R10ter (mode smooth) : on ne déconnecte **temporairement** pas plus
-    d'**un** ouvrage à la fois par **ré-aiguillage (boucle longue)**. Les
-    dé-énergisations **en place** (« avant ouverture sectionneur », sans tampon)
-    sont l'**exception** tolérée et ne sont pas comptées.
-
-    Rejoue la séquence : un départ est « temporairement hors tension par
-    parking » entre une ouverture de son DJ en **boucle longue** et la
-    refermeture correspondante. On signale tout moment où **deux** tels ouvrages
-    le sont simultanément (chevauchement de ré-aiguillages)."""
-    cells = poste.cellules
-    coupling_sids = {s for cp in _inter_sjb_couplers(poste) for s in cp.switch_ids}
-    dj_eq: dict[str, str] = {}
-    for c in cells.cellules_depart:
-        for b in c.breakers:
-            if b.switch_id not in coupling_sids:
-                dj_eq[b.switch_id] = c.equipment_id
-    if not dj_eq:
-        return []
-
-    temp_parking: set[str] = set()   # ouvrages hors tension via boucle longue
-    ecarts: list[str] = []
-    for m in manoeuvres:
-        eq = dj_eq.get(m.switch_id)
-        if eq is None:
-            continue
-        longue = (m.type_boucle == "LONGUE" or "boucle longue" in (m.raison or ""))
-        if m.action == "OPEN" and longue:
-            temp_parking.add(eq)
-        elif m.action == "CLOSE":
-            temp_parking.discard(eq)
-        if len(temp_parking) > 1:
-            ecarts.append(
-                "plus d'un ouvrage hors tension simultanément (ré-aiguillage) : "
-                + ", ".join(sorted(temp_parking)))
-    return list(dict.fromkeys(ecarts))
+    """Règle R10ter : pas plus d'**un** ouvrage hors tension par ré-aiguillage
+    (boucle longue) simultanément (cf. ``_rejeu_securite``)."""
+    return _rejeu_securite(poste, manoeuvres)[2]
 
 
 def _sectionneurs_sous_charge_par_manoeuvre(
@@ -2008,43 +2050,29 @@ def _sectionneurs_sous_charge_par_manoeuvre(
     Un sectionneur ne se manœuvre que hors charge : la parade est de dé-énergiser
     la branche par son **disjoncteur** avant d'ouvrir le sectionneur.
     """
-    disc: dict[str, tuple[int, int]] = {}
-    for u, v, d in poste.graph.edges(data=True):
-        sid = d.get("switch_id")
-        if sid and d.get("kind") == SwitchKind.DISCONNECTOR:
-            disc[sid] = (u, v)
-    # Sectionnements de barre (sectionneurs SA reliant deux SJB) : le message de
-    # parade diffère d'un sélecteur de barre de départ (on dé-énergise une
-    # **section de barre**, pas une branche par son disjoncteur).
-    sect_ids: set[str] = set()
-    for cp in _inter_sjb_couplers(poste):
-        if cp.is_sectionnement:
-            sect_ids.update(cp.switch_ids)
-    equip = {n for n, d in poste.graph.nodes(data=True) if d.get("equipment_id")}
-    G = poste.graph.copy()
-    out: list[Optional[str]] = []
-    for m in manoeuvres:
-        msg: Optional[str] = None
-        if (m.action == "OPEN" and m.switch_id in disc
-                and not _is_open(G, m.switch_id)):
-            u, v = disc[m.switch_id]
-            H = _live_graph_sans(G, [m.switch_id])
-            relies = u in H and v in H and nx.has_path(H, u, v)
-            if not relies:
-                cu = nx.node_connected_component(H, u) if u in H else {u}
-                cv = nx.node_connected_component(H, v) if v in H else {v}
-                if (cu & equip) and (cv & equip):
-                    if m.switch_id in sect_ids:
-                        msg = ("sectionneur de barre manœuvré sous charge — mettre "
-                               "la section de barre hors tension (ré-aiguiller ses "
-                               "départs sur l'autre section) avant d'ouvrir ce "
-                               "sectionnement")
-                    else:
-                        msg = ("sectionneur manœuvré sous charge — dé-énergiser la "
-                               "branche par son disjoncteur avant d'ouvrir ce "
-                               "sectionneur")
-        out.append(msg)
-        _set_switch(G, m.switch_id, m.action == "OPEN")
+    return _rejeu_securite(poste, manoeuvres)[1]
+
+
+def _verifier_regles(
+    poste: PosteTopologique,
+    manoeuvres: list[Manoeuvre],
+    un_seul: bool = True,
+) -> list[str]:
+    """Agrège, en **une seule passe de rejeu** (``_rejeu_securite``), les écarts
+    des règles du sectionneur dans l'ordre historique : sécurité des
+    sectionnements, [un seul ouvrage hors tension,] sectionneurs hors charge.
+
+    ``un_seul`` : inclure la règle R10ter (modes smooth / multi-barres) ; les
+    orchestrations « batch » (agressif, séquenceur à sections) l'omettent.
+    """
+    securite, sous_charge, un = _rejeu_securite(poste, manoeuvres)
+    hors_charge = list(dict.fromkeys(
+        f"{m.switch_id} : {msg}"
+        for m, msg in zip(manoeuvres, sous_charge) if msg))
+    out = list(securite)
+    if un_seul:
+        out += un
+    out += hors_charge
     return out
 
 

--- a/expert_op4grid_recommender/manoeuvre/algo.py
+++ b/expert_op4grid_recommender/manoeuvre/algo.py
@@ -1468,7 +1468,10 @@ def determiner_manoeuvres_avec_sections(
         sjb_set = {sjb_node_par_id[s] for s in sjb_ids if s in sjb_node_par_id}
         for s in sjb_set:
             node_de_sjb[s] = idx
-        for eq in departs:
+        # ``departs`` est un ensemble : on l'itère **trié** pour que l'ordre
+        # d'insertion dans ``target_sjb`` (donc l'ordre des manœuvres qui en
+        # découlent) soit reproductible d'un process à l'autre (PYTHONHASHSEED).
+        for eq in sorted(departs):
             if organes_fixes and eq in organes_fixes:
                 continue  # organe interne à 2 bornes : laissé en place
             cell = cells.get_cellule_depart(eq)
@@ -1585,7 +1588,9 @@ def determiner_manoeuvres_avec_sections(
         return a in Hc and b in Hc and nx.has_path(Hc, a, b)
 
     def _departs_cables(s: int) -> list[str]:
-        return [eq for eq in target_sjb if s in _wired_sjbs(G, cells, eq)]
+        # Tri explicite : la séquence de dé-énergisation ne doit pas dépendre de
+        # l'ordre d'itération de ``target_sjb`` (cf. construction triée ci-dessus).
+        return sorted(eq for eq in target_sjb if s in _wired_sjbs(G, cells, eq))
 
     def parking_sjb(eq: str, target: int) -> Optional[int]:
         """SJB **tampon** où garer temporairement le départ pendant l'ouverture

--- a/expert_op4grid_recommender/manoeuvre/algo.py
+++ b/expert_op4grid_recommender/manoeuvre/algo.py
@@ -1395,7 +1395,17 @@ def _inter_sjb_couplers(poste: PosteTopologique) -> list[_InterSjbCoupler]:
     """
     Recense les liaisons inter-SJB (sectionnements et couplages) d'un poste,
     en contractant les nœuds intermédiaires du sous-graphe de couplage.
+
+    **Mémoïsé sur le poste** (auparavant recalculé ~10×/analyse). Le résultat ne
+    dépend que de la **topologie** (graphe + tronçonnement), pas de l'état
+    ouvert/fermé des organes — propriété vérifiée par
+    ``tests/manoeuvre/test_couplers_memoisation.py``. Le poste n'étant jamais
+    muté structurellement, le cache reste valide toute sa durée de vie.
     """
+    cached = getattr(poste, "_inter_sjb_couplers_cache", None)
+    if cached is not None:
+        return cached
+
     G = poste.graph
     bb_nodes = set(poste.tronconnement.barre_par_busbar)
 
@@ -1437,6 +1447,8 @@ def _inter_sjb_couplers(poste: PosteTopologique) -> list[_InterSjbCoupler]:
                     couplers.append(_InterSjbCoupler(a, b, sw_ids, brk_ids))
                 # Retirer les arêtes du chemin pour révéler un couplage parallèle.
                 H.remove_edges_from(edges)
+
+    poste._inter_sjb_couplers_cache = couplers
     return couplers
 
 

--- a/expert_op4grid_recommender/manoeuvre/algo.py
+++ b/expert_op4grid_recommender/manoeuvre/algo.py
@@ -1041,6 +1041,23 @@ def _placement_automatique(
 
     k = len(nodes)
 
+    # Connexité d'un groupe de SJB dans CG : **mémoïsée**. Le même sous-ensemble
+    # réapparaît dans des milliers d'affectations ; on passe de ~k^n appels à
+    # ``nx.is_connected`` à ≤ 2^(nb SJB) calculs distincts.
+    _conn: dict[frozenset, bool] = {}
+
+    def _groupe_connexe(sjb_set: set[int]) -> bool:
+        key = frozenset(sjb_set)
+        r = _conn.get(key)
+        if r is None:
+            r = nx.is_connected(CG.subgraph(key))
+            _conn[key] = r
+        return r
+
+    # État courant (fermé ?) de chaque coupler : **invariant** de la recherche,
+    # calculé une seule fois (au lieu d'être recalculé à chaque itération).
+    cp_closed = [all(not _is_open(G, s) for s in cp.switch_ids) for cp in couplers]
+
     # Recherche exhaustive d'une affectation **complète** (tous les nœuds placés),
     # uniquement si elle est possible (k ≤ nb SJB) et tient dans le garde-fou.
     best = None  # (cost, assign tuple)
@@ -1052,7 +1069,7 @@ def _placement_automatique(
             if any(not s for s in node_sjbs.values()):
                 continue  # chaque nœud doit avoir ≥ 1 SJB
             # Groupes connexes dans le graphe des couplers
-            if not all(nx.is_connected(CG.subgraph(s)) for s in node_sjbs.values()):
+            if not all(_groupe_connexe(s) for s in node_sjbs.values()):
                 continue
             # Faisabilité : chaque départ atteint une SJB de son nœud
             ok = True
@@ -1072,9 +1089,8 @@ def _placement_automatique(
             node_of_sjb = {sjb_nodes[j]: assign[j] for j in range(len(sjb_nodes))}
             cpl = 0
             sect = 0
-            for cp in couplers:
+            for cp, currently_closed in zip(couplers, cp_closed):
                 same = node_of_sjb[cp.sjb_a] == node_of_sjb[cp.sjb_b]
-                currently_closed = all(not _is_open(G, s) for s in cp.switch_ids)
                 if same and not currently_closed:
                     cpl += 1
                 elif (not same) and currently_closed:
@@ -1242,6 +1258,17 @@ def _placement_best_effort(
     if (k + 1) ** n_sjb > 2_000_000:
         return _placement_greedy(nodes, R, sjb_nodes, sjb_id)
 
+    # Connexité d'un groupe de SJB : **mémoïsée** (cf. ``_placement_automatique``).
+    _conn: dict[frozenset, bool] = {}
+
+    def _groupe_connexe(sjb_set: set[int]) -> bool:
+        key = frozenset(sjb_set)
+        r = _conn.get(key)
+        if r is None:
+            r = nx.is_connected(CG.subgraph(key))
+            _conn[key] = r
+        return r
+
     best = None  # (score, placement, non_places)
     for assign in itertools.product(range(k + 1), repeat=n_sjb):
         node_sjbs: dict[int, set[int]] = {i: set() for i in range(k)}
@@ -1254,7 +1281,7 @@ def _placement_best_effort(
             s = node_sjbs[i]
             if not s:
                 continue  # nœud abandonné (laissé à l'opérateur)
-            if not nx.is_connected(CG.subgraph(s)):
+            if not _groupe_connexe(s):
                 valide = False
                 break
             if any(not (R.get(eq, frozenset()) & s) for eq in nodes[i]):

--- a/expert_op4grid_recommender/manoeuvre/algo.py
+++ b/expert_op4grid_recommender/manoeuvre/algo.py
@@ -83,7 +83,6 @@ from .topologie import (
     TopologieNodale,
     PosteTopologique,
 )
-from .troncons import Troncon
 
 logger = logging.getLogger(__name__)
 
@@ -1668,7 +1667,6 @@ def determiner_manoeuvres_avec_sections(
     # --- groupes SJB finaux (couplers gardés fermés) -----------------------
     sjb_graph = nx.Graph()
     sjb_graph.add_nodes_from(poste.tronconnement.barre_par_busbar)
-    open_ids = {sid for cp in to_open for sid in cp.switch_ids}
     for cp in couplers:
         if cp not in to_open:
             sjb_graph.add_edge(cp.sjb_a, cp.sjb_b)
@@ -1782,12 +1780,14 @@ def determiner_manoeuvres_avec_sections(
         for cp in list(restants):
             if cp.breaker_ids:                       # DJ -> couplage sûr
                 _fermer_coupler(cp, "fermeture couplage de barres")
-                restants.remove(cp); changed = True
+                restants.remove(cp)
+                changed = True
             elif (_equipotentiel(cp.sjb_a, cp.sjb_b)
                   or not _departs_cables(cp.sjb_a)
                   or not _departs_cables(cp.sjb_b)):  # sectionneur sûr
                 _fermer_coupler(cp, "fermeture sectionnement (barres équipotentielles)")
-                restants.remove(cp); changed = True
+                restants.remove(cp)
+                changed = True
 
     # Sectionneurs encore non sûrs : dé-énergiser le côté « stub » (moins de
     # départs) en ré-aiguillant ses départs vers une SJB du même nœud déjà

--- a/expert_op4grid_recommender/manoeuvre/algo.py
+++ b/expert_op4grid_recommender/manoeuvre/algo.py
@@ -238,12 +238,10 @@ def _wired_busbar(cell: CelluleDepart, graph: nx.Graph) -> Optional[int]:
 
 
 def _edges_of_switches(graph: nx.Graph, switch_ids):
-    out = []
-    sset = set(switch_ids)
-    for u, v, d in graph.edges(data=True):
-        if d.get("switch_id") in sset:
-            out.append((u, v))
-    return out
+    """Arêtes (u, v) des switches donnés, via l'index O(1) (un id inconnu est
+    simplement omis — même sémantique que l'ancien scan linéaire)."""
+    idx = _switch_edge_index(graph)
+    return [idx[sid] for sid in switch_ids if sid in idx]
 
 
 def _departure_dj_changes(
@@ -1397,30 +1395,34 @@ def _placement_greedy(
 def _switch_edge_index(G: nx.Graph) -> dict[str, tuple[int, int]]:
     """Index ``switch_id -> (u, v)`` mémoïsé sur le graphe (``G.graph``).
 
-    Construit en une passe au premier accès, puis réutilisé en O(1) — il
+    Construit en une passe au premier accès, puis réutilisé en **O(1)** — il
     remplace les anciens scans linéaires de ``_is_open`` / ``_set_switch``.
 
     Validité : la coordonnée ``(u, v)`` d'un switch est **topologique**, donc
     stable tant que la structure du graphe ne change pas. Le séquenceur ne fait
     que basculer l'attribut ``open`` (jamais ajouter/retirer d'arête), et
     ``G.copy()`` préserve nœuds et arêtes : l'index reste valide sur les graphes
-    dérivés (copies de travail, ``cible_graph`` du même réseau). Le nombre
-    d'arêtes sert de garde-fou : toute modification structurelle force une
-    reconstruction.
+    dérivés (copies de travail, ``cible_graph`` du même réseau).
+
+    Garde-fou **O(1)** : le nombre de *nœuds* (``len(G)``, immédiat) sert de
+    canari. ``number_of_edges()`` serait O(arêtes) (somme des degrés) et, appelé
+    à chaque lookup, annulerait le bénéfice de l'index. Dans ce module la
+    structure (nœuds **et** arêtes) est figée après construction ; une variation
+    du nombre de nœuds (sous-graphe, vue) force la reconstruction.
     """
     cache = G.graph.get("_switch_edge_index")
-    if cache is None or cache[0] != G.number_of_edges():
+    if cache is None or cache[0] != G.number_of_nodes():
         mapping = {d["switch_id"]: (u, v)
                    for u, v, d in G.edges(data=True)
                    if d.get("switch_id") is not None}
-        cache = (G.number_of_edges(), mapping)
+        cache = (G.number_of_nodes(), mapping)
         G.graph["_switch_edge_index"] = cache
     return cache[1]
 
 
 def _equipment_node_index(G: nx.Graph) -> dict[str, int]:
     """Index ``equipment_id -> node`` mémoïsé sur le graphe (cf.
-    ``_switch_edge_index`` ; garde-fou sur le nombre de nœuds)."""
+    ``_switch_edge_index`` ; garde-fou O(1) sur le nombre de nœuds)."""
     cache = G.graph.get("_equipment_node_index")
     if cache is None or cache[0] != G.number_of_nodes():
         mapping = {d["equipment_id"]: n

--- a/expert_op4grid_recommender/manoeuvre/cellules.py
+++ b/expert_op4grid_recommender/manoeuvre/cellules.py
@@ -124,6 +124,11 @@ class CelluleDepart:
     connected_busbars: set[int] = field(default_factory=set)
     shared_equipment_ids: set[str] = field(default_factory=set)
     subgraph: Optional[nx.Graph] = field(default=None, repr=False)
+    # Cache des chemins SA (équipement -> SJB) : structurel donc **indépendant de
+    # l'état ouvert/fermé** des organes (le sous-graphe de la cellule est figé).
+    # Voir ``disconnectors_vers_barre`` (appelé des dizaines de milliers de fois).
+    _path_cache: dict = field(default_factory=dict, init=False, repr=False,
+                              compare=False)
 
     # ------------------------------------------------------------------
     # Propriétés utilitaires
@@ -195,11 +200,20 @@ class CelluleDepart:
         Utilisé dans le ré-aiguillage (step 2.4.4) pour identifier les OC
         à manœuvrer afin de changer de barre.
 
+        **Mémoïsé** par ``bbs_node`` : le chemin est structurel (sous-graphe de
+        cellule figé), donc invariant ; la méthode est appelée en très grand
+        nombre (``_sa_path_to_sjb``) lors du placement et du séquencement.
+
         Parameters
         ----------
         bbs_node :
             Nœud de connectivité de la SJB cible.
         """
+        if bbs_node not in self._path_cache:
+            self._path_cache[bbs_node] = self._compute_disconnectors_vers_barre(bbs_node)
+        return self._path_cache[bbs_node]
+
+    def _compute_disconnectors_vers_barre(self, bbs_node: int) -> list[SwitchInfo]:
         if self.subgraph is None or bbs_node not in self.subgraph:
             return []
 

--- a/expert_op4grid_recommender/manoeuvre/cellules.py
+++ b/expert_op4grid_recommender/manoeuvre/cellules.py
@@ -49,8 +49,8 @@ from typing import Optional
 
 import networkx as nx
 
-from .models import NodeType, EquipmentType, SwitchKind, EdgeAttrs, NodeAttrs
-from .graph import get_node_attrs, get_edge_attrs, busbar_nodes, equipment_nodes
+from .models import EquipmentType, SwitchKind
+from .graph import get_node_attrs, busbar_nodes, equipment_nodes
 
 logger = logging.getLogger(__name__)
 

--- a/expert_op4grid_recommender/manoeuvre/models.py
+++ b/expert_op4grid_recommender/manoeuvre/models.py
@@ -10,7 +10,7 @@ et les phases algorithmiques ultérieures.
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from enum import Enum
 from typing import Optional
 

--- a/expert_op4grid_recommender/manoeuvre/topologie.py
+++ b/expert_op4grid_recommender/manoeuvre/topologie.py
@@ -16,8 +16,8 @@ from typing import Optional
 
 import networkx as nx
 
-from .models import NodeType, EquipmentType, SwitchKind
-from .graph import busbar_nodes, equipment_nodes, get_node_attrs
+from .models import EquipmentType
+from .graph import equipment_nodes, get_node_attrs
 from .cellules import CellulesVL, detecter_cellules
 from .troncons import Tronconnement, construire_tronconnement
 

--- a/expert_op4grid_recommender/manoeuvre/troncons.py
+++ b/expert_op4grid_recommender/manoeuvre/troncons.py
@@ -47,7 +47,7 @@ from typing import Optional
 
 import networkx as nx
 
-from .models import NodeType, SwitchKind
+from .models import SwitchKind
 from .graph import busbar_nodes
 from .cellules import CellulesVL, SwitchInfo
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,3 +58,24 @@ exclude = ["tests*", "venv*", "alphaDeesp*"]
 Homepage = "https://github.com/marota/Expert_op4grid_recommender"
 Repository = "https://github.com/marota/Expert_op4grid_recommender"
 Issues = "https://github.com/marota/Expert_op4grid_recommender/issues"
+
+# ---------------------------------------------------------------------------
+# Outils qualité (extra "quality"). Câblés en CI sur le module manoeuvre
+# (cf. .circleci/config.yml). Le reste du dépôt n'est pas encore couvert :
+# dette technique a resorber progressivement.
+# ---------------------------------------------------------------------------
+
+[tool.ruff]
+target-version = "py310"
+line-length = 100
+# Jeu de règles ruff par défaut (E4/E7/E9 + pyflakes F) : haute valeur, faible
+# bruit (imports/variables inutilisés, noms indéfinis, statements douteux...).
+
+[tool.interrogate]
+# Couverture des docstrings. Les fonctions imbriquées (closures), __init__ et
+# méthodes magiques ne sont pas exigées ; les fonctions privées de premier
+# niveau, si.
+fail-under = 80
+ignore-init-method = true
+ignore-magic = true
+ignore-nested-functions = true

--- a/scripts/manoeuvre_ihm.py
+++ b/scripts/manoeuvre_ihm.py
@@ -49,6 +49,7 @@ from __future__ import annotations
 import argparse
 import json
 import pathlib
+import re
 import sys
 
 # Rendre le package importable quand lancé depuis la racine du dépôt
@@ -164,7 +165,6 @@ def _normalize_groups(all_branches, groups) -> list[list[str]]:
 def _decode_svg_id(s: str) -> str:
     """Décode un identifiant SVG pypowsybl (``_46_`` → ``.``, ``_95_`` → ``_``,
     ``_45_`` → ``-``…). Fonction pure."""
-    import re
     return re.sub(r"_(\d+)_", lambda m: chr(int(m.group(1))), s)
 
 
@@ -180,7 +180,6 @@ def _parse_feeder_meta(svg: str) -> dict:
       (bas) ; ``_NW_LABEL`` (barres) est exclu.
 
     Fonction pure (testable sans pypowsybl)."""
-    import re
     groups = re.findall(
         r'<g class="[^"]*sld-(top|bottom)-feeder[^"]*" id="(id[^"]+?)"'
         r'[^>]*transform="translate\(([0-9.]+),[0-9.]+\)"', svg)
@@ -200,7 +199,6 @@ def _parse_node_colors(svg: str) -> dict:
     élément (clé = id décodé sans le préfixe ``id``), via la palette
     ``.sld-vlXtoY.sld-bus-N {--sld-vl-color: #hex}`` et les classes
     ``sld-vl… sld-bus-N`` portées par les éléments. Fonction pure."""
-    import re
     palette = {}
     for vlc, busc, hexc in re.findall(
             r"\.(sld-vl\w+)\.(sld-bus-\d+)\s*\{\s*--sld-vl-color:\s*"
@@ -667,7 +665,6 @@ class Session:
         }
 
     def save_scenario(self, name: str) -> str:
-        import re
         name = re.sub(r"[^A-Za-z0-9._-]+", "_", (name or "").strip()) or self.vl
         data = {
             "voltage_level_id": self.vl,
@@ -765,7 +762,6 @@ class Session:
         éditée est sérialisée telle quelle ; on recalcule seulement l'état nodal
         final atteint et la concordance avec la cible.
         """
-        import re
         if not self.seq_states:   # aucune séquence calculée : on en calcule une
             self.sequence()
         info = self._seq_payload()
@@ -811,7 +807,6 @@ def _prefix_svg_ids(svg: str, pfx: str) -> str:
     Appliqué au schéma « départ » (non interactif) ; le schéma « cible » garde
     ses ids d'origine (cohérents avec le mapping switch → svgId).
     """
-    import re
     svg = re.sub(r'id="([^"]+)"', lambda m: f'id="{pfx}{m.group(1)}"', svg)
     svg = re.sub(r'url\(#([^)]+)\)', lambda m: f'url(#{pfx}{m.group(1)})', svg)
     svg = re.sub(r'(xlink:href|href)="#([^"]+)"',
@@ -894,7 +889,6 @@ def api_scenarios():
 
 
 def _safe_name(name, default):
-    import re
     return re.sub(r"[^A-Za-z0-9._-]+", "_", (name or "").strip()) or default
 
 

--- a/tests/manoeuvre/fixture_loader.py
+++ b/tests/manoeuvre/fixture_loader.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 import json
 import logging
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any
 
 import networkx as nx
 

--- a/tests/manoeuvre/goldens/BXTO5P3_cible_2noeuds_miseServiceSectionnement__aggressive.golden.json
+++ b/tests/manoeuvre/goldens/BXTO5P3_cible_2noeuds_miseServiceSectionnement__aggressive.golden.json
@@ -1,0 +1,96 @@
+{
+  "ecarts": [],
+  "is_verified": true,
+  "is_verified_detaillee": true,
+  "manoeuvres": [
+    [
+      "BXTO5P3_BXTO53SINCE.2 DJ_OC",
+      "OPEN",
+      null
+    ],
+    [
+      "BXTO5P3_BXTO53COUPL.1 DJ_OC",
+      "OPEN",
+      null
+    ],
+    [
+      "BXTO5P3_BXTO53SEC..23 SS.2.23_OC",
+      "CLOSE",
+      null
+    ],
+    [
+      "BXTO5P3_BXTO53SINCE.2 SA.2_OC",
+      "CLOSE",
+      null
+    ],
+    [
+      "BXTO5P3_BXTO53SINCE.2 SA.1_OC",
+      "OPEN",
+      null
+    ],
+    [
+      "BXTO5P3_BXTO53HAM.1 SA.2_OC",
+      "CLOSE",
+      null
+    ],
+    [
+      "BXTO5P3_BXTO53TR317 SA.2_OC",
+      "CLOSE",
+      null
+    ],
+    [
+      "BXTO5P3_BXTO53TR317 SA.1_OC",
+      "OPEN",
+      null
+    ],
+    [
+      "BXTO5P3_BXTO53SINCE.2 DJ_OC",
+      "CLOSE",
+      null
+    ],
+    [
+      "BXTO5P3_BXTO53TR317 DJ.HT_OC",
+      "CLOSE",
+      null
+    ]
+  ],
+  "mode": "aggressive",
+  "n_manoeuvres": 10,
+  "noeuds_non_realisables": [],
+  "partition_obtenue": [
+    [
+      "BXTO53Y316",
+      "BXTO5IN1",
+      "BXTO5L31SINCE"
+    ],
+    [
+      "BXTO53Y317",
+      "BXTO5IN2",
+      "BXTO5ING",
+      "BXTO5L31LAON",
+      "BXTO5L31MANO5",
+      "BXTO5L31SOISS",
+      "BXTO5L31ZMAR7",
+      "BXTO5L32HAM",
+      "BXTO5L32SINCE",
+      "BXTO5Y631",
+      "BXTO5Y635"
+    ],
+    [
+      "BXTO5INF"
+    ],
+    [
+      "BXTO5L31HAM"
+    ],
+    [
+      "BXTO5L31TERGN"
+    ],
+    [
+      "BXTO5L32TERGN"
+    ],
+    [
+      "BXTO5Y638"
+    ]
+  ],
+  "voltage_level_id": "BXTO5P3"
+}

--- a/tests/manoeuvre/goldens/BXTO5P3_cible_2noeuds_miseServiceSectionnement__smooth.golden.json
+++ b/tests/manoeuvre/goldens/BXTO5P3_cible_2noeuds_miseServiceSectionnement__smooth.golden.json
@@ -1,0 +1,86 @@
+{
+  "ecarts": [],
+  "is_verified": true,
+  "is_verified_detaillee": true,
+  "manoeuvres": [
+    [
+      "BXTO5P3_BXTO53SEC..23 SS.2.23_OC",
+      "CLOSE",
+      null
+    ],
+    [
+      "BXTO5P3_BXTO53TR317 SA.2_OC",
+      "CLOSE",
+      "COURTE"
+    ],
+    [
+      "BXTO5P3_BXTO53TR317 SA.1_OC",
+      "OPEN",
+      "COURTE"
+    ],
+    [
+      "BXTO5P3_BXTO53SINCE.2 SA.2_OC",
+      "CLOSE",
+      "COURTE"
+    ],
+    [
+      "BXTO5P3_BXTO53SINCE.2 SA.1_OC",
+      "OPEN",
+      "COURTE"
+    ],
+    [
+      "BXTO5P3_BXTO53COUPL.1 DJ_OC",
+      "OPEN",
+      null
+    ],
+    [
+      "BXTO5P3_BXTO53HAM.1 SA.2_OC",
+      "CLOSE",
+      "COURTE"
+    ],
+    [
+      "BXTO5P3_BXTO53TR317 DJ.HT_OC",
+      "CLOSE",
+      null
+    ]
+  ],
+  "mode": "smooth",
+  "n_manoeuvres": 8,
+  "noeuds_non_realisables": [],
+  "partition_obtenue": [
+    [
+      "BXTO53Y316",
+      "BXTO5IN1",
+      "BXTO5L31SINCE"
+    ],
+    [
+      "BXTO53Y317",
+      "BXTO5IN2",
+      "BXTO5ING",
+      "BXTO5L31LAON",
+      "BXTO5L31MANO5",
+      "BXTO5L31SOISS",
+      "BXTO5L31ZMAR7",
+      "BXTO5L32HAM",
+      "BXTO5L32SINCE",
+      "BXTO5Y631",
+      "BXTO5Y635"
+    ],
+    [
+      "BXTO5INF"
+    ],
+    [
+      "BXTO5L31HAM"
+    ],
+    [
+      "BXTO5L31TERGN"
+    ],
+    [
+      "BXTO5L32TERGN"
+    ],
+    [
+      "BXTO5Y638"
+    ]
+  ],
+  "voltage_level_id": "BXTO5P3"
+}

--- a/tests/manoeuvre/goldens/CARRIP3_cible_1noeud__aggressive.golden.json
+++ b/tests/manoeuvre/goldens/CARRIP3_cible_1noeud__aggressive.golden.json
@@ -1,0 +1,46 @@
+{
+  "ecarts": [],
+  "is_verified": true,
+  "is_verified_detaillee": true,
+  "manoeuvres": [
+    [
+      "CARRIP3_CARRI3COUPL.1 DJ_OC",
+      "CLOSE",
+      null
+    ],
+    [
+      "CARRIP3_CARRI3SEC..12 SS.1.12_OC",
+      "CLOSE",
+      null
+    ]
+  ],
+  "mode": "aggressive",
+  "n_manoeuvres": 2,
+  "noeuds_non_realisables": [],
+  "partition_obtenue": [
+    [
+      "BARR6L31CARRI",
+      "BERT L31CARRI",
+      "BRENOL31CARRI",
+      "CARRI3T312",
+      "CARRI3T313",
+      "CARRI3T314",
+      "CARRIL31PERSA",
+      "CARRIL31RANTI",
+      "CARRIL31U.MON",
+      "CARRIL31V.PAU",
+      "CARRIL31VALES",
+      "CARRIL32U.MON",
+      "CARRIY631",
+      "CARRIY632",
+      "CARRIY633"
+    ],
+    [
+      "CARRIINF"
+    ],
+    [
+      "CARRIING"
+    ]
+  ],
+  "voltage_level_id": "CARRIP3"
+}

--- a/tests/manoeuvre/goldens/CARRIP3_cible_1noeud__smooth.golden.json
+++ b/tests/manoeuvre/goldens/CARRIP3_cible_1noeud__smooth.golden.json
@@ -1,0 +1,136 @@
+{
+  "ecarts": [],
+  "is_verified": true,
+  "is_verified_detaillee": true,
+  "manoeuvres": [
+    [
+      "CARRIP3_CARRI3COUPL.1 DJ_OC",
+      "CLOSE",
+      null
+    ],
+    [
+      "CARRIP3_CARRI3TR312 DJ.HT_OC",
+      "OPEN",
+      "LONGUE"
+    ],
+    [
+      "CARRIP3_CARRI3TR312 SA.1_OC",
+      "OPEN",
+      "LONGUE"
+    ],
+    [
+      "CARRIP3_CARRI3TR312 SA.2_OC",
+      "CLOSE",
+      "LONGUE"
+    ],
+    [
+      "CARRIP3_CARRI3TR312 DJ.HT_OC",
+      "CLOSE",
+      "LONGUE"
+    ],
+    [
+      "CARRIP3_CARRI3PERSA.1 DJ_OC",
+      "OPEN",
+      "LONGUE"
+    ],
+    [
+      "CARRIP3_CARRI3PERSA.1 SA.1_OC",
+      "OPEN",
+      "LONGUE"
+    ],
+    [
+      "CARRIP3_CARRI3PERSA.1 SA.2_OC",
+      "CLOSE",
+      "LONGUE"
+    ],
+    [
+      "CARRIP3_CARRI3PERSA.1 DJ_OC",
+      "CLOSE",
+      "LONGUE"
+    ],
+    [
+      "CARRIP3_CARRI3V.PAU.1 DJ_OC",
+      "OPEN",
+      "LONGUE"
+    ],
+    [
+      "CARRIP3_CARRI3V.PAU.1 SA.1_OC",
+      "OPEN",
+      "LONGUE"
+    ],
+    [
+      "CARRIP3_CARRI3V.PAU.1 SA.2_OC",
+      "CLOSE",
+      "LONGUE"
+    ],
+    [
+      "CARRIP3_CARRI3V.PAU.1 DJ_OC",
+      "CLOSE",
+      "LONGUE"
+    ],
+    [
+      "CARRIP3_CARRI3SEC..12 SS.1.12_OC",
+      "CLOSE",
+      null
+    ],
+    [
+      "CARRIP3_CARRI3TR312 SA.1_OC",
+      "CLOSE",
+      "COURTE"
+    ],
+    [
+      "CARRIP3_CARRI3TR312 SA.2_OC",
+      "OPEN",
+      "COURTE"
+    ],
+    [
+      "CARRIP3_CARRI3PERSA.1 SA.1_OC",
+      "CLOSE",
+      "COURTE"
+    ],
+    [
+      "CARRIP3_CARRI3PERSA.1 SA.2_OC",
+      "OPEN",
+      "COURTE"
+    ],
+    [
+      "CARRIP3_CARRI3V.PAU.1 SA.1_OC",
+      "CLOSE",
+      "COURTE"
+    ],
+    [
+      "CARRIP3_CARRI3V.PAU.1 SA.2_OC",
+      "OPEN",
+      "COURTE"
+    ]
+  ],
+  "mode": "smooth",
+  "n_manoeuvres": 20,
+  "noeuds_non_realisables": [],
+  "partition_obtenue": [
+    [
+      "BARR6L31CARRI",
+      "BERT L31CARRI",
+      "BRENOL31CARRI",
+      "CARRI3T312",
+      "CARRI3T313",
+      "CARRI3T314",
+      "CARRIL31PERSA",
+      "CARRIL31RANTI",
+      "CARRIL31U.MON",
+      "CARRIL31V.PAU",
+      "CARRIL31VALES",
+      "CARRIL32U.MON",
+      "CARRIY631",
+      "CARRIY632",
+      "CARRIY633"
+    ],
+    [
+      "CARRIINF"
+    ],
+    [
+      "CARRIING"
+    ]
+  ],
+  "voltage_level_id": "CARRIP3"
+}

--- a/tests/manoeuvre/goldens/CARRIP3_cible_3noeuds__aggressive.golden.json
+++ b/tests/manoeuvre/goldens/CARRIP3_cible_3noeuds__aggressive.golden.json
@@ -1,0 +1,82 @@
+{
+  "ecarts": [
+    "CARRIP3_CARRI3TR312 SA.2_OC : sectionneur manœuvré sous charge — dé-énergiser la branche par son disjoncteur avant d'ouvrir ce sectionneur"
+  ],
+  "is_verified": true,
+  "is_verified_detaillee": false,
+  "manoeuvres": [
+    [
+      "CARRIP3_CARRI3V.PAU.1 DJ_OC",
+      "OPEN",
+      null
+    ],
+    [
+      "CARRIP3_CARRI3PERSA.1 DJ_OC",
+      "OPEN",
+      null
+    ],
+    [
+      "CARRIP3_CARRI3COUPL.1 DJ_OC",
+      "OPEN",
+      null
+    ],
+    [
+      "CARRIP3_CARRI3SEC..12 SS.1.12_OC",
+      "OPEN",
+      null
+    ],
+    [
+      "CARRIP3_CARRI3TR312 SA.1_OC",
+      "CLOSE",
+      null
+    ],
+    [
+      "CARRIP3_CARRI3TR312 SA.2_OC",
+      "OPEN",
+      null
+    ],
+    [
+      "CARRIP3_CARRI3V.PAU.1 DJ_OC",
+      "CLOSE",
+      null
+    ],
+    [
+      "CARRIP3_CARRI3PERSA.1 DJ_OC",
+      "CLOSE",
+      null
+    ]
+  ],
+  "mode": "aggressive",
+  "n_manoeuvres": 8,
+  "noeuds_non_realisables": [],
+  "partition_obtenue": [
+    [
+      "BARR6L31CARRI",
+      "CARRI3T314",
+      "CARRIL31U.MON",
+      "CARRIL31VALES",
+      "CARRIY631"
+    ],
+    [
+      "BERT L31CARRI",
+      "BRENOL31CARRI",
+      "CARRI3T313",
+      "CARRIL31RANTI",
+      "CARRIL32U.MON",
+      "CARRIY632",
+      "CARRIY633"
+    ],
+    [
+      "CARRI3T312",
+      "CARRIL31PERSA",
+      "CARRIL31V.PAU"
+    ],
+    [
+      "CARRIINF"
+    ],
+    [
+      "CARRIING"
+    ]
+  ],
+  "voltage_level_id": "CARRIP3"
+}

--- a/tests/manoeuvre/goldens/CARRIP3_cible_3noeuds__smooth.golden.json
+++ b/tests/manoeuvre/goldens/CARRIP3_cible_3noeuds__smooth.golden.json
@@ -1,0 +1,130 @@
+{
+  "ecarts": [],
+  "is_verified": true,
+  "is_verified_detaillee": true,
+  "manoeuvres": [
+    [
+      "CARRIP3_CARRI3PERSA.1 SA.2_OC",
+      "CLOSE",
+      "COURTE"
+    ],
+    [
+      "CARRIP3_CARRI3PERSA.1 SA.1_OC",
+      "OPEN",
+      "COURTE"
+    ],
+    [
+      "CARRIP3_CARRI3V.PAU.1 SA.2_OC",
+      "CLOSE",
+      "COURTE"
+    ],
+    [
+      "CARRIP3_CARRI3V.PAU.1 SA.1_OC",
+      "OPEN",
+      "COURTE"
+    ],
+    [
+      "CARRIP3_CARRI3SEC..12 SS.1.12_OC",
+      "OPEN",
+      null
+    ],
+    [
+      "CARRIP3_CARRI3COUPL.1 DJ_OC",
+      "OPEN",
+      null
+    ],
+    [
+      "CARRIP3_CARRI3TR312 DJ.HT_OC",
+      "OPEN",
+      "LONGUE"
+    ],
+    [
+      "CARRIP3_CARRI3TR312 SA.2_OC",
+      "OPEN",
+      "LONGUE"
+    ],
+    [
+      "CARRIP3_CARRI3TR312 SA.1_OC",
+      "CLOSE",
+      "LONGUE"
+    ],
+    [
+      "CARRIP3_CARRI3TR312 DJ.HT_OC",
+      "CLOSE",
+      "LONGUE"
+    ],
+    [
+      "CARRIP3_CARRI3PERSA.1 DJ_OC",
+      "OPEN",
+      "LONGUE"
+    ],
+    [
+      "CARRIP3_CARRI3PERSA.1 SA.2_OC",
+      "OPEN",
+      "LONGUE"
+    ],
+    [
+      "CARRIP3_CARRI3PERSA.1 SA.1_OC",
+      "CLOSE",
+      "LONGUE"
+    ],
+    [
+      "CARRIP3_CARRI3PERSA.1 DJ_OC",
+      "CLOSE",
+      "LONGUE"
+    ],
+    [
+      "CARRIP3_CARRI3V.PAU.1 DJ_OC",
+      "OPEN",
+      "LONGUE"
+    ],
+    [
+      "CARRIP3_CARRI3V.PAU.1 SA.2_OC",
+      "OPEN",
+      "LONGUE"
+    ],
+    [
+      "CARRIP3_CARRI3V.PAU.1 SA.1_OC",
+      "CLOSE",
+      "LONGUE"
+    ],
+    [
+      "CARRIP3_CARRI3V.PAU.1 DJ_OC",
+      "CLOSE",
+      "LONGUE"
+    ]
+  ],
+  "mode": "smooth",
+  "n_manoeuvres": 18,
+  "noeuds_non_realisables": [],
+  "partition_obtenue": [
+    [
+      "BARR6L31CARRI",
+      "CARRI3T314",
+      "CARRIL31U.MON",
+      "CARRIL31VALES",
+      "CARRIY631"
+    ],
+    [
+      "BERT L31CARRI",
+      "BRENOL31CARRI",
+      "CARRI3T313",
+      "CARRIL31RANTI",
+      "CARRIL32U.MON",
+      "CARRIY632",
+      "CARRIY633"
+    ],
+    [
+      "CARRI3T312",
+      "CARRIL31PERSA",
+      "CARRIL31V.PAU"
+    ],
+    [
+      "CARRIINF"
+    ],
+    [
+      "CARRIING"
+    ]
+  ],
+  "voltage_level_id": "CARRIP3"
+}

--- a/tests/manoeuvre/goldens/CARRIP6_cible_4noeuds__aggressive.golden.json
+++ b/tests/manoeuvre/goldens/CARRIP6_cible_4noeuds__aggressive.golden.json
@@ -1,0 +1,120 @@
+{
+  "ecarts": [],
+  "is_verified": true,
+  "is_verified_detaillee": true,
+  "manoeuvres": [
+    [
+      "CARRIP6_CARRI6MORU.1 DJ_OC",
+      "OPEN",
+      null
+    ],
+    [
+      "CARRIP6_CARRI6TR611 DJ.HT_OC",
+      "OPEN",
+      null
+    ],
+    [
+      "CARRIP6_CARRI6VALES.1 DJ_OC",
+      "OPEN",
+      null
+    ],
+    [
+      "CARRIP6_CARRI6TR631 DJ_OC",
+      "OPEN",
+      null
+    ],
+    [
+      "CARRIP6_CARRI6TR632 DJ_OC",
+      "OPEN",
+      null
+    ],
+    [
+      "CARRIP6_CARRI6COUPL.3 DJ_OC",
+      "OPEN",
+      null
+    ],
+    [
+      "CARRIP6_CARRI6SEC..12 SS.1.12_OC",
+      "OPEN",
+      null
+    ],
+    [
+      "CARRIP6_CARRI6SEC..23 SS.2.23_OC",
+      "OPEN",
+      null
+    ],
+    [
+      "CARRIP6_CARRI6MORU.1 SA.1_OC",
+      "CLOSE",
+      null
+    ],
+    [
+      "CARRIP6_CARRI6MORU.1 SA.2_OC",
+      "OPEN",
+      null
+    ],
+    [
+      "CARRIP6_CARRI6TR611 SA.2_OC",
+      "OPEN",
+      null
+    ],
+    [
+      "CARRIP6_CARRI6TR611 SA.1_OC",
+      "CLOSE",
+      null
+    ],
+    [
+      "CARRIP6_CARRI6VALES.1 DJ_OC",
+      "CLOSE",
+      null
+    ],
+    [
+      "CARRIP6_CARRI6TR631 DJ_OC",
+      "CLOSE",
+      null
+    ],
+    [
+      "CARRIP6_CARRI6TR632 DJ_OC",
+      "CLOSE",
+      null
+    ],
+    [
+      "CARRIP6_CARRI6MORU.1 DJ_OC",
+      "CLOSE",
+      null
+    ],
+    [
+      "CARRIP6_CARRI6TR611 DJ.HT_OC",
+      "CLOSE",
+      null
+    ]
+  ],
+  "mode": "aggressive",
+  "n_manoeuvres": 17,
+  "noeuds_non_realisables": [],
+  "partition_obtenue": [
+    [
+      "CARRI6CREI5.1",
+      "CARRI6T611",
+      "CARRIL61TERRI",
+      "CARRIL61ZB.FR"
+    ],
+    [
+      "CARRI6CREI5.2",
+      "CARRIL61GOUVI",
+      "CARRIY633"
+    ],
+    [
+      "CARRIL61MORU",
+      "CARRIL61VALES",
+      "CARRIY631"
+    ],
+    [
+      "CARRIL62TERRI"
+    ],
+    [
+      "CARRIY632"
+    ]
+  ],
+  "voltage_level_id": "CARRIP6"
+}

--- a/tests/manoeuvre/goldens/CARRIP6_cible_4noeuds__smooth.golden.json
+++ b/tests/manoeuvre/goldens/CARRIP6_cible_4noeuds__smooth.golden.json
@@ -1,0 +1,200 @@
+{
+  "ecarts": [],
+  "is_verified": true,
+  "is_verified_detaillee": true,
+  "manoeuvres": [
+    [
+      "CARRIP6_CARRI6TR611 SA.1_OC",
+      "CLOSE",
+      "COURTE"
+    ],
+    [
+      "CARRIP6_CARRI6TR611 SA.2_OC",
+      "OPEN",
+      "COURTE"
+    ],
+    [
+      "CARRIP6_CARRI6VALES.1 SA.2_OC",
+      "CLOSE",
+      "COURTE"
+    ],
+    [
+      "CARRIP6_CARRI6VALES.1 SA.1_OC",
+      "OPEN",
+      "COURTE"
+    ],
+    [
+      "CARRIP6_CARRI6TR631 SA.2_OC",
+      "CLOSE",
+      "COURTE"
+    ],
+    [
+      "CARRIP6_CARRI6TR631 SA.1_OC",
+      "OPEN",
+      "COURTE"
+    ],
+    [
+      "CARRIP6_CARRI6TR632 SA.1_OC",
+      "CLOSE",
+      "COURTE"
+    ],
+    [
+      "CARRIP6_CARRI6TR632 SA.2_OC",
+      "OPEN",
+      "COURTE"
+    ],
+    [
+      "CARRIP6_CARRI6SEC..12 SS.1.12_OC",
+      "OPEN",
+      null
+    ],
+    [
+      "CARRIP6_CARRI6VALES.1 DJ_OC",
+      "OPEN",
+      null
+    ],
+    [
+      "CARRIP6_CARRI6TR631 DJ_OC",
+      "OPEN",
+      null
+    ],
+    [
+      "CARRIP6_CARRI6MORU.1 DJ_OC",
+      "OPEN",
+      null
+    ],
+    [
+      "CARRIP6_CARRI6SEC..23 SS.2.23_OC",
+      "OPEN",
+      null
+    ],
+    [
+      "CARRIP6_CARRI6VALES.1 DJ_OC",
+      "CLOSE",
+      null
+    ],
+    [
+      "CARRIP6_CARRI6TR631 DJ_OC",
+      "CLOSE",
+      null
+    ],
+    [
+      "CARRIP6_CARRI6MORU.1 DJ_OC",
+      "CLOSE",
+      null
+    ],
+    [
+      "CARRIP6_CARRI6COUPL.3 DJ_OC",
+      "OPEN",
+      null
+    ],
+    [
+      "CARRIP6_CARRI6MORU.1 DJ_OC",
+      "OPEN",
+      "LONGUE"
+    ],
+    [
+      "CARRIP6_CARRI6MORU.1 SA.2_OC",
+      "OPEN",
+      "LONGUE"
+    ],
+    [
+      "CARRIP6_CARRI6MORU.1 SA.1_OC",
+      "CLOSE",
+      "LONGUE"
+    ],
+    [
+      "CARRIP6_CARRI6MORU.1 DJ_OC",
+      "CLOSE",
+      "LONGUE"
+    ],
+    [
+      "CARRIP6_CARRI6VALES.1 DJ_OC",
+      "OPEN",
+      "LONGUE"
+    ],
+    [
+      "CARRIP6_CARRI6VALES.1 SA.2_OC",
+      "OPEN",
+      "LONGUE"
+    ],
+    [
+      "CARRIP6_CARRI6VALES.1 SA.1_OC",
+      "CLOSE",
+      "LONGUE"
+    ],
+    [
+      "CARRIP6_CARRI6VALES.1 DJ_OC",
+      "CLOSE",
+      "LONGUE"
+    ],
+    [
+      "CARRIP6_CARRI6TR631 DJ_OC",
+      "OPEN",
+      "LONGUE"
+    ],
+    [
+      "CARRIP6_CARRI6TR631 SA.2_OC",
+      "OPEN",
+      "LONGUE"
+    ],
+    [
+      "CARRIP6_CARRI6TR631 SA.1_OC",
+      "CLOSE",
+      "LONGUE"
+    ],
+    [
+      "CARRIP6_CARRI6TR631 DJ_OC",
+      "CLOSE",
+      "LONGUE"
+    ],
+    [
+      "CARRIP6_CARRI6TR632 DJ_OC",
+      "OPEN",
+      "LONGUE"
+    ],
+    [
+      "CARRIP6_CARRI6TR632 SA.1_OC",
+      "OPEN",
+      "LONGUE"
+    ],
+    [
+      "CARRIP6_CARRI6TR632 SA.2_OC",
+      "CLOSE",
+      "LONGUE"
+    ],
+    [
+      "CARRIP6_CARRI6TR632 DJ_OC",
+      "CLOSE",
+      "LONGUE"
+    ]
+  ],
+  "mode": "smooth",
+  "n_manoeuvres": 33,
+  "noeuds_non_realisables": [],
+  "partition_obtenue": [
+    [
+      "CARRI6CREI5.1",
+      "CARRI6T611",
+      "CARRIL61TERRI",
+      "CARRIL61ZB.FR"
+    ],
+    [
+      "CARRI6CREI5.2",
+      "CARRIL61GOUVI",
+      "CARRIY633"
+    ],
+    [
+      "CARRIL61MORU",
+      "CARRIL61VALES",
+      "CARRIY631"
+    ],
+    [
+      "CARRIL62TERRI"
+    ],
+    [
+      "CARRIY632"
+    ]
+  ],
+  "voltage_level_id": "CARRIP6"
+}

--- a/tests/manoeuvre/goldens/CARRIP6_cible__aggressive.golden.json
+++ b/tests/manoeuvre/goldens/CARRIP6_cible__aggressive.golden.json
@@ -1,0 +1,36 @@
+{
+  "ecarts": [],
+  "is_verified": true,
+  "is_verified_detaillee": true,
+  "manoeuvres": [
+    [
+      "CARRIP6_CARRI6COUPL.3 DJ_OC",
+      "OPEN",
+      null
+    ]
+  ],
+  "mode": "aggressive",
+  "n_manoeuvres": 1,
+  "noeuds_non_realisables": [],
+  "partition_obtenue": [
+    [
+      "CARRI6CREI5.1",
+      "CARRIL61TERRI",
+      "CARRIL61VALES",
+      "CARRIL61ZB.FR",
+      "CARRIY631"
+    ],
+    [
+      "CARRI6CREI5.2",
+      "CARRI6T611",
+      "CARRIL61GOUVI",
+      "CARRIL61MORU",
+      "CARRIY632",
+      "CARRIY633"
+    ],
+    [
+      "CARRIL62TERRI"
+    ]
+  ],
+  "voltage_level_id": "CARRIP6"
+}

--- a/tests/manoeuvre/goldens/CARRIP6_cible__smooth.golden.json
+++ b/tests/manoeuvre/goldens/CARRIP6_cible__smooth.golden.json
@@ -1,0 +1,36 @@
+{
+  "ecarts": [],
+  "is_verified": true,
+  "is_verified_detaillee": true,
+  "manoeuvres": [
+    [
+      "CARRIP6_CARRI6COUPL.3 DJ_OC",
+      "OPEN",
+      null
+    ]
+  ],
+  "mode": "smooth",
+  "n_manoeuvres": 1,
+  "noeuds_non_realisables": [],
+  "partition_obtenue": [
+    [
+      "CARRI6CREI5.1",
+      "CARRIL61TERRI",
+      "CARRIL61VALES",
+      "CARRIL61ZB.FR",
+      "CARRIY631"
+    ],
+    [
+      "CARRI6CREI5.2",
+      "CARRI6T611",
+      "CARRIL61GOUVI",
+      "CARRIL61MORU",
+      "CARRIY632",
+      "CARRIY633"
+    ],
+    [
+      "CARRIL62TERRI"
+    ]
+  ],
+  "voltage_level_id": "CARRIP6"
+}

--- a/tests/manoeuvre/goldens/CZBEVP3_cible_3noeuds__aggressive.golden.json
+++ b/tests/manoeuvre/goldens/CZBEVP3_cible_3noeuds__aggressive.golden.json
@@ -1,0 +1,75 @@
+{
+  "ecarts": [],
+  "is_verified": true,
+  "is_verified_detaillee": true,
+  "manoeuvres": [
+    [
+      "CZBEVP3_CZBEV3FALLO.2 DJ_OC",
+      "OPEN",
+      null
+    ],
+    [
+      "CZBEVP3_CZBEV3TR311 DJ.HT_OC",
+      "OPEN",
+      null
+    ],
+    [
+      "CZBEVP3_CZBEV3DANT5.1 DJ_OC",
+      "OPEN",
+      null
+    ],
+    [
+      "CZBEVP3_CZBEV3TR312 DJ.HT_OC",
+      "OPEN",
+      null
+    ],
+    [
+      "CZBEVP3_CZBEV3CBO.1 SS.1.12_OC",
+      "OPEN",
+      null
+    ],
+    [
+      "CZBEVP3_CZBEV3CBO.1 SS.1.23_OC",
+      "OPEN",
+      null
+    ],
+    [
+      "CZBEVP3_CZBEV3DANT5.1 DJ_OC",
+      "CLOSE",
+      null
+    ],
+    [
+      "CZBEVP3_CZBEV3FALLO.2 DJ_OC",
+      "CLOSE",
+      null
+    ],
+    [
+      "CZBEVP3_CZBEV3TR311 DJ.HT_OC",
+      "CLOSE",
+      null
+    ],
+    [
+      "CZBEVP3_CZBEV3TR312 DJ.HT_OC",
+      "CLOSE",
+      null
+    ]
+  ],
+  "mode": "aggressive",
+  "n_manoeuvres": 10,
+  "noeuds_non_realisables": [],
+  "partition_obtenue": [
+    [
+      "CZBEV3T311",
+      "CZBEVL32FALLO"
+    ],
+    [
+      "CZBEV3T312",
+      "CZBEVL31DANT5"
+    ],
+    [
+      "CZBEV3T313",
+      "CZBEVL31FALLO"
+    ]
+  ],
+  "voltage_level_id": "CZBEVP3"
+}

--- a/tests/manoeuvre/goldens/CZBEVP3_cible_3noeuds__smooth.golden.json
+++ b/tests/manoeuvre/goldens/CZBEVP3_cible_3noeuds__smooth.golden.json
@@ -1,0 +1,75 @@
+{
+  "ecarts": [],
+  "is_verified": true,
+  "is_verified_detaillee": true,
+  "manoeuvres": [
+    [
+      "CZBEVP3_CZBEV3FALLO.2 DJ_OC",
+      "OPEN",
+      null
+    ],
+    [
+      "CZBEVP3_CZBEV3TR311 DJ.HT_OC",
+      "OPEN",
+      null
+    ],
+    [
+      "CZBEVP3_CZBEV3CBO.1 SS.1.12_OC",
+      "OPEN",
+      null
+    ],
+    [
+      "CZBEVP3_CZBEV3FALLO.2 DJ_OC",
+      "CLOSE",
+      null
+    ],
+    [
+      "CZBEVP3_CZBEV3TR311 DJ.HT_OC",
+      "CLOSE",
+      null
+    ],
+    [
+      "CZBEVP3_CZBEV3DANT5.1 DJ_OC",
+      "OPEN",
+      null
+    ],
+    [
+      "CZBEVP3_CZBEV3TR312 DJ.HT_OC",
+      "OPEN",
+      null
+    ],
+    [
+      "CZBEVP3_CZBEV3CBO.1 SS.1.23_OC",
+      "OPEN",
+      null
+    ],
+    [
+      "CZBEVP3_CZBEV3DANT5.1 DJ_OC",
+      "CLOSE",
+      null
+    ],
+    [
+      "CZBEVP3_CZBEV3TR312 DJ.HT_OC",
+      "CLOSE",
+      null
+    ]
+  ],
+  "mode": "smooth",
+  "n_manoeuvres": 10,
+  "noeuds_non_realisables": [],
+  "partition_obtenue": [
+    [
+      "CZBEV3T311",
+      "CZBEVL32FALLO"
+    ],
+    [
+      "CZBEV3T312",
+      "CZBEVL31DANT5"
+    ],
+    [
+      "CZBEV3T313",
+      "CZBEVL31FALLO"
+    ]
+  ],
+  "voltage_level_id": "CZBEVP3"
+}

--- a/tests/manoeuvre/goldens/CZTRYP6_cible_3noeuds__aggressive.golden.json
+++ b/tests/manoeuvre/goldens/CZTRYP6_cible_3noeuds__aggressive.golden.json
@@ -1,0 +1,68 @@
+{
+  "ecarts": [],
+  "is_verified": true,
+  "is_verified_detaillee": true,
+  "manoeuvres": [
+    [
+      "CZTRYP6_CZTRY6CHESN.3 DJ_OC",
+      "OPEN",
+      null
+    ],
+    [
+      "CZTRYP6_CZTRY6CHESN.1 DJ_OC",
+      "OPEN",
+      null
+    ],
+    [
+      "CZTRYP6_CZTRY6TR633 DJ_OC",
+      "OPEN",
+      null
+    ],
+    [
+      "CZTRYP6_CZTRY6COUPL.1 DJ_OC",
+      "OPEN",
+      null
+    ],
+    [
+      "CZTRYP6_CZTRY6SEC..34 SS.1.34_OC",
+      "OPEN",
+      null
+    ],
+    [
+      "CZTRYP6_CZTRY6CHESN.3 DJ_OC",
+      "CLOSE",
+      null
+    ],
+    [
+      "CZTRYP6_CZTRY6CHESN.1 DJ_OC",
+      "CLOSE",
+      null
+    ],
+    [
+      "CZTRYP6_CZTRY6TR633 DJ_OC",
+      "CLOSE",
+      null
+    ]
+  ],
+  "mode": "aggressive",
+  "n_manoeuvres": 8,
+  "noeuds_non_realisables": [],
+  "partition_obtenue": [
+    [
+      "CHESNL61CZTRY",
+      "CHESNL63CZTRY",
+      "CZTRYY633"
+    ],
+    [
+      "CHESNL62CZTRY",
+      "CZTRYL61MOISE",
+      "CZTRYY632"
+    ],
+    [
+      "CZTRYL61PLISO",
+      "CZTRYL61SENAR",
+      "CZTRYY634"
+    ]
+  ],
+  "voltage_level_id": "CZTRYP6"
+}

--- a/tests/manoeuvre/goldens/CZTRYP6_cible_3noeuds__smooth.golden.json
+++ b/tests/manoeuvre/goldens/CZTRYP6_cible_3noeuds__smooth.golden.json
@@ -1,0 +1,128 @@
+{
+  "ecarts": [],
+  "is_verified": true,
+  "is_verified_detaillee": true,
+  "manoeuvres": [
+    [
+      "CZTRYP6_CZTRY6PLISO.1 SA.2_OC",
+      "CLOSE",
+      "COURTE"
+    ],
+    [
+      "CZTRYP6_CZTRY6PLISO.1 SA.1_OC",
+      "OPEN",
+      "COURTE"
+    ],
+    [
+      "CZTRYP6_CZTRY6SENAR.1 SA.2_OC",
+      "CLOSE",
+      "COURTE"
+    ],
+    [
+      "CZTRYP6_CZTRY6SENAR.1 SA.1_OC",
+      "OPEN",
+      "COURTE"
+    ],
+    [
+      "CZTRYP6_CZTRY6TR634 SA.2_OC",
+      "CLOSE",
+      "COURTE"
+    ],
+    [
+      "CZTRYP6_CZTRY6TR634 SA.1_OC",
+      "OPEN",
+      "COURTE"
+    ],
+    [
+      "CZTRYP6_CZTRY6SEC..34 SS.1.34_OC",
+      "OPEN",
+      null
+    ],
+    [
+      "CZTRYP6_CZTRY6COUPL.1 DJ_OC",
+      "OPEN",
+      null
+    ],
+    [
+      "CZTRYP6_CZTRY6PLISO.1 DJ_OC",
+      "OPEN",
+      "LONGUE"
+    ],
+    [
+      "CZTRYP6_CZTRY6PLISO.1 SA.2_OC",
+      "OPEN",
+      "LONGUE"
+    ],
+    [
+      "CZTRYP6_CZTRY6PLISO.1 SA.1_OC",
+      "CLOSE",
+      "LONGUE"
+    ],
+    [
+      "CZTRYP6_CZTRY6PLISO.1 DJ_OC",
+      "CLOSE",
+      "LONGUE"
+    ],
+    [
+      "CZTRYP6_CZTRY6SENAR.1 DJ_OC",
+      "OPEN",
+      "LONGUE"
+    ],
+    [
+      "CZTRYP6_CZTRY6SENAR.1 SA.2_OC",
+      "OPEN",
+      "LONGUE"
+    ],
+    [
+      "CZTRYP6_CZTRY6SENAR.1 SA.1_OC",
+      "CLOSE",
+      "LONGUE"
+    ],
+    [
+      "CZTRYP6_CZTRY6SENAR.1 DJ_OC",
+      "CLOSE",
+      "LONGUE"
+    ],
+    [
+      "CZTRYP6_CZTRY6TR634 DJ_OC",
+      "OPEN",
+      "LONGUE"
+    ],
+    [
+      "CZTRYP6_CZTRY6TR634 SA.2_OC",
+      "OPEN",
+      "LONGUE"
+    ],
+    [
+      "CZTRYP6_CZTRY6TR634 SA.1_OC",
+      "CLOSE",
+      "LONGUE"
+    ],
+    [
+      "CZTRYP6_CZTRY6TR634 DJ_OC",
+      "CLOSE",
+      "LONGUE"
+    ]
+  ],
+  "mode": "smooth",
+  "n_manoeuvres": 20,
+  "noeuds_non_realisables": [],
+  "partition_obtenue": [
+    [
+      "CHESNL61CZTRY",
+      "CHESNL63CZTRY",
+      "CZTRYY633"
+    ],
+    [
+      "CHESNL62CZTRY",
+      "CZTRYL61MOISE",
+      "CZTRYY632"
+    ],
+    [
+      "CZTRYL61PLISO",
+      "CZTRYL61SENAR",
+      "CZTRYY634"
+    ]
+  ],
+  "voltage_level_id": "CZTRYP6"
+}

--- a/tests/manoeuvre/goldens/MORBRP6_cible_4noeuds__aggressive.golden.json
+++ b/tests/manoeuvre/goldens/MORBRP6_cible_4noeuds__aggressive.golden.json
@@ -1,0 +1,144 @@
+{
+  "ecarts": [
+    "'MORBRL61REAC.' sur MORBRP6_3B au lieu de MORBRP6_4B"
+  ],
+  "is_verified": true,
+  "is_verified_detaillee": false,
+  "manoeuvres": [
+    [
+      "MORBRP6_MORBR6COSSI.1 DJ_OC",
+      "OPEN",
+      null
+    ],
+    [
+      "MORBRP6_MORBR6LANG6.1 DJ_OC",
+      "OPEN",
+      null
+    ],
+    [
+      "MORBRP6_MORBR6ARRIG.1 DJ_OC",
+      "OPEN",
+      null
+    ],
+    [
+      "MORBRP6_MORBR6ZLAN8.2 DJ_OC",
+      "OPEN",
+      null
+    ],
+    [
+      "MORBRP6_MORBR6AT764 DJ_OC",
+      "OPEN",
+      null
+    ],
+    [
+      "MORBRP6_MORBR6SONNE.2 DJ_OC",
+      "OPEN",
+      null
+    ],
+    [
+      "MORBRP6_MORBR6TRO.1AB DJ_OC",
+      "OPEN",
+      null
+    ],
+    [
+      "MORBRP6_MORBR6COUPL.A DJ_OC",
+      "OPEN",
+      null
+    ],
+    [
+      "MORBRP6_MORBR6COUPL.B DJ_OC",
+      "OPEN",
+      null
+    ],
+    [
+      "MORBRP6_MORBR6COSSI.1 SA.1_OC",
+      "OPEN",
+      null
+    ],
+    [
+      "MORBRP6_MORBR6COSSI.1 SA.2_OC",
+      "CLOSE",
+      null
+    ],
+    [
+      "MORBRP6_MORBR6LANG6.1 SA.2_OC",
+      "OPEN",
+      null
+    ],
+    [
+      "MORBRP6_MORBR6LANG6.1 SA.1_OC",
+      "CLOSE",
+      null
+    ],
+    [
+      "MORBRP6_MORBR6ARRIG.1 SA.1_OC",
+      "OPEN",
+      null
+    ],
+    [
+      "MORBRP6_MORBR6ZLAN8.2 DJ_OC",
+      "CLOSE",
+      null
+    ],
+    [
+      "MORBRP6_MORBR6COSSI.1 DJ_OC",
+      "CLOSE",
+      null
+    ],
+    [
+      "MORBRP6_MORBR6LANG6.1 DJ_OC",
+      "CLOSE",
+      null
+    ],
+    [
+      "MORBRP6_MORBR6AT764 DJ_OC",
+      "CLOSE",
+      null
+    ],
+    [
+      "MORBRP6_MORBR6ARRIG.1 DJ_OC",
+      "CLOSE",
+      null
+    ],
+    [
+      "MORBRP6_MORBR6SONNE.2 DJ_OC",
+      "CLOSE",
+      null
+    ]
+  ],
+  "mode": "aggressive",
+  "n_manoeuvres": 20,
+  "noeuds_non_realisables": [],
+  "partition_obtenue": [
+    [
+      "ARRIGL61MORBR"
+    ],
+    [
+      "ARRIGL62MORBR",
+      "COSSIL61MORBR",
+      "MORBRL61SONNE",
+      "MORBRL62MORB5",
+      "MORBRY762",
+      "MORBRY763"
+    ],
+    [
+      "LANG6L61MORBR",
+      "MORBRL61MORB5",
+      "MORBRY761"
+    ],
+    [
+      "MORBRL61REAC.",
+      "MORBRL61V.GEO"
+    ],
+    [
+      "MORBRL61REAC.",
+      "MORBRL62SONNE",
+      "MORBRL62ZLAN8",
+      "MORBRY764"
+    ],
+    [
+      "MORBRL61ZORS6"
+    ]
+  ],
+  "voltage_level_id": "MORBRP6"
+}

--- a/tests/manoeuvre/goldens/MORBRP6_cible_4noeuds__smooth.golden.json
+++ b/tests/manoeuvre/goldens/MORBRP6_cible_4noeuds__smooth.golden.json
@@ -1,0 +1,92 @@
+{
+  "ecarts": [],
+  "is_verified": true,
+  "is_verified_detaillee": true,
+  "manoeuvres": [
+    [
+      "MORBRP6_MORBR6COSSI.1 SA.2_OC",
+      "CLOSE",
+      "COURTE"
+    ],
+    [
+      "MORBRP6_MORBR6COSSI.1 SA.1_OC",
+      "OPEN",
+      "COURTE"
+    ],
+    [
+      "MORBRP6_MORBR6LANG6.1 SA.1_OC",
+      "CLOSE",
+      "COURTE"
+    ],
+    [
+      "MORBRP6_MORBR6LANG6.1 SA.2_OC",
+      "OPEN",
+      "COURTE"
+    ],
+    [
+      "MORBRP6_MORBR6TRO.1AB DJ_OC",
+      "OPEN",
+      null
+    ],
+    [
+      "MORBRP6_MORBR6COUPL.A DJ_OC",
+      "OPEN",
+      null
+    ],
+    [
+      "MORBRP6_MORBR6COUPL.B DJ_OC",
+      "OPEN",
+      null
+    ],
+    [
+      "MORBRP6_MORBR6ARRIG.1 DJ_OC",
+      "OPEN",
+      null
+    ],
+    [
+      "MORBRP6_MORBR6ARRIG.1 SA.1_OC",
+      "OPEN",
+      null
+    ],
+    [
+      "MORBRP6_MORBR6ARRIG.1 DJ_OC",
+      "CLOSE",
+      null
+    ]
+  ],
+  "mode": "smooth",
+  "n_manoeuvres": 10,
+  "noeuds_non_realisables": [],
+  "partition_obtenue": [
+    [
+      "ARRIGL61MORBR"
+    ],
+    [
+      "ARRIGL62MORBR",
+      "COSSIL61MORBR",
+      "MORBRL61SONNE",
+      "MORBRL62MORB5",
+      "MORBRY762",
+      "MORBRY763"
+    ],
+    [
+      "LANG6L61MORBR",
+      "MORBRL61MORB5",
+      "MORBRY761"
+    ],
+    [
+      "MORBRL61REAC.",
+      "MORBRL61V.GEO"
+    ],
+    [
+      "MORBRL61REAC.",
+      "MORBRL62SONNE",
+      "MORBRL62ZLAN8",
+      "MORBRY764"
+    ],
+    [
+      "MORBRL61ZORS6"
+    ]
+  ],
+  "voltage_level_id": "MORBRP6"
+}

--- a/tests/manoeuvre/goldens/MORBRP6_cible_4noeuds_non_atteignable__aggressive.golden.json
+++ b/tests/manoeuvre/goldens/MORBRP6_cible_4noeuds_non_atteignable__aggressive.golden.json
@@ -1,0 +1,155 @@
+{
+  "ecarts": [
+    "MORBRP6_MORBRP6-MORBRP6.SJB.3.2-MORBR6REAC.1SA_F : sectionneur manœuvré sous charge — dé-énergiser la branche par son disjoncteur avant d'ouvrir ce sectionneur"
+  ],
+  "is_verified": true,
+  "is_verified_detaillee": false,
+  "manoeuvres": [
+    [
+      "MORBRP6_MORBR6COSSI.1 DJ_OC",
+      "OPEN",
+      null
+    ],
+    [
+      "MORBRP6_MORBR6LANG6.1 DJ_OC",
+      "OPEN",
+      null
+    ],
+    [
+      "MORBRP6_MORBR6ARRIG.1 DJ_OC",
+      "OPEN",
+      null
+    ],
+    [
+      "MORBRP6_MORBR6ZLAN8.2 DJ_OC",
+      "OPEN",
+      null
+    ],
+    [
+      "MORBRP6_MORBR6AT764 DJ_OC",
+      "OPEN",
+      null
+    ],
+    [
+      "MORBRP6_MORBR6SONNE.2 DJ_OC",
+      "OPEN",
+      null
+    ],
+    [
+      "MORBRP6_MORBR6TRO.1AB DJ_OC",
+      "OPEN",
+      null
+    ],
+    [
+      "MORBRP6_MORBR6COUPL.A DJ_OC",
+      "OPEN",
+      null
+    ],
+    [
+      "MORBRP6_MORBR6COUPL.B DJ_OC",
+      "OPEN",
+      null
+    ],
+    [
+      "MORBRP6_MORBR6COSSI.1 SA.1_OC",
+      "OPEN",
+      null
+    ],
+    [
+      "MORBRP6_MORBR6COSSI.1 SA.2_OC",
+      "CLOSE",
+      null
+    ],
+    [
+      "MORBRP6_MORBR6LANG6.1 SA.2_OC",
+      "OPEN",
+      null
+    ],
+    [
+      "MORBRP6_MORBR6LANG6.1 SA.1_OC",
+      "CLOSE",
+      null
+    ],
+    [
+      "MORBRP6_MORBR6ARRIG.1 SA.1_OC",
+      "OPEN",
+      null
+    ],
+    [
+      "MORBRP6_MORBRP6-MORBRP6.SJB.3.1-MORBR6REAC.1SA_F",
+      "OPEN",
+      null
+    ],
+    [
+      "MORBRP6_MORBRP6-MORBRP6.SJB.3.2-MORBR6REAC.1SA_F",
+      "OPEN",
+      null
+    ],
+    [
+      "MORBRP6_MORBR6ZLAN8.2 DJ_OC",
+      "CLOSE",
+      null
+    ],
+    [
+      "MORBRP6_MORBR6COSSI.1 DJ_OC",
+      "CLOSE",
+      null
+    ],
+    [
+      "MORBRP6_MORBR6LANG6.1 DJ_OC",
+      "CLOSE",
+      null
+    ],
+    [
+      "MORBRP6_MORBR6AT764 DJ_OC",
+      "CLOSE",
+      null
+    ],
+    [
+      "MORBRP6_MORBR6ARRIG.1 DJ_OC",
+      "CLOSE",
+      null
+    ],
+    [
+      "MORBRP6_MORBR6SONNE.2 DJ_OC",
+      "CLOSE",
+      null
+    ]
+  ],
+  "mode": "aggressive",
+  "n_manoeuvres": 22,
+  "noeuds_non_realisables": [],
+  "partition_obtenue": [
+    [
+      "ARRIGL61MORBR"
+    ],
+    [
+      "ARRIGL62MORBR",
+      "COSSIL61MORBR",
+      "MORBRL61SONNE",
+      "MORBRL62MORB5",
+      "MORBRY762",
+      "MORBRY763"
+    ],
+    [
+      "LANG6L61MORBR",
+      "MORBRL61MORB5",
+      "MORBRY761"
+    ],
+    [
+      "MORBRL61REAC."
+    ],
+    [
+      "MORBRL61V.GEO"
+    ],
+    [
+      "MORBRL61ZORS6"
+    ],
+    [
+      "MORBRL62SONNE",
+      "MORBRL62ZLAN8",
+      "MORBRY764"
+    ]
+  ],
+  "voltage_level_id": "MORBRP6"
+}

--- a/tests/manoeuvre/goldens/MORBRP6_cible_4noeuds_non_atteignable__smooth.golden.json
+++ b/tests/manoeuvre/goldens/MORBRP6_cible_4noeuds_non_atteignable__smooth.golden.json
@@ -1,0 +1,108 @@
+{
+  "ecarts": [
+    "nœud à compléter manuellement : {MORBRL61REAC.}",
+    "nœud à compléter manuellement : {MORBRL61V.GEO}",
+    "nœud à compléter manuellement : {MORBRL62SONNE, MORBRL62ZLAN8, MORBRY764}"
+  ],
+  "is_verified": false,
+  "is_verified_detaillee": false,
+  "manoeuvres": [
+    [
+      "MORBRP6_MORBR6COSSI.1 SA.2_OC",
+      "CLOSE",
+      "COURTE"
+    ],
+    [
+      "MORBRP6_MORBR6COSSI.1 SA.1_OC",
+      "OPEN",
+      "COURTE"
+    ],
+    [
+      "MORBRP6_MORBR6LANG6.1 SA.1_OC",
+      "CLOSE",
+      "COURTE"
+    ],
+    [
+      "MORBRP6_MORBR6LANG6.1 SA.2_OC",
+      "OPEN",
+      "COURTE"
+    ],
+    [
+      "MORBRP6_MORBR6TRO.1AB DJ_OC",
+      "OPEN",
+      null
+    ],
+    [
+      "MORBRP6_MORBR6COUPL.A DJ_OC",
+      "OPEN",
+      null
+    ],
+    [
+      "MORBRP6_MORBR6COUPL.B DJ_OC",
+      "OPEN",
+      null
+    ],
+    [
+      "MORBRP6_MORBR6ARRIG.1 DJ_OC",
+      "OPEN",
+      null
+    ],
+    [
+      "MORBRP6_MORBR6ARRIG.1 SA.1_OC",
+      "OPEN",
+      null
+    ],
+    [
+      "MORBRP6_MORBR6ARRIG.1 DJ_OC",
+      "CLOSE",
+      null
+    ]
+  ],
+  "mode": "smooth",
+  "n_manoeuvres": 10,
+  "noeuds_non_realisables": [
+    [
+      "MORBRL61REAC."
+    ],
+    [
+      "MORBRL61V.GEO"
+    ],
+    [
+      "MORBRL62SONNE",
+      "MORBRL62ZLAN8",
+      "MORBRY764"
+    ]
+  ],
+  "partition_obtenue": [
+    [
+      "ARRIGL61MORBR"
+    ],
+    [
+      "ARRIGL62MORBR",
+      "COSSIL61MORBR",
+      "MORBRL61SONNE",
+      "MORBRL62MORB5",
+      "MORBRY762",
+      "MORBRY763"
+    ],
+    [
+      "LANG6L61MORBR",
+      "MORBRL61MORB5",
+      "MORBRY761"
+    ],
+    [
+      "MORBRL61REAC.",
+      "MORBRL61V.GEO"
+    ],
+    [
+      "MORBRL61REAC.",
+      "MORBRL62SONNE",
+      "MORBRL62ZLAN8",
+      "MORBRY764"
+    ],
+    [
+      "MORBRL61ZORS6"
+    ]
+  ],
+  "voltage_level_id": "MORBRP6"
+}

--- a/tests/manoeuvre/goldens/NOVIOP3_cible_3noeuds__aggressive.golden.json
+++ b/tests/manoeuvre/goldens/NOVIOP3_cible_3noeuds__aggressive.golden.json
@@ -1,0 +1,56 @@
+{
+  "ecarts": [
+    "NOVIOP3_NOVIO3ASNIE.1 SA.1_OC : sectionneur manœuvré sous charge — dé-énergiser la branche par son disjoncteur avant d'ouvrir ce sectionneur"
+  ],
+  "is_verified": true,
+  "is_verified_detaillee": false,
+  "manoeuvres": [
+    [
+      "NOVIOP3_NOVIO3ASNIE.1 DJ_OC",
+      "OPEN",
+      null
+    ],
+    [
+      "NOVIOP3_NOVIO3COUPL.A DJ_OC",
+      "OPEN",
+      null
+    ],
+    [
+      "NOVIOP3_NOVIO3ASNIE.1 SA.2_OC",
+      "CLOSE",
+      null
+    ],
+    [
+      "NOVIOP3_NOVIO3ASNIE.1 SA.1_OC",
+      "OPEN",
+      null
+    ],
+    [
+      "NOVIOP3_NOVIO3ASNIE.1 DJ_OC",
+      "CLOSE",
+      null
+    ]
+  ],
+  "mode": "aggressive",
+  "n_manoeuvres": 5,
+  "noeuds_non_realisables": [],
+  "partition_obtenue": [
+    [
+      "ASNIEL31NOVIO",
+      "FALLOL32NOVIO",
+      "FALLOL34NOVIO",
+      "LAMARL31NOVIO",
+      "NOVIO3TR0312"
+    ],
+    [
+      "ASNIEL32NOVIO",
+      "NOVIOY631",
+      "NOVIOY632"
+    ],
+    [
+      "FALLOL33NOVIO",
+      "NOVIO3TR0314"
+    ]
+  ],
+  "voltage_level_id": "NOVIOP3"
+}

--- a/tests/manoeuvre/goldens/NOVIOP3_cible_3noeuds__smooth.golden.json
+++ b/tests/manoeuvre/goldens/NOVIOP3_cible_3noeuds__smooth.golden.json
@@ -1,0 +1,54 @@
+{
+  "ecarts": [],
+  "is_verified": true,
+  "is_verified_detaillee": true,
+  "manoeuvres": [
+    [
+      "NOVIOP3_NOVIO3ASNIE.1 DJ_OC",
+      "OPEN",
+      "LONGUE"
+    ],
+    [
+      "NOVIOP3_NOVIO3ASNIE.1 SA.1_OC",
+      "OPEN",
+      "LONGUE"
+    ],
+    [
+      "NOVIOP3_NOVIO3ASNIE.1 SA.2_OC",
+      "CLOSE",
+      "LONGUE"
+    ],
+    [
+      "NOVIOP3_NOVIO3ASNIE.1 DJ_OC",
+      "CLOSE",
+      "LONGUE"
+    ],
+    [
+      "NOVIOP3_NOVIO3COUPL.A DJ_OC",
+      "OPEN",
+      null
+    ]
+  ],
+  "mode": "smooth",
+  "n_manoeuvres": 5,
+  "noeuds_non_realisables": [],
+  "partition_obtenue": [
+    [
+      "ASNIEL31NOVIO",
+      "FALLOL32NOVIO",
+      "FALLOL34NOVIO",
+      "LAMARL31NOVIO",
+      "NOVIO3TR0312"
+    ],
+    [
+      "ASNIEL32NOVIO",
+      "NOVIOY631",
+      "NOVIOY632"
+    ],
+    [
+      "FALLOL33NOVIO",
+      "NOVIO3TR0314"
+    ]
+  ],
+  "voltage_level_id": "NOVIOP3"
+}

--- a/tests/manoeuvre/goldens/PALUNP3_cible_4noeuds__aggressive.golden.json
+++ b/tests/manoeuvre/goldens/PALUNP3_cible_4noeuds__aggressive.golden.json
@@ -1,0 +1,86 @@
+{
+  "ecarts": [],
+  "is_verified": true,
+  "is_verified_detaillee": true,
+  "manoeuvres": [
+    [
+      "PALUNP3_PALUN3ENSOL.1 DJ_OC",
+      "OPEN",
+      null
+    ],
+    [
+      "PALUNP3_PALUN3CHAB5.1 DJ_OC",
+      "OPEN",
+      null
+    ],
+    [
+      "PALUNP3_PALUN3COUPL.2 DJ_OC",
+      "OPEN",
+      null
+    ],
+    [
+      "PALUNP3_PALUN3SEC..12 SS.1.12_OC",
+      "OPEN",
+      null
+    ],
+    [
+      "PALUNP3_PALUN3ENSOL.1 SA.2_OC",
+      "OPEN",
+      null
+    ],
+    [
+      "PALUNP3_PALUN3ENSOL.1 SA.1_OC",
+      "CLOSE",
+      null
+    ],
+    [
+      "PALUNP3_PALUN3ENSOL.1 DJ_OC",
+      "CLOSE",
+      null
+    ],
+    [
+      "PALUNP3_PALUN3CHAB5.1 DJ_OC",
+      "CLOSE",
+      null
+    ]
+  ],
+  "mode": "aggressive",
+  "n_manoeuvres": 8,
+  "noeuds_non_realisables": [],
+  "partition_obtenue": [
+    [
+      "AIX  L31PALUN",
+      "GARDAL32PALUN",
+      "PALUNY631"
+    ],
+    [
+      "AIX  L32PALUN",
+      "ENSOLL32PALUN",
+      "GARD6L31PALUN",
+      "GARDAL31PALUN",
+      "PALUN3PROVESA1",
+      "PALUNL31ROUS5",
+      "PALUNL31SSSA6",
+      "PALUNY632",
+      "fict_PALUNP3_1.1"
+    ],
+    [
+      "CHAB5L31PALUN",
+      "ENSOLL31PALUN"
+    ],
+    [
+      "PALUN3COND.1"
+    ],
+    [
+      "PALUN3COND.2"
+    ],
+    [
+      "PALUNL31SEPTE"
+    ],
+    [
+      "PALUNL32ROUS5",
+      "PALUNY633"
+    ]
+  ],
+  "voltage_level_id": "PALUNP3"
+}

--- a/tests/manoeuvre/goldens/PALUNP3_cible_4noeuds__smooth.golden.json
+++ b/tests/manoeuvre/goldens/PALUNP3_cible_4noeuds__smooth.golden.json
@@ -1,0 +1,86 @@
+{
+  "ecarts": [],
+  "is_verified": true,
+  "is_verified_detaillee": true,
+  "manoeuvres": [
+    [
+      "PALUNP3_PALUN3ENSOL.1 SA.1_OC",
+      "CLOSE",
+      "COURTE"
+    ],
+    [
+      "PALUNP3_PALUN3ENSOL.1 SA.2_OC",
+      "OPEN",
+      "COURTE"
+    ],
+    [
+      "PALUNP3_PALUN3COUPL.2 DJ_OC",
+      "OPEN",
+      null
+    ],
+    [
+      "PALUNP3_PALUN3ENSOL.1 DJ_OC",
+      "OPEN",
+      null
+    ],
+    [
+      "PALUNP3_PALUN3CHAB5.1 DJ_OC",
+      "OPEN",
+      null
+    ],
+    [
+      "PALUNP3_PALUN3SEC..12 SS.1.12_OC",
+      "OPEN",
+      null
+    ],
+    [
+      "PALUNP3_PALUN3ENSOL.1 DJ_OC",
+      "CLOSE",
+      null
+    ],
+    [
+      "PALUNP3_PALUN3CHAB5.1 DJ_OC",
+      "CLOSE",
+      null
+    ]
+  ],
+  "mode": "smooth",
+  "n_manoeuvres": 8,
+  "noeuds_non_realisables": [],
+  "partition_obtenue": [
+    [
+      "AIX  L31PALUN",
+      "GARDAL32PALUN",
+      "PALUNY631"
+    ],
+    [
+      "AIX  L32PALUN",
+      "ENSOLL32PALUN",
+      "GARD6L31PALUN",
+      "GARDAL31PALUN",
+      "PALUN3PROVESA1",
+      "PALUNL31ROUS5",
+      "PALUNL31SSSA6",
+      "PALUNY632",
+      "fict_PALUNP3_1.1"
+    ],
+    [
+      "CHAB5L31PALUN",
+      "ENSOLL31PALUN"
+    ],
+    [
+      "PALUN3COND.1"
+    ],
+    [
+      "PALUN3COND.2"
+    ],
+    [
+      "PALUNL31SEPTE"
+    ],
+    [
+      "PALUNL32ROUS5",
+      "PALUNY633"
+    ]
+  ],
+  "voltage_level_id": "PALUNP3"
+}

--- a/tests/manoeuvre/goldens/SSAVOP3_cible_4noeuds__aggressive.golden.json
+++ b/tests/manoeuvre/goldens/SSAVOP3_cible_4noeuds__aggressive.golden.json
@@ -1,0 +1,209 @@
+{
+  "ecarts": [],
+  "is_verified": true,
+  "is_verified_detaillee": true,
+  "manoeuvres": [
+    [
+      "SSAVOP3_SSAVO3CARLI.1 DJ_OC",
+      "OPEN",
+      null
+    ],
+    [
+      "SSAVOP3_SSAVO3LAND5.1 DJ_OC",
+      "OPEN",
+      null
+    ],
+    [
+      "SSAVOP3_SSAVO3PUTTE.1 DJ_OC",
+      "OPEN",
+      null
+    ],
+    [
+      "SSAVOP3_SSAVO3BOULA.1 DJ_OC",
+      "OPEN",
+      null
+    ],
+    [
+      "SSAVOP3_SSAVO3TR636 DJ_OC",
+      "OPEN",
+      null
+    ],
+    [
+      "SSAVOP3_SSAVO3ANCER.1 DJ_OC",
+      "OPEN",
+      null
+    ],
+    [
+      "SSAVOP3_SSAVO3TR638 DJ_OC",
+      "OPEN",
+      null
+    ],
+    [
+      "SSAVOP3_SSAVO3BETTI.1 DJ_OC",
+      "OPEN",
+      null
+    ],
+    [
+      "SSAVOP3_SSAVO3LAND5.2 DJ_OC",
+      "OPEN",
+      null
+    ],
+    [
+      "SSAVOP3_SSAVOP3-N1_DJ_F",
+      "OPEN",
+      null
+    ],
+    [
+      "SSAVOP3_SSAVOP3-SSAVO3TR311_DJ_F",
+      "OPEN",
+      null
+    ],
+    [
+      "SSAVOP3_SSAVO3TR311 DJ.HT_OC",
+      "OPEN",
+      null
+    ],
+    [
+      "SSAVOP3_SSAVOP3-N7_DJ_F",
+      "OPEN",
+      null
+    ],
+    [
+      "SSAVOP3_SSAVO3SEC.A23 SS.1A23_OC",
+      "OPEN",
+      null
+    ],
+    [
+      "SSAVOP3_SSAVO3SEC.A23 SS.2A23_OC",
+      "OPEN",
+      null
+    ],
+    [
+      "SSAVOP3_SSAVO3CARLI.1 SA.1_OC",
+      "OPEN",
+      null
+    ],
+    [
+      "SSAVOP3_SSAVO3CARLI.1 SA.2_OC",
+      "CLOSE",
+      null
+    ],
+    [
+      "SSAVOP3_SSAVO3ANCER.1 DJ_OC",
+      "CLOSE",
+      null
+    ],
+    [
+      "SSAVOP3_SSAVO3CARLI.1 DJ_OC",
+      "CLOSE",
+      null
+    ],
+    [
+      "SSAVOP3_SSAVO3TR638 DJ_OC",
+      "CLOSE",
+      null
+    ],
+    [
+      "SSAVOP3_SSAVO3LAND5.1 DJ_OC",
+      "CLOSE",
+      null
+    ],
+    [
+      "SSAVOP3_SSAVO3PUTTE.1 DJ_OC",
+      "CLOSE",
+      null
+    ],
+    [
+      "SSAVOP3_SSAVO3BOULA.1 DJ_OC",
+      "CLOSE",
+      null
+    ],
+    [
+      "SSAVOP3_SSAVO3TR636 DJ_OC",
+      "CLOSE",
+      null
+    ],
+    [
+      "SSAVOP3_SSAVO3BETTI.1 DJ_OC",
+      "CLOSE",
+      null
+    ],
+    [
+      "SSAVOP3_SSAVO3LAND5.2 DJ_OC",
+      "CLOSE",
+      null
+    ],
+    [
+      "SSAVOP3_SSAVOP3-N1_DJ_F",
+      "CLOSE",
+      null
+    ],
+    [
+      "SSAVOP3_SSAVOP3-SSAVO3TR311_DJ_F",
+      "CLOSE",
+      null
+    ],
+    [
+      "SSAVOP3_SSAVO3TR311 DJ.HT_OC",
+      "CLOSE",
+      null
+    ],
+    [
+      "SSAVOP3_SSAVOP3-N7_DJ_F",
+      "CLOSE",
+      null
+    ]
+  ],
+  "mode": "aggressive",
+  "n_manoeuvres": 30,
+  "noeuds_non_realisables": [],
+  "partition_obtenue": [
+    [
+      "ANCERL31SSAVO",
+      "BETTIL31SSAVO",
+      "LAND5L32SSAVO",
+      "SSAVO3TR311",
+      "SSAVOIN1",
+      "SSAVOIN7",
+      "SSAVOY638"
+    ],
+    [
+      "BOULAL31SSAVO",
+      "LAND5L31SSAVO",
+      "PUTTEL31SSAVO",
+      "SSAVOY636"
+    ],
+    [
+      "CARLIL31SSAVO",
+      "NORSOL31SSAVO",
+      "P.ROSL31SSAVO",
+      "SSAVOL31STEAM",
+      "SSAVOL31SYNTH",
+      "SSAVOL31ZCAR8",
+      "SSAVOL32SYNTH",
+      "SSAVOY637"
+    ],
+    [
+      "CREUTL31SSAVO",
+      "MERBEL31SSAVO",
+      "MERBEL32SSAVO",
+      "SSAVO3ATPOL",
+      "SSAVO3AUEH1",
+      "SSAVO3AUEH6",
+      "SSAVO3TR313",
+      "SSAVOIN3",
+      "SSAVOIN6",
+      "SSAVOL33SYNTH",
+      "SSAVOY634"
+    ],
+    [
+      "SSAVO3TR312",
+      "SSAVOIN2",
+      "SSAVOING"
+    ],
+    [
+      "SSAVOINF"
+    ]
+  ],
+  "voltage_level_id": "SSAVOP3"
+}

--- a/tests/manoeuvre/goldens/SSAVOP3_cible_4noeuds__smooth.golden.json
+++ b/tests/manoeuvre/goldens/SSAVOP3_cible_4noeuds__smooth.golden.json
@@ -1,0 +1,369 @@
+{
+  "ecarts": [],
+  "is_verified": true,
+  "is_verified_detaillee": true,
+  "manoeuvres": [
+    [
+      "SSAVOP3_SSAVO3BETTI.1 DJ_OC",
+      "OPEN",
+      "LONGUE"
+    ],
+    [
+      "SSAVOP3_SSAVO3BETTI.1 SA.2_OC",
+      "OPEN",
+      "LONGUE"
+    ],
+    [
+      "SSAVOP3_SSAVO3BETTI.1 SA.1_OC",
+      "CLOSE",
+      "LONGUE"
+    ],
+    [
+      "SSAVOP3_SSAVO3BETTI.1 DJ_OC",
+      "CLOSE",
+      "LONGUE"
+    ],
+    [
+      "SSAVOP3_SSAVO3CARLI.1 DJ_OC",
+      "OPEN",
+      "LONGUE"
+    ],
+    [
+      "SSAVOP3_SSAVO3CARLI.1 SA.1_OC",
+      "OPEN",
+      "LONGUE"
+    ],
+    [
+      "SSAVOP3_SSAVO3CARLI.1 SA.2_OC",
+      "CLOSE",
+      "LONGUE"
+    ],
+    [
+      "SSAVOP3_SSAVO3CARLI.1 DJ_OC",
+      "CLOSE",
+      "LONGUE"
+    ],
+    [
+      "SSAVOP3_SSAVO3LAND5.1 DJ_OC",
+      "OPEN",
+      "LONGUE"
+    ],
+    [
+      "SSAVOP3_SSAVO3LAND5.1 SA.1_OC",
+      "OPEN",
+      "LONGUE"
+    ],
+    [
+      "SSAVOP3_SSAVO3LAND5.1 SA.2_OC",
+      "CLOSE",
+      "LONGUE"
+    ],
+    [
+      "SSAVOP3_SSAVO3LAND5.1 DJ_OC",
+      "CLOSE",
+      "LONGUE"
+    ],
+    [
+      "SSAVOP3_SSAVO3LAND5.2 DJ_OC",
+      "OPEN",
+      "LONGUE"
+    ],
+    [
+      "SSAVOP3_SSAVO3LAND5.2 SA.2_OC",
+      "OPEN",
+      "LONGUE"
+    ],
+    [
+      "SSAVOP3_SSAVO3LAND5.2 SA.1_OC",
+      "CLOSE",
+      "LONGUE"
+    ],
+    [
+      "SSAVOP3_SSAVO3LAND5.2 DJ_OC",
+      "CLOSE",
+      "LONGUE"
+    ],
+    [
+      "SSAVOP3_SSAVO3TR311 DJ.HT_OC",
+      "OPEN",
+      "LONGUE"
+    ],
+    [
+      "SSAVOP3_SSAVO3TR311 SA.2_OC",
+      "OPEN",
+      "LONGUE"
+    ],
+    [
+      "SSAVOP3_SSAVO3TR311 SA.1_OC",
+      "CLOSE",
+      "LONGUE"
+    ],
+    [
+      "SSAVOP3_SSAVO3TR311 DJ.HT_OC",
+      "CLOSE",
+      "LONGUE"
+    ],
+    [
+      "SSAVOP3_SSAVO3PUTTE.1 DJ_OC",
+      "OPEN",
+      null
+    ],
+    [
+      "SSAVOP3_SSAVO3BOULA.1 DJ_OC",
+      "OPEN",
+      null
+    ],
+    [
+      "SSAVOP3_SSAVO3TR636 DJ_OC",
+      "OPEN",
+      null
+    ],
+    [
+      "SSAVOP3_SSAVO3BETTI.1 DJ_OC",
+      "OPEN",
+      null
+    ],
+    [
+      "SSAVOP3_SSAVO3LAND5.2 DJ_OC",
+      "OPEN",
+      null
+    ],
+    [
+      "SSAVOP3_SSAVOP3-N1_DJ_F",
+      "OPEN",
+      null
+    ],
+    [
+      "SSAVOP3_SSAVOP3-SSAVO3TR311_DJ_F",
+      "OPEN",
+      null
+    ],
+    [
+      "SSAVOP3_SSAVO3TR311 DJ.HT_OC",
+      "OPEN",
+      null
+    ],
+    [
+      "SSAVOP3_SSAVOP3-N7_DJ_F",
+      "OPEN",
+      null
+    ],
+    [
+      "SSAVOP3_SSAVO3SEC.A23 SS.1A23_OC",
+      "OPEN",
+      null
+    ],
+    [
+      "SSAVOP3_SSAVO3PUTTE.1 DJ_OC",
+      "CLOSE",
+      null
+    ],
+    [
+      "SSAVOP3_SSAVO3BOULA.1 DJ_OC",
+      "CLOSE",
+      null
+    ],
+    [
+      "SSAVOP3_SSAVO3TR636 DJ_OC",
+      "CLOSE",
+      null
+    ],
+    [
+      "SSAVOP3_SSAVO3BETTI.1 DJ_OC",
+      "CLOSE",
+      null
+    ],
+    [
+      "SSAVOP3_SSAVO3LAND5.2 DJ_OC",
+      "CLOSE",
+      null
+    ],
+    [
+      "SSAVOP3_SSAVOP3-N1_DJ_F",
+      "CLOSE",
+      null
+    ],
+    [
+      "SSAVOP3_SSAVOP3-SSAVO3TR311_DJ_F",
+      "CLOSE",
+      null
+    ],
+    [
+      "SSAVOP3_SSAVO3TR311 DJ.HT_OC",
+      "CLOSE",
+      null
+    ],
+    [
+      "SSAVOP3_SSAVOP3-N7_DJ_F",
+      "CLOSE",
+      null
+    ],
+    [
+      "SSAVOP3_SSAVO3ANCER.1 DJ_OC",
+      "OPEN",
+      null
+    ],
+    [
+      "SSAVOP3_SSAVO3TR638 DJ_OC",
+      "OPEN",
+      null
+    ],
+    [
+      "SSAVOP3_SSAVO3LAND5.1 DJ_OC",
+      "OPEN",
+      null
+    ],
+    [
+      "SSAVOP3_SSAVO3SEC.A23 SS.2A23_OC",
+      "OPEN",
+      null
+    ],
+    [
+      "SSAVOP3_SSAVO3ANCER.1 DJ_OC",
+      "CLOSE",
+      null
+    ],
+    [
+      "SSAVOP3_SSAVO3TR638 DJ_OC",
+      "CLOSE",
+      null
+    ],
+    [
+      "SSAVOP3_SSAVO3LAND5.1 DJ_OC",
+      "CLOSE",
+      null
+    ],
+    [
+      "SSAVOP3_SSAVO3BETTI.1 DJ_OC",
+      "OPEN",
+      "LONGUE"
+    ],
+    [
+      "SSAVOP3_SSAVO3BETTI.1 SA.1_OC",
+      "OPEN",
+      "LONGUE"
+    ],
+    [
+      "SSAVOP3_SSAVO3BETTI.1 SA.2_OC",
+      "CLOSE",
+      "LONGUE"
+    ],
+    [
+      "SSAVOP3_SSAVO3BETTI.1 DJ_OC",
+      "CLOSE",
+      "LONGUE"
+    ],
+    [
+      "SSAVOP3_SSAVO3LAND5.1 DJ_OC",
+      "OPEN",
+      "LONGUE"
+    ],
+    [
+      "SSAVOP3_SSAVO3LAND5.1 SA.2_OC",
+      "OPEN",
+      "LONGUE"
+    ],
+    [
+      "SSAVOP3_SSAVO3LAND5.1 SA.1_OC",
+      "CLOSE",
+      "LONGUE"
+    ],
+    [
+      "SSAVOP3_SSAVO3LAND5.1 DJ_OC",
+      "CLOSE",
+      "LONGUE"
+    ],
+    [
+      "SSAVOP3_SSAVO3LAND5.2 DJ_OC",
+      "OPEN",
+      "LONGUE"
+    ],
+    [
+      "SSAVOP3_SSAVO3LAND5.2 SA.1_OC",
+      "OPEN",
+      "LONGUE"
+    ],
+    [
+      "SSAVOP3_SSAVO3LAND5.2 SA.2_OC",
+      "CLOSE",
+      "LONGUE"
+    ],
+    [
+      "SSAVOP3_SSAVO3LAND5.2 DJ_OC",
+      "CLOSE",
+      "LONGUE"
+    ],
+    [
+      "SSAVOP3_SSAVO3TR311 DJ.HT_OC",
+      "OPEN",
+      "LONGUE"
+    ],
+    [
+      "SSAVOP3_SSAVO3TR311 SA.1_OC",
+      "OPEN",
+      "LONGUE"
+    ],
+    [
+      "SSAVOP3_SSAVO3TR311 SA.2_OC",
+      "CLOSE",
+      "LONGUE"
+    ],
+    [
+      "SSAVOP3_SSAVO3TR311 DJ.HT_OC",
+      "CLOSE",
+      "LONGUE"
+    ]
+  ],
+  "mode": "smooth",
+  "n_manoeuvres": 62,
+  "noeuds_non_realisables": [],
+  "partition_obtenue": [
+    [
+      "ANCERL31SSAVO",
+      "BETTIL31SSAVO",
+      "LAND5L32SSAVO",
+      "SSAVO3TR311",
+      "SSAVOIN1",
+      "SSAVOIN7",
+      "SSAVOY638"
+    ],
+    [
+      "BOULAL31SSAVO",
+      "LAND5L31SSAVO",
+      "PUTTEL31SSAVO",
+      "SSAVOY636"
+    ],
+    [
+      "CARLIL31SSAVO",
+      "NORSOL31SSAVO",
+      "P.ROSL31SSAVO",
+      "SSAVOL31STEAM",
+      "SSAVOL31SYNTH",
+      "SSAVOL31ZCAR8",
+      "SSAVOL32SYNTH",
+      "SSAVOY637"
+    ],
+    [
+      "CREUTL31SSAVO",
+      "MERBEL31SSAVO",
+      "MERBEL32SSAVO",
+      "SSAVO3ATPOL",
+      "SSAVO3AUEH1",
+      "SSAVO3AUEH6",
+      "SSAVO3TR313",
+      "SSAVOIN3",
+      "SSAVOIN6",
+      "SSAVOL33SYNTH",
+      "SSAVOY634"
+    ],
+    [
+      "SSAVO3TR312",
+      "SSAVOIN2",
+      "SSAVOING"
+    ],
+    [
+      "SSAVOINF"
+    ]
+  ],
+  "voltage_level_id": "SSAVOP3"
+}

--- a/tests/manoeuvre/test_carrip3_3noeuds.py
+++ b/tests/manoeuvre/test_carrip3_3noeuds.py
@@ -293,7 +293,6 @@ def test_departs_du_3eme_noeud_en_boucle_longue():
     boucle longue, donc avec ouverture/fermeture de leur disjoncteur."""
     res = _run()
     longues = [m for m in res.manoeuvres if m.type_boucle == "LONGUE"]
-    eqs = {m.switch_id.split()[0] for m in longues}  # préfixe ~ cellule
     # Au moins un DJ ouvert puis refermé pour les départs du nœud 2
     opens = [m for m in longues if m.action == "OPEN" and "hors tension" in m.raison]
     closes = [m for m in longues if m.action == "CLOSE" and "sous tension" in m.raison]

--- a/tests/manoeuvre/test_couplers_memoisation.py
+++ b/tests/manoeuvre/test_couplers_memoisation.py
@@ -1,0 +1,168 @@
+"""
+tests/manoeuvre/test_couplers_memoisation.py
+----------------------------------------------
+**Filet de sécurité ciblé pour le refactor « mémoïsation de
+``_inter_sjb_couplers`` »** (#2).
+
+``_inter_sjb_couplers(poste)`` est aujourd'hui recalculé ~10× par analyse. #2
+le mémoïsera sur le ``PosteTopologique``. Trois **préconditions** rendent un tel
+cache correct ; ce module les fige (elles ne l'étaient pas) :
+
+1. **Invariance à l'état des organes** : le résultat ne dépend que de la
+   *topologie* du poste (graphe + tronçonnement), pas de l'état ouvert/fermé des
+   switches. Inverser tous les organes ne change pas les liaisons inter-SJB.
+   → c'est ce qui autorise à cacher sur le poste sans clé d'état.
+2. **Pureté** : l'appel ne mute pas le poste ; deux appels successifs renvoient
+   une structure identique (idempotence).
+3. **Non-mutation de ``poste.graph`` par le pipeline** : les points d'entrée
+   publics travaillent sur une *copie* du graphe ; ``poste.graph`` reste intact,
+   donc un résultat caché reste valide pendant toute l'analyse.
+
+Plus une caractérisation unitaire de la détection des **couplages parallèles**
+(MORBRP6 : ``COUPL.B`` masqué par la liaison ``SELF.1``), structure subtile que
+le cache devra reproduire à l'identique.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from expert_op4grid_recommender.manoeuvre.topologie import PosteTopologique
+from expert_op4grid_recommender.manoeuvre.algo import (
+    _inter_sjb_couplers,
+    determiner_manoeuvres_cible_detaillee,
+)
+
+from .fixture_loader import build_graph_from_fixture, list_available_fixtures
+
+SCEN_DIR = Path(__file__).parent / "scenarios"
+
+# Postes (≥ 2 jeux de barres) portant des liaisons inter-SJB à recenser.
+POSTES = ["CARRIP3", "CARRIP6", "CZTRYP6", "PALUNP3", "SSAVOP3", "MORBRP6"]
+
+
+def _available(postes):
+    fx = set(list_available_fixtures())
+    return [p for p in postes if p in fx]
+
+
+def _flip_all_switches(G):
+    """Inverse l'état ouvert/fermé de **tous** les switches réels (les internal
+    connections, ``switch_id`` None, restent fermées)."""
+    for _u, _v, d in G.edges(data=True):
+        if d.get("switch_id") is not None:
+            d["open"] = not d.get("open", False)
+    return G
+
+
+def _switch_state(G) -> dict:
+    return {d["switch_id"]: bool(d.get("open", False))
+            for _u, _v, d in G.edges(data=True) if d.get("switch_id")}
+
+
+def _canon_couplers(couplers) -> list[tuple]:
+    """Forme canonique, comparable et indépendante de l'ordre, d'une liste de
+    liaisons inter-SJB (gère les couplages parallèles via ``switch_ids``)."""
+    return sorted(
+        (cp.sjb_a, cp.sjb_b,
+         tuple(sorted(cp.switch_ids)), tuple(sorted(cp.breaker_ids)),
+         cp.is_sectionnement)
+        for cp in couplers
+    )
+
+
+@pytest.mark.parametrize("vl", _available(POSTES))
+def test_couplers_invariants_a_l_etat_des_organes(vl):
+    """Précondition #1 du cache : les liaisons inter-SJB ne dépendent QUE de la
+    topologie. Inverser tous les organes ne doit rien changer."""
+    poste_a = PosteTopologique.from_graph(build_graph_from_fixture(vl), vl)
+    poste_b = PosteTopologique.from_graph(
+        _flip_all_switches(build_graph_from_fixture(vl)), vl)
+
+    couplers_a = _canon_couplers(_inter_sjb_couplers(poste_a))
+    couplers_b = _canon_couplers(_inter_sjb_couplers(poste_b))
+
+    assert couplers_a == couplers_b, (
+        f"{vl}: les couplers dépendent de l'état des organes — "
+        "un cache sur le poste serait incorrect")
+
+
+@pytest.mark.parametrize("vl", _available(POSTES))
+def test_couplers_idempotents_et_purs(vl):
+    """Préconditions #2 : appel pur (ne mute pas le poste) et idempotent (deux
+    appels donnent la même structure)."""
+    poste = PosteTopologique.from_graph(build_graph_from_fixture(vl), vl)
+    avant = _switch_state(poste.graph)
+
+    c1 = _canon_couplers(_inter_sjb_couplers(poste))
+    c2 = _canon_couplers(_inter_sjb_couplers(poste))
+
+    assert c1 == c2, f"{vl}: _inter_sjb_couplers non idempotent"
+    assert _switch_state(poste.graph) == avant, \
+        f"{vl}: _inter_sjb_couplers a muté poste.graph"
+
+
+def test_couplers_paralleles_detectes_morbrp6():
+    """Caractérisation : MORBRP6 détecte le **couplage parallèle** ``COUPL.B``
+    (masqué par la liaison ``SELF.1``). Le cache devra reproduire cette
+    structure ; on pin sa présence au niveau unitaire."""
+    if "MORBRP6" not in list_available_fixtures():
+        pytest.skip("Fixture MORBRP6 absente")
+    poste = PosteTopologique.from_graph(
+        build_graph_from_fixture("MORBRP6"), "MORBRP6")
+    couplers = _inter_sjb_couplers(poste)
+
+    tous_sids = {sid for cp in couplers for sid in cp.switch_ids}
+    assert any("COUPL.B" in sid for sid in tous_sids), \
+        "le couplage parallèle COUPL.B n'est pas recensé"
+    # Au moins une paire de SJB reliée par ≥ 2 liaisons (parallélisme effectif).
+    from collections import Counter
+    paires = Counter((cp.sjb_a, cp.sjb_b) for cp in couplers)
+    assert any(n >= 2 for n in paires.values()), \
+        "aucune liaison parallèle détectée sur MORBRP6"
+
+
+# ---------------------------------------------------------------------------
+# Précondition #3 : le pipeline ne mute pas poste.graph
+# ---------------------------------------------------------------------------
+
+def _graph_from_states(vl: str, states: dict):
+    G = build_graph_from_fixture(vl)
+    for _u, _v, d in G.edges(data=True):
+        sid = d.get("switch_id")
+        if sid in states:
+            d["open"] = states[sid]
+    return G
+
+
+def _scenarios_pipeline():
+    names = ["CARRIP3_cible_3noeuds", "PALUNP3_cible_4noeuds",
+             "MORBRP6_cible_4noeuds"]
+    out = []
+    for n in names:
+        p = SCEN_DIR / f"{n}.json"
+        if p.exists():
+            out.append(p)
+    return out
+
+
+@pytest.mark.parametrize("path", _scenarios_pipeline(), ids=lambda p: p.stem)
+@pytest.mark.parametrize("mode", ["smooth", "aggressive"])
+def test_pipeline_ne_mute_pas_poste_graph(path, mode):
+    """Précondition #3 du cache : ``determiner_manoeuvres_cible_detaillee`` ne
+    doit pas altérer ``poste.graph`` (il travaille sur une copie). Un résultat de
+    ``_inter_sjb_couplers`` mémoïsé sur le poste reste donc valide tout du long."""
+    d = json.loads(path.read_text())
+    vl = d["voltage_level_id"]
+    if vl not in list_available_fixtures():
+        pytest.skip(f"Fixture {vl} absente")
+    poste = PosteTopologique.from_graph(_graph_from_states(vl, d["depart"]), vl)
+    cible_graph = _graph_from_states(vl, d["cible"])
+
+    avant = _switch_state(poste.graph)
+    determiner_manoeuvres_cible_detaillee(poste, cible_graph, mode=mode)
+    assert _switch_state(poste.graph) == avant, \
+        f"{path.stem}/{mode}: le pipeline a muté poste.graph"

--- a/tests/manoeuvre/test_golden_sequences.py
+++ b/tests/manoeuvre/test_golden_sequences.py
@@ -1,0 +1,157 @@
+"""
+tests/manoeuvre/test_golden_sequences.py
+------------------------------------------
+**Golden / test de caractérisation** du séquenceur (phase 2).
+
+But : figer le **comportement observable** de ``determiner_manoeuvres_cible_detaillee``
+sur tout le corpus de scénarios sauvegardés (``tests/manoeuvre/scenarios/*.json``),
+dans les deux modes (``smooth`` / ``aggressive``), afin de servir de **filet de
+sécurité aux refactors à iso-comportement** (indexation des lookups, passe de
+rejeu unique des vérificateurs…).
+
+Pour chaque (scénario, mode) on sérialise un instantané canonique
+``tests/manoeuvre/goldens/<scenario>__<mode>.golden.json`` :
+
+- ``manoeuvres`` : **séquence ordonnée exacte** ``[switch_id, action, type_boucle]``
+  (l'ordre est la propriété la plus fragile d'un refactor du séquenceur) ;
+- ``is_verified`` / ``is_verified_detaillee`` ;
+- ``ecarts`` : liste **ordonnée** des écarts détaillés résiduels ;
+- ``noeuds_non_realisables`` : **canonique** (trié) — dérivé d'ensembles ;
+- ``partition_obtenue`` : **canonique** (trié) — le regroupement est sémantique,
+  pas l'ordre ni le nom des nœuds.
+
+Régénération **consciente** après un changement de comportement assumé :
+
+    UPDATE_GOLDENS=1 pytest tests/manoeuvre/test_golden_sequences.py
+
+Déterminisme : la sortie a été vérifiée stable d'un process à l'autre
+(``PYTHONHASHSEED`` variable) ; les champs dérivés d'ensembles de chaînes sont
+néanmoins canonicalisés par prudence.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from expert_op4grid_recommender.manoeuvre.topologie import PosteTopologique
+from expert_op4grid_recommender.manoeuvre.algo import (
+    determiner_manoeuvres_cible_detaillee,
+)
+
+from .fixture_loader import build_graph_from_fixture, list_available_fixtures
+
+SCEN_DIR = Path(__file__).parent / "scenarios"
+GOLDEN_DIR = Path(__file__).parent / "goldens"
+MODES = ("smooth", "aggressive")
+
+_UPDATE = os.environ.get("UPDATE_GOLDENS") == "1"
+
+
+def _scenarios() -> list[Path]:
+    if not SCEN_DIR.exists():
+        return []
+    return sorted(SCEN_DIR.glob("*.json"))
+
+
+pytestmark = pytest.mark.skipif(
+    not _scenarios(), reason="Aucun scénario sauvegardé.")
+
+
+def _graph_from_states(vl: str, states: dict):
+    """Graphe de fixture avec les états d'organes du scénario appliqués."""
+    G = build_graph_from_fixture(vl)
+    for _u, _v, d in G.edges(data=True):
+        sid = d.get("switch_id")
+        if sid in states:
+            d["open"] = states[sid]
+    return G
+
+
+def _canon_groups(groups) -> list[list[str]]:
+    """Forme canonique (triée) d'une collection de groupes d'équipements."""
+    return sorted(sorted(g) for g in groups)
+
+
+def _snapshot(path: Path, mode: str) -> dict:
+    d = json.loads(path.read_text())
+    vl = d["voltage_level_id"]
+    poste = PosteTopologique.from_graph(_graph_from_states(vl, d["depart"]), vl)
+    cible_graph = _graph_from_states(vl, d["cible"])
+    res = determiner_manoeuvres_cible_detaillee(poste, cible_graph, mode=mode)
+
+    partition = (sorted(sorted(grp) for grp in res.topo_obtenue.partition())
+                 if res.topo_obtenue is not None else [])
+    return {
+        "voltage_level_id": vl,
+        "mode": mode,
+        "n_manoeuvres": res.nb_manoeuvres,
+        "manoeuvres": [[m.switch_id, m.action, m.type_boucle]
+                       for m in res.manoeuvres],
+        "is_verified": bool(res.is_verified),
+        "is_verified_detaillee": bool(res.is_verified_detaillee),
+        "ecarts": list(res.ecarts),
+        "noeuds_non_realisables": _canon_groups(res.noeuds_non_realisables),
+        "partition_obtenue": partition,
+    }
+
+
+def _dump(snapshot: dict) -> str:
+    return json.dumps(snapshot, indent=2, ensure_ascii=False, sort_keys=True) + "\n"
+
+
+def _cases() -> list[tuple[Path, str]]:
+    return [(p, mode) for p in _scenarios() for mode in MODES]
+
+
+@pytest.mark.parametrize(
+    "path,mode", _cases(),
+    ids=lambda v: (v.stem if isinstance(v, Path) else v),
+)
+def test_golden_sequence(path: Path, mode: str):
+    """La séquence produite (et l'état de vérification) doit correspondre, octet
+    pour octet, au golden versionné. Une divergence signale soit une régression
+    d'un refactor censé être à iso-comportement, soit un changement de
+    comportement à valider (régénérer avec ``UPDATE_GOLDENS=1``)."""
+    vl = json.loads(path.read_text())["voltage_level_id"]
+    if vl not in list_available_fixtures():
+        pytest.skip(f"Fixture {vl} absente")
+    # Les organes du scénario doivent exister dans la fixture.
+    known = {dd.get("switch_id")
+             for _u, _v, dd in build_graph_from_fixture(vl).edges(data=True)}
+    depart = json.loads(path.read_text())["depart"]
+    if not set(depart) <= known:
+        pytest.skip(f"Organes du scénario absents de la fixture {vl}")
+
+    snap = _snapshot(path, mode)
+    golden_path = GOLDEN_DIR / f"{path.stem}__{mode}.golden.json"
+
+    if _UPDATE:
+        GOLDEN_DIR.mkdir(parents=True, exist_ok=True)
+        golden_path.write_text(_dump(snap))
+
+    assert golden_path.exists(), (
+        f"Golden absent : {golden_path.name}. "
+        "Le générer avec : UPDATE_GOLDENS=1 pytest "
+        "tests/manoeuvre/test_golden_sequences.py")
+
+    expected = json.loads(golden_path.read_text())
+    # Round-trip JSON pour comparer des types homogènes (tuples -> listes).
+    snap = json.loads(json.dumps(snap))
+
+    if snap != expected:
+        diffs = [k for k in set(snap) | set(expected)
+                 if snap.get(k) != expected.get(k)]
+        msg = [f"Divergence golden {golden_path.name} — champs: {sorted(diffs)}"]
+        if "manoeuvres" in diffs:
+            cur, old = snap["manoeuvres"], expected["manoeuvres"]
+            msg.append(f"  manoeuvres: {len(cur)} obtenue(s) vs {len(old)} golden")
+            for i in range(min(len(cur), len(old))):
+                if cur[i] != old[i]:
+                    msg.append(f"  1ère divergence idx {i}: "
+                               f"obtenu={cur[i]} golden={old[i]}")
+                    break
+        assert snap == expected, "\n".join(msg)

--- a/tests/manoeuvre/test_graph_cellules.py
+++ b/tests/manoeuvre/test_graph_cellules.py
@@ -39,8 +39,6 @@ from expert_op4grid_recommender.manoeuvre.graph import (
 from expert_op4grid_recommender.manoeuvre.cellules import (
     detecter_cellules,
     calculer_connected_busbars,
-    CelluleDepart,
-    CelluleCouplage,
 )
 from expert_op4grid_recommender.manoeuvre.models import (
     NodeType,

--- a/tests/manoeuvre/test_lookup_helpers.py
+++ b/tests/manoeuvre/test_lookup_helpers.py
@@ -1,0 +1,192 @@
+"""
+tests/manoeuvre/test_lookup_helpers.py
+----------------------------------------
+**Filet de sécurité ciblé pour le refactor « indexation des lookups »** (#1).
+
+``_is_open`` / ``_set_switch`` / ``_eq_node`` retrouvent aujourd'hui un organe
+ou un nœud par **scan linéaire** du graphe. #1 remplacera ces scans par un
+index ``switch_id -> arête`` / ``equipment_id -> nœud`` porté par le poste.
+
+Ces tests **figent le contrat observable** que l'index devra reproduire :
+
+1. **Comportement sur identifiant inconnu** (mode d'échec actuel, *silencieux*) :
+   ``_is_open`` → ``True`` (considéré ouvert) ; ``_set_switch`` → no-op sans
+   exception ; ``_eq_node`` → ``None``.
+   ⚠ Si #1 choisit de **durcir** ce contrat (lever ``KeyError`` sur id inconnu),
+   ces trois tests doivent être mis à jour **consciemment** — c'est le but.
+2. **Validité sur graphe dérivé** : l'index sera construit sur ``poste.graph``
+   mais utilisé sur des **copies** (``poste.graph.copy()``, postes virtuels).
+   Les coordonnées topologiques (nœuds, arêtes) sont stables par copie : les
+   lookups doivent rester corrects, et muter une copie ne doit pas toucher
+   l'original.
+3. **Invariant d'intégrité** : tout ``switch_id`` émis dans une séquence existe
+   réellement comme arête (sinon ``_set_switch`` no-op silencieusement et la
+   séquence est faussée sans bruit).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from expert_op4grid_recommender.manoeuvre.topologie import (
+    PosteTopologique,
+    TopologieNodale,
+)
+from expert_op4grid_recommender.manoeuvre.algo import (
+    determiner_topo_complete_cible,
+    _is_open,
+    _set_switch,
+    _eq_node,
+)
+
+from .fixture_loader import build_graph_from_fixture, list_available_fixtures
+
+VL = "CARRIP3"
+
+pytestmark = pytest.mark.skipif(
+    VL not in list_available_fixtures(), reason="Fixture CARRIP3 absente.")
+
+
+def _graph():
+    return build_graph_from_fixture(VL)
+
+
+def _switch_ids(G) -> list[str]:
+    return [d["switch_id"] for _u, _v, d in G.edges(data=True)
+            if d.get("switch_id")]
+
+
+def _equipment_ids(G) -> list[str]:
+    return [d["equipment_id"] for _n, d in G.nodes(data=True)
+            if d.get("equipment_id")]
+
+
+# ---------------------------------------------------------------------------
+# 1. Contrat sur identifiant inconnu (mode d'échec actuel, à figer)
+# ---------------------------------------------------------------------------
+
+def test_is_open_unknown_id_returns_true():
+    """Contrat actuel : un organe inconnu est considéré **ouvert**."""
+    G = _graph()
+    assert _is_open(G, "ORGANE_INEXISTANT") is True
+
+
+def test_set_switch_unknown_id_is_silent_noop():
+    """Contrat actuel : ``_set_switch`` sur id inconnu ne lève pas et ne modifie
+    **rien** (no-op silencieux). #1 peut choisir de durcir ce contrat — auquel
+    cas ce test devra être actualisé sciemment."""
+    G = _graph()
+    before = {d["switch_id"]: d["open"]
+              for _u, _v, d in G.edges(data=True) if d.get("switch_id")}
+    _set_switch(G, "ORGANE_INEXISTANT", True)   # ne doit pas lever
+    after = {d["switch_id"]: d["open"]
+             for _u, _v, d in G.edges(data=True) if d.get("switch_id")}
+    assert after == before
+
+
+def test_eq_node_unknown_returns_none():
+    G = _graph()
+    assert _eq_node(G, "EQUIPEMENT_INEXISTANT") is None
+
+
+# ---------------------------------------------------------------------------
+# 2. Lookups corrects pour des identifiants réels
+# ---------------------------------------------------------------------------
+
+def test_is_open_reflects_state():
+    """``_is_open`` reflète l'état stocké sur l'arête, dans les deux sens."""
+    G = _graph()
+    sid = _switch_ids(G)[0]
+    _set_switch(G, sid, True)
+    assert _is_open(G, sid) is True
+    _set_switch(G, sid, False)
+    assert _is_open(G, sid) is False
+
+
+def test_set_switch_toggles_known_id():
+    G = _graph()
+    sid = _switch_ids(G)[0]
+    _set_switch(G, sid, True)
+    assert _is_open(G, sid) is True
+
+
+def test_eq_node_finds_equipment():
+    G = _graph()
+    eq = _equipment_ids(G)[0]
+    node = _eq_node(G, eq)
+    assert node is not None
+    assert G.nodes[node].get("equipment_id") == eq
+
+
+# ---------------------------------------------------------------------------
+# 3. Validité sur graphe dérivé (copie)
+# ---------------------------------------------------------------------------
+
+def test_lookups_valides_sur_copie_et_original_intact():
+    """Muter une **copie** via ``_set_switch`` n'affecte pas l'original, et les
+    lookups restent corrects sur la copie (coordonnées topologiques stables)."""
+    G = _graph()
+    sid = _switch_ids(G)[0]
+    _set_switch(G, sid, False)            # état connu sur l'original
+    H = G.copy()
+    _set_switch(H, sid, True)             # on ne touche que la copie
+    assert _is_open(H, sid) is True
+    assert _is_open(G, sid) is False, "la copie ne doit pas affecter l'original"
+    # equipment_id -> node reste valide sur la copie
+    eq = _equipment_ids(G)[0]
+    assert _eq_node(H, eq) == _eq_node(G, eq)
+
+
+# ---------------------------------------------------------------------------
+# 4. Invariant d'intégrité : tout switch_id émis existe
+# ---------------------------------------------------------------------------
+
+def _cible_fusion_un_noeud(poste):
+    """Cible 1 nœud (départs connectés fusionnés) — produit une séquence non
+    triviale de ré-aiguillages et de manœuvres de couplage."""
+    connectes, isoles = [], []
+    for noeud in poste.topologie_nodale.noeuds.values():
+        ids = sorted(noeud.equipment_ids)
+        (connectes if len(ids) > 1 else isoles).append(ids)
+    groupes = [sorted(sum(connectes, []))] + isoles
+    return TopologieNodale.from_node_groups(poste.voltage_level_id, groupes)
+
+
+def test_sequence_switch_ids_existent_tous():
+    """Tout ``switch_id`` d'une séquence produite correspond à une arête réelle
+    (garde-fou contre le no-op silencieux de ``_set_switch``)."""
+    G = _graph()
+    # Couplage ouvert au départ -> ≥ 2 nœuds, fusion non triviale ensuite.
+    _set_switch(G, "CARRIP3_CARRI3COUPL.1 DJ_OC", True)
+    poste = PosteTopologique.from_graph(G, VL)
+    res = determiner_topo_complete_cible(poste, _cible_fusion_un_noeud(poste))
+
+    assert res.manoeuvres, "séquence attendue non vide"
+    valides = set(_switch_ids(poste.graph))
+    inconnus = sorted({m.switch_id for m in res.manoeuvres} - valides)
+    assert not inconnus, f"switch_id émis sans arête correspondante : {inconnus}"
+
+
+def test_rejeu_sur_copie_est_reproductible():
+    """Rejouer la séquence sur une **copie** du graphe est déterministe et
+    laisse l'original intact."""
+    G = _graph()
+    _set_switch(G, "CARRIP3_CARRI3COUPL.1 DJ_OC", True)
+    poste = PosteTopologique.from_graph(G, VL)
+    res = determiner_topo_complete_cible(poste, _cible_fusion_un_noeud(poste))
+
+    def rejouer():
+        H = poste.graph.copy()
+        for m in res.manoeuvres:
+            _set_switch(H, m.switch_id, m.action == "OPEN")
+        return {d["switch_id"]: d["open"]
+                for _u, _v, d in H.edges(data=True) if d.get("switch_id")}
+
+    etat_initial = {d["switch_id"]: d["open"]
+                    for _u, _v, d in poste.graph.edges(data=True)
+                    if d.get("switch_id")}
+    assert rejouer() == rejouer()                      # déterministe
+    # L'original n'a pas bougé pendant les rejeux sur copie.
+    assert {d["switch_id"]: d["open"]
+            for _u, _v, d in poste.graph.edges(data=True)
+            if d.get("switch_id")} == etat_initial

--- a/tests/manoeuvre/test_postes_reels.py
+++ b/tests/manoeuvre/test_postes_reels.py
@@ -34,30 +34,24 @@ Usage :
 
 from __future__ import annotations
 
-import json
 import logging
-from pathlib import Path
 
 import networkx as nx
 import pytest
 
 from expert_op4grid_recommender.manoeuvre.models import (
     NodeType,
-    EquipmentType,
     SwitchKind,
 )
 from expert_op4grid_recommender.manoeuvre.graph import busbar_nodes, equipment_nodes
 from expert_op4grid_recommender.manoeuvre.cellules import (
     detecter_cellules,
     calculer_connected_busbars,
-    CellulesVL,
 )
 
 from .fixture_loader import (
-    FIXTURES_DIR,
     list_available_fixtures,
     load_fixture_index,
-    load_fixture_json,
     build_graph_from_fixture,
     get_fixture_metadata,
 )

--- a/tests/manoeuvre/test_refacto_invariants.py
+++ b/tests/manoeuvre/test_refacto_invariants.py
@@ -1,0 +1,164 @@
+"""
+tests/manoeuvre/test_refacto_invariants.py
+--------------------------------------------
+Couverture des **invariants introduits par la campagne d'optimisation**
+(cf. ``docs/manoeuvre_optimisations.md``). Complète les filets T1–T4 en pinnant
+directement, au niveau unitaire, les propriétés sur lesquelles repose
+l'iso-comportement des refactors :
+
+- **P1+** : ``_assignations_connexes`` énumère **exactement** le même ensemble
+  d'affectations que ``itertools.product`` filtré sur « groupes non vides et
+  connexes » — c'est ce qui garantit le même coût minimal (donc, avec le
+  tie-break lex-min, la même sortie).
+- **Q1** : ``disconnectors_vers_barre`` est mémoïsé et **structurel** (invariant
+  à l'état des organes) ; ``_edges_of_switches`` passe par l'index.
+- **#3** : ``_verifier_regles`` est exactement la concaténation des
+  vérificateurs individuels.
+"""
+
+from __future__ import annotations
+
+import itertools
+
+import networkx as nx
+import pytest
+
+from expert_op4grid_recommender.manoeuvre.topologie import (
+    PosteTopologique,
+    TopologieNodale,
+)
+from expert_op4grid_recommender.manoeuvre.algo import (
+    _assignations_connexes,
+    _edges_of_switches,
+    _verifier_regles,
+    _verifier_securite_sectionneurs,
+    _verifier_un_seul_hors_tension,
+    _verifier_sectionneurs_hors_charge,
+    determiner_topo_complete_cible,
+)
+
+from .fixture_loader import build_graph_from_fixture, list_available_fixtures
+
+VL = "CARRIP3"
+
+
+# ---------------------------------------------------------------------------
+# P1+ — équivalence du générateur de partitions connexes
+# ---------------------------------------------------------------------------
+
+def _product_filtre(sjb_nodes, k, CG):
+    """Référence : affectations de ``product`` à k groupes **tous non vides et
+    connexes** (l'ensemble que l'ancien code parcourait avant filtrage)."""
+    ref = set()
+    for assign in itertools.product(range(k), repeat=len(sjb_nodes)):
+        groups: dict[int, set[int]] = {}
+        for j, ni in enumerate(assign):
+            groups.setdefault(ni, set()).add(sjb_nodes[j])
+        if len(groups) != k:
+            continue  # au moins un nœud vide
+        if all(nx.is_connected(CG.subgraph(g)) for g in groups.values()):
+            ref.add(assign)
+    return ref
+
+
+@pytest.mark.parametrize("edges", [
+    [(0, 1), (1, 2), (2, 3)],            # barre à 4 sections (chaîne)
+    [(0, 1), (2, 3), (0, 2)],            # 2 barres × 2 sections + couplage
+    [(0, 1), (1, 2), (0, 2), (2, 3)],    # cycle + antenne
+])
+def test_assignations_connexes_equivaut_au_filtre_product(edges):
+    """``_assignations_connexes`` génère **exactement** l'ensemble des
+    affectations à groupes connexes (ni plus, ni moins, sans doublon)."""
+    sjb = sorted({n for e in edges for n in e})
+    CG = nx.Graph()
+    CG.add_nodes_from(sjb)
+    CG.add_edges_from(edges)
+
+    def conn(fs):
+        return bool(fs) and nx.is_connected(CG.subgraph(fs))
+
+    for k in range(1, len(sjb) + 1):
+        produit = list(_assignations_connexes(sjb, k, conn))
+        assert len(produit) == len(set(produit)), f"k={k}: doublons générés"
+        assert set(produit) == _product_filtre(sjb, k, CG), \
+            f"k={k}: ensemble de candidats différent de product filtré"
+
+
+# ---------------------------------------------------------------------------
+# Q1 — mémoïsation des chemins SA (structurels, invariants à l'état)
+# ---------------------------------------------------------------------------
+
+pytestmark_carrip3 = pytest.mark.skipif(
+    VL not in list_available_fixtures(), reason="Fixture CARRIP3 absente.")
+
+
+@pytestmark_carrip3
+def test_disconnectors_vers_barre_memoise():
+    """Deux appels renvoient le **même objet** (mémoïsation effective)."""
+    poste = PosteTopologique.from_graph(build_graph_from_fixture(VL), VL)
+    cell = next(c for c in poste.cellules.cellules_depart if c.busbar_nodes)
+    bb = next(iter(cell.busbar_nodes))
+    assert cell.disconnectors_vers_barre(bb) is cell.disconnectors_vers_barre(bb)
+
+
+@pytestmark_carrip3
+def test_disconnectors_vers_barre_invariant_a_l_etat():
+    """Le chemin SA (switch_ids) est **structurel** : inverser l'état de tous
+    les organes ne le change pas."""
+    poste = PosteTopologique.from_graph(build_graph_from_fixture(VL), VL)
+    cell = next(c for c in poste.cellules.cellules_depart if c.busbar_nodes)
+    bb = next(iter(cell.busbar_nodes))
+    ref = [s.switch_id for s in cell.disconnectors_vers_barre(bb)]
+
+    G2 = build_graph_from_fixture(VL)
+    for _u, _v, d in G2.edges(data=True):
+        if d.get("switch_id"):
+            d["open"] = not d.get("open", False)
+    poste2 = PosteTopologique.from_graph(G2, VL)
+    cell2 = poste2.cellules.get_cellule_depart(cell.equipment_id)
+    # même nœud SJB (les ids de nœuds sont stables entre deux constructions)
+    got = [s.switch_id for s in cell2.disconnectors_vers_barre(bb)]
+    assert got == ref
+
+
+@pytestmark_carrip3
+def test_edges_of_switches_via_index():
+    """``_edges_of_switches`` rend les bonnes arêtes (par l'index) et **omet**
+    les ids inconnus."""
+    G = build_graph_from_fixture(VL)
+    sids = [d["switch_id"] for _u, _v, d in G.edges(data=True)
+            if d.get("switch_id")][:5]
+    edges = _edges_of_switches(G, sids)
+    assert {G.edges[u, v]["switch_id"] for u, v in edges} == set(sids)
+    assert _edges_of_switches(G, ["ORGANE_INEXISTANT"]) == []
+
+
+# ---------------------------------------------------------------------------
+# #3 — _verifier_regles == concaténation des vérificateurs individuels
+# ---------------------------------------------------------------------------
+
+@pytestmark_carrip3
+def test_verifier_regles_egale_somme_des_verificateurs():
+    """L'agrégateur à passe unique reproduit exactement la concaténation
+    historique : sécurité + [un seul HS] + hors charge."""
+    G = build_graph_from_fixture(VL)
+    # Couplage ouvert -> ≥ 2 nœuds ; cible = fusion en 1 nœud (séquence riche).
+    for _u, _v, d in G.edges(data=True):
+        if d.get("switch_id") == "CARRIP3_CARRI3COUPL.1 DJ_OC":
+            d["open"] = True
+    poste = PosteTopologique.from_graph(G, VL)
+    connectes, isoles = [], []
+    for noeud in poste.topologie_nodale.noeuds.values():
+        ids = sorted(noeud.equipment_ids)
+        (connectes if len(ids) > 1 else isoles).append(ids)
+    cible = TopologieNodale.from_node_groups(VL, [sorted(sum(connectes, []))] + isoles)
+    manos = determiner_topo_complete_cible(poste, cible).manoeuvres
+
+    attendu_avec = (_verifier_securite_sectionneurs(poste, manos)
+                    + _verifier_un_seul_hors_tension(poste, manos)
+                    + _verifier_sectionneurs_hors_charge(poste, manos))
+    assert _verifier_regles(poste, manos, un_seul=True) == attendu_avec
+
+    attendu_sans = (_verifier_securite_sectionneurs(poste, manos)
+                    + _verifier_sectionneurs_hors_charge(poste, manos))
+    assert _verifier_regles(poste, manos, un_seul=False) == attendu_sans

--- a/tests/manoeuvre/test_topologie.py
+++ b/tests/manoeuvre/test_topologie.py
@@ -11,7 +11,6 @@ import pytest
 from expert_op4grid_recommender.manoeuvre.topologie import (
     TopologieNodale,
     PosteTopologique,
-    attribuer_noeuds,
 )
 
 from .fixture_loader import build_graph_from_fixture, list_available_fixtures

--- a/tests/manoeuvre/test_verificateurs_exact.py
+++ b/tests/manoeuvre/test_verificateurs_exact.py
@@ -1,0 +1,163 @@
+"""
+tests/manoeuvre/test_verificateurs_exact.py
+---------------------------------------------
+**Filet de sécurité ciblé pour le refactor « passe de rejeu unique »** (#3).
+
+Les vérificateurs de règles (``_sectionneurs_sous_charge_par_manoeuvre``,
+``_verifier_sectionneurs_hors_charge``) rejouent aujourd'hui la séquence
+chacun de leur côté. Un refactor qui les fusionne en **une seule passe** doit
+préserver, exactement :
+
+1. l'**alignement** de la liste « par manœuvre » sur la séquence (même longueur) ;
+2. les **positions exactes** des infractions (et leur identité d'organe) ;
+3. la **liste d'écarts dédupliquée** (mêmes organes, même ordre, sans doublon) ;
+4. l'**idempotence** (rejouer deux fois donne le même résultat) ;
+5. la **non-mutation** du graphe du poste (les vérificateurs travaillent sur une
+   copie ; ils ne doivent pas altérer ``poste.graph``).
+
+Contrairement au golden (qui fige la sortie de bout en bout), ces tests
+attaquent **directement** les fonctions que #3 va réécrire, avec des assertions
+d'égalité de liste **structurelles** (identité d'organe + violé/non-violé),
+robustes au libellé exact des messages.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from expert_op4grid_recommender.manoeuvre.topologie import PosteTopologique
+from expert_op4grid_recommender.manoeuvre.algo import (
+    Manoeuvre,
+    _sectionneurs_sous_charge_par_manoeuvre,
+    _verifier_sectionneurs_hors_charge,
+)
+
+from .fixture_loader import build_graph_from_fixture, list_available_fixtures
+
+SEQ_DIR = Path(__file__).parent / "sequences"
+
+
+def _graph_from_states(vl: str, states: dict):
+    G = build_graph_from_fixture(vl)
+    for _u, _v, d in G.edges(data=True):
+        sid = d.get("switch_id")
+        if sid in states:
+            d["open"] = states[sid]
+    return G
+
+
+def _switch_state(G) -> dict:
+    return {d["switch_id"]: d.get("open", False)
+            for _u, _v, d in G.edges(data=True) if d.get("switch_id")}
+
+
+def _load(name: str):
+    path = SEQ_DIR / name
+    if not path.exists():
+        pytest.skip(f"Séquence absente : {name}")
+    d = json.loads(path.read_text())
+    vl = d["voltage_level_id"]
+    if vl not in list_available_fixtures():
+        pytest.skip(f"Fixture {vl} absente")
+    poste = PosteTopologique.from_graph(_graph_from_states(vl, d["depart"]), vl)
+    manos = [Manoeuvre(m["switch_id"], m["action"], m.get("raison", ""))
+             for m in d["manoeuvres"]]
+    return poste, manos
+
+
+def _offending_switches(ecarts: list[str]) -> list[str]:
+    """Identifiant d'organe en tête de chaque écart « <sid> : <message> »."""
+    return [e.split(" : ", 1)[0] for e in ecarts]
+
+
+# Vérité-terrain (cf. fixtures de séquences « fautives ») : une seule infraction,
+# en dernière position, sur un sélecteur de barre de départ.
+BAD_SEQUENCES = [
+    ("MORBRP6_cible_4noeuds_mauvaise_manoeuvre.json",
+     [3], "MORBRP6_MORBR6AT761 SA.1_OC"),
+    ("MORBRP6_cible_4noeuds_wrong_last_step.json",
+     [7], "MORBRP6_MORBR6ARRIG.1 SA.1_OC"),
+]
+
+
+@pytest.mark.parametrize("name,viol_idx,sid", BAD_SEQUENCES,
+                         ids=lambda v: v if isinstance(v, str) else "")
+def test_par_manoeuvre_alignement_et_indices_exacts(name, viol_idx, sid):
+    """``par_man`` est **aligné** sur la séquence et les infractions tombent aux
+    **positions exactes** attendues (égalité de liste structurelle)."""
+    poste, manos = _load(name)
+    par_man = _sectionneurs_sous_charge_par_manoeuvre(poste, manos)
+
+    assert len(par_man) == len(manos), "liste non alignée sur la séquence"
+    assert [i for i, v in enumerate(par_man) if v is not None] == viol_idx
+    # L'organe fautif est bien celui de la manœuvre incriminée.
+    for i in viol_idx:
+        assert manos[i].switch_id == sid
+        assert "disjoncteur" in par_man[i]  # parade « par son disjoncteur »
+
+
+@pytest.mark.parametrize("name,viol_idx,sid", BAD_SEQUENCES,
+                         ids=lambda v: v if isinstance(v, str) else "")
+def test_ecarts_hors_charge_liste_exacte(name, viol_idx, sid):
+    """``_verifier_sectionneurs_hors_charge`` renvoie **exactement** la liste des
+    organes fautifs (identité + nombre), dédupliquée."""
+    poste, manos = _load(name)
+    ecarts = _verifier_sectionneurs_hors_charge(poste, manos)
+
+    assert _offending_switches(ecarts) == [sid]
+    assert len(ecarts) == len(set(ecarts)), "écarts non dédupliqués"
+
+
+@pytest.mark.parametrize("name,viol_idx,sid", BAD_SEQUENCES,
+                         ids=lambda v: v if isinstance(v, str) else "")
+def test_verificateurs_idempotents(name, viol_idx, sid):
+    """Rejouer deux fois les vérificateurs sur le même couple (poste, séquence)
+    donne un résultat **identique** (pas d'état partagé entre passes — invariant
+    à préserver si #3 fusionne les rejeux)."""
+    poste, manos = _load(name)
+    a1 = _sectionneurs_sous_charge_par_manoeuvre(poste, manos)
+    a2 = _sectionneurs_sous_charge_par_manoeuvre(poste, manos)
+    assert a1 == a2
+    b1 = _verifier_sectionneurs_hors_charge(poste, manos)
+    b2 = _verifier_sectionneurs_hors_charge(poste, manos)
+    assert b1 == b2
+
+
+@pytest.mark.parametrize("name,viol_idx,sid", BAD_SEQUENCES,
+                         ids=lambda v: v if isinstance(v, str) else "")
+def test_verificateurs_ne_mutent_pas_le_graphe(name, viol_idx, sid):
+    """Les vérificateurs travaillent sur une **copie** : ``poste.graph`` doit
+    rester intact (une passe fusionnée ne doit pas muter l'état partagé)."""
+    poste, manos = _load(name)
+    avant = _switch_state(poste.graph)
+    _sectionneurs_sous_charge_par_manoeuvre(poste, manos)
+    _verifier_sectionneurs_hors_charge(poste, manos)
+    assert _switch_state(poste.graph) == avant
+
+
+def test_message_parade_selon_type_de_sectionneur():
+    """La parade dépend du type d'organe : **sectionnement de barre** → « section
+    de barre » ; **sélecteur de barre de départ** → « par son disjoncteur ».
+    Invariant métier que #3 ne doit pas brouiller en fusionnant les passes."""
+    # Sélecteur de barre de départ (séquence fautive MORBRP6).
+    poste, manos = _load("MORBRP6_cible_4noeuds_mauvaise_manoeuvre.json")
+    msg_depart = next(m for m in _sectionneurs_sous_charge_par_manoeuvre(poste, manos)
+                      if m is not None)
+    assert "disjoncteur" in msg_depart and "section de barre" not in msg_depart
+
+    # Sectionnement de barre (CZBEVP3, sectionneur de section SS.1.12).
+    VL = "CZBEVP3"
+    if VL not in list_available_fixtures():
+        pytest.skip("Fixture CZBEVP3 absente")
+    G = build_graph_from_fixture(VL)
+    sid = "CZBEVP3_CZBEV3CBO.1 SS.1.12_OC"
+    if not any(d.get("switch_id") == sid for _u, _v, d in G.edges(data=True)):
+        pytest.skip("Sectionneur de section CZBEVP3 absent de la fixture")
+    poste = PosteTopologique.from_graph(G, VL)
+    msgs = _sectionneurs_sous_charge_par_manoeuvre(
+        poste, [Manoeuvre(sid, "OPEN", "manœuvre manuelle (expert)")])
+    assert msgs[0] is not None and "section de barre" in msgs[0]
+    assert "disjoncteur" not in msgs[0]


### PR DESCRIPTION
## Summary

This PR implements a comprehensive optimization and refactoring campaign for the `manoeuvre` module, improving performance and code quality through:
- **Indexing lookups** (switch_id → edge, equipment_id → node) to replace O(n) scans
- **Memoization** of structural computations (`_inter_sjb_couplers`, `disconnectors_vers_barre`)
- **Unified verification pass** consolidating three separate rule checkers into one
- **Algorithmic improvements** for SJB placement (connected partition enumeration)
- **Comprehensive test coverage** with golden tests and regression filets

## Key Changes

### Core Algorithm Improvements
- **`_assignations_connexes()`**: New generator for SJB→node assignments that enumerates only valid (non-empty, connected) partitions, replacing filtered `itertools.product()` — guarantees identical cost-minimal solutions with better performance
- **`_edges_of_switches()`**: Refactored to use O(1) index lookup instead of O(n) graph scan
- **`_verifier_regles()`**: Unified verification function consolidating `_verifier_securite_sectionneurs()`, `_verifier_un_seul_hors_tension()`, and `_verifier_sectionneurs_hors_charge()` into a single pass with `un_seul` parameter

### Performance Optimizations
- Added module-level constants for placement search parameters:
  - `POIDS_REAIGUILLAGE`, `POIDS_MANOEUVRE_COUPLER`, `POIDS_OUVERTURE_SECTIONNEMENT` (cost weights)
  - `MAX_COMBINAISONS_PLACEMENT`, `MAX_COMBINAISONS_BEST_EFFORT` (combinatorial guards)
- Memoization infrastructure for structural computations (prepared for caching on `PosteTopologique`)
- Removed unused import of `Troncon` class

### Code Quality & Maintainability
- Consolidated imports (`itertools`, `Counter`) at module level
- Improved docstrings with French technical documentation
- Removed redundant local imports (e.g., `Counter` from `_organes_internes_2bornes()`)
- Cleaned up unused imports across related modules (`cellules.py`, `topologie.py`, `models.py`, `troncons.py`)

### Test Infrastructure
Added comprehensive regression test suite (4 new test modules, 20+ golden JSON files):

1. **`test_golden_sequences.py`**: Golden tests for `determiner_manoeuvres_cible_detaillee()` across 10+ scenarios in both `smooth` and `aggressive` modes — filet de sécurité for iso-behavior refactors
2. **`test_lookup_helpers.py`**: Validates `_is_open()`, `_set_switch()`, `_eq_node()` behavior on unknown IDs and derived graphs
3. **`test_couplers_memoisation.py`**: Ensures `_inter_sjb_couplers()` is pure, invariant to switch state, and non-mutating
4. **`test_refacto_invariants.py`**: Pins invariants for partition enumeration (P1+), edge indexing (Q1), and unified verification (#3)
5. **`test_verificateurs_exact.py`**: Validates exact alignment and deduplication of rule violations across verification passes

Golden files cover:
- CARRIP3, CARRIP6, CZBEVP3, CZTRYP6, MORBRP6, NOVIOP3, PALUNP3, SSAVOP3, BXTO5P3
- Multiple target topologies (1–4 nodes, non-attainable scenarios)
- Both modes (smooth/aggressive)

### Documentation
- **`docs/manoeuvre_optimisations.md`**: Comprehensive report on the optimization campaign, including diagnostic, refactors, measured gains, and filet methodology
- Updated **`CLAUDE.md`** with regression test suite description

### CI/CD
- Added `quality` job to `.circleci/config

https://claude.ai/code/session_01HupsCXFXjJNXnFgsHpGoCJ