### PR TITLE
Fix prioritization: honor per-type MIN_* floors above n_action_max + …

### DIFF
--- a/expert_op4grid_recommender/action_evaluation/discovery/_orchestrator.py
+++ b/expert_op4grid_recommender/action_evaluation/discovery/_orchestrator.py
@@ -202,23 +202,44 @@ class OrchestratorMixin:
             # 1. Add minimum required actions using a high per-type limit exactly equal to the min required
             from expert_op4grid_recommender import config
 
+            # The per-type MIN_* counts are GUARANTEED floors: at least this
+            # many actions of each type must be returned when candidates exist.
+            # Their sum can exceed ``n_action_max`` (the fill target). If we
+            # capped the minimum-enforcement phase at ``n_action_max``, the
+            # types added last (load shedding, redispatch) would be starved
+            # once the earlier types already filled the budget — silently
+            # dropping a requested floor. So the minimum phase uses a cap that
+            # admits every floor; only the fill phase (step 2 below) honours
+            # ``n_action_max`` as the overall target.
+            min_phase_cap = max(
+                n_action_max,
+                config.MIN_LINE_RECONNECTIONS
+                + config.MIN_CLOSE_COUPLING
+                + config.MIN_PST
+                + config.MIN_OPEN_COUPLING
+                + config.MIN_LINE_DISCONNECTIONS
+                + config.MIN_RENEWABLE_CURTAILMENT
+                + config.MIN_LOAD_SHEDDING
+                + getattr(config, "MIN_REDISPATCH", 0),
+            )
+
             self.prioritized_actions = add_prioritized_actions(
                 self.prioritized_actions,
                 self.identified_reconnections,
-                n_action_max,
+                min_phase_cap,
                 n_action_max_per_type=config.MIN_LINE_RECONNECTIONS,
             )
             self.prioritized_actions = add_prioritized_actions(
                 self.prioritized_actions,
                 self.identified_merges,
-                n_action_max,
+                min_phase_cap,
                 n_action_max_per_type=config.MIN_CLOSE_COUPLING,
             )
             # Step 1.3: Add minimum required PST actions
             self.prioritized_actions = add_prioritized_actions(
                 self.prioritized_actions,
                 getattr(self, "identified_pst_actions", {}),
-                n_action_max,
+                min_phase_cap,
                 n_action_max_per_type=config.MIN_PST,
             )
 
@@ -226,37 +247,37 @@ class OrchestratorMixin:
             self.prioritized_actions = add_prioritized_actions(
                 self.prioritized_actions,
                 self.identified_splits,
-                n_action_max,
+                min_phase_cap,
                 n_action_max_per_type=config.MIN_OPEN_COUPLING,
             )
             self.prioritized_actions = add_prioritized_actions(
                 self.prioritized_actions,
                 self.identified_disconnections,
-                n_action_max,
+                min_phase_cap,
                 n_action_max_per_type=config.MIN_LINE_DISCONNECTIONS,
             )
             self.prioritized_actions = add_prioritized_actions(
                 self.prioritized_actions,
                 self.identified_renewable_curtailment,
-                n_action_max,
+                min_phase_cap,
                 n_action_max_per_type=config.MIN_RENEWABLE_CURTAILMENT,
             )
             self.prioritized_actions = add_prioritized_actions(
                 self.prioritized_actions,
                 self.identified_load_shedding,
-                n_action_max,
+                min_phase_cap,
                 n_action_max_per_type=config.MIN_LOAD_SHEDDING,
             )
             self.prioritized_actions = add_prioritized_actions(
                 self.prioritized_actions,
                 self.identified_redispatch,
-                n_action_max,
+                min_phase_cap,
                 n_action_max_per_type=getattr(config, "MIN_REDISPATCH", 0),
             )
             self.prioritized_actions = add_prioritized_actions(
                 self.prioritized_actions,
                 self.identified_renewable_curtailment,
-                n_action_max,
+                min_phase_cap,
                 n_action_max_per_type=getattr(config, "MIN_RENEWABLE_CURTAILMENT", 0),
             )
 

--- a/expert_op4grid_recommender/main.py
+++ b/expert_op4grid_recommender/main.py
@@ -507,16 +507,28 @@ def run_analysis_step2_graph(context: Dict[str, Any]) -> Dict[str, Any]:
                 nodes_red_loops = list(rl_nodes)
             except Exception as exc:
                 print("Could not pre-compute red-loop dispatch paths for overflow viewer: " + str(exc))
-            make_overflow_graph_visualization(
-                env, overflow_sim, g_overflow, hubs, obs_simu_defaut, save_folder, graph_file_name, lines_swapped,
-                custom_layout, lines_we_care_about=lines_we_care_about,
-                monitoring_factor_thermal_limits=getattr(config, 'MONITORING_FACTOR_THERMAL_LIMITS', 1.0),
-                lines_constrained_path=lines_constrained_path,
-                nodes_constrained_path=nodes_constrained_path,
-                lines_red_loops=lines_red_loops,
-                nodes_red_loops=nodes_red_loops,
-                extra_lines_to_cut_ids=extra_lines_to_cut_ids,
-            )
+            # The overflow-graph visualization is a presentational artifact
+            # (PDF/HTML overlay). Its rendering goes through alphaDeesp +
+            # external tooling (graphviz `dot`/`neato`); when that tooling
+            # fails or is missing, alphaDeesp raises (e.g. AssertionError in
+            # display_geo). That must NOT abort step-2: the downstream action
+            # discovery only needs the graph data structures, not the picture.
+            try:
+                make_overflow_graph_visualization(
+                    env, overflow_sim, g_overflow, hubs, obs_simu_defaut, save_folder, graph_file_name, lines_swapped,
+                    custom_layout, lines_we_care_about=lines_we_care_about,
+                    monitoring_factor_thermal_limits=getattr(config, 'MONITORING_FACTOR_THERMAL_LIMITS', 1.0),
+                    lines_constrained_path=lines_constrained_path,
+                    nodes_constrained_path=nodes_constrained_path,
+                    lines_red_loops=lines_red_loops,
+                    nodes_red_loops=nodes_red_loops,
+                    extra_lines_to_cut_ids=extra_lines_to_cut_ids,
+                )
+            except Exception as exc:
+                print(
+                    "Overflow-graph visualization failed (continuing without it): "
+                    f"{type(exc).__name__}: {exc}"
+                )
     else:
         print("Skipping visualization (DO_VISUALIZATION=False)")
 

--- a/tests/test_min_action_counts.py
+++ b/tests/test_min_action_counts.py
@@ -133,18 +133,22 @@ class TestMinActionCountEnforcement:
         """Replicate the two-pass logic from discovery.py for unit-testing."""
         prioritized = {}
 
-        # Pass 1 – minimum guarantees
+        # Pass 1 – minimum guarantees. The MIN_* counts are GUARANTEED floors,
+        # so the minimum phase is capped at max(n_total, sum of floors): a floor
+        # listed late must not be starved because earlier types already filled
+        # n_total. Mirrors `min_phase_cap` in discovery/_orchestrator.py.
+        min_cap = max(n_total, min_reco + min_close + min_open + min_deco)
         prioritized = self.add_prioritized_actions(
-            prioritized, reconnections, n_total, n_action_max_per_type=min_reco
+            prioritized, reconnections, min_cap, n_action_max_per_type=min_reco
         )
         prioritized = self.add_prioritized_actions(
-            prioritized, merges, n_total, n_action_max_per_type=min_close
+            prioritized, merges, min_cap, n_action_max_per_type=min_close
         )
         prioritized = self.add_prioritized_actions(
-            prioritized, splits, n_total, n_action_max_per_type=min_open
+            prioritized, splits, min_cap, n_action_max_per_type=min_open
         )
         prioritized = self.add_prioritized_actions(
-            prioritized, disconnections, n_total, n_action_max_per_type=min_deco
+            prioritized, disconnections, min_cap, n_action_max_per_type=min_deco
         )
 
         # Pass 2 – fill remaining slots
@@ -213,6 +217,32 @@ class TestMinActionCountEnforcement:
         deco = _make_identified([f"D{i}" for i in range(3)])
         result = self._run_two_pass(reco, merges, splits, deco, 1, 1, 1, 1, n_total=5)
         assert len(result) <= 5
+
+    def test_floors_honored_when_min_sum_exceeds_total(self):
+        """When the per-type floors sum to MORE than n_total, EVERY floor is
+        still honored (the result may exceed n_total).
+
+        Regression for the small_grid demo: with mins
+        reco2+close3+open2+disco3 = 10 > n_total, the floors added last
+        (load shedding) were silently dropped because the earlier types had
+        already filled the n_total budget. The minimum phase must admit all
+        floors; only the fill phase honours n_total as the target.
+        """
+        reco = _make_identified([f"R{i}" for i in range(3)])
+        merges = _make_identified([f"M{i}" for i in range(4)])
+        splits = _make_identified([f"S{i}" for i in range(3)])
+        deco = _make_identified([f"D{i}" for i in range(4)])
+        # floors sum to 2+3+2+3 = 10, well above n_total=5
+        result = self._run_two_pass(
+            reco, merges, splits, deco,
+            min_reco=2, min_close=3, min_open=2, min_deco=3, n_total=5,
+        )
+        assert len([k for k in result if k.startswith("R")]) >= 2
+        assert len([k for k in result if k.startswith("M")]) >= 3
+        assert len([k for k in result if k.startswith("S")]) >= 2
+        assert len([k for k in result if k.startswith("D")]) >= 3
+        # All floors honored even though their sum exceeds n_total.
+        assert len(result) >= 10
 
     def test_min_more_than_available_does_not_crash(self):
         """MIN_* larger than number of available actions should not crash."""


### PR DESCRIPTION
…harden overflow viz

Two root-cause fixes for the small_grid demo regression (Co-Study4Grid PR #162 CI):

1. Minimum-phase floor starvation (the demo failure): the per-type MIN_* counts are GUARANTEED floors, but the minimum-enforcement phase capped each add_prioritized_actions call at n_action_max. When the floors sum above n_action_max (reco2+close3+open2+disco3+ls2 = 12 > 10), the types added last (load shedding, redispatch) were silently starved once the earlier types filled the budget — so load_shedding_* never surfaced despite MIN_LOAD_SHEDDING=2. The minimum phase now uses min_phase_cap = max(n_action_max, sum of all floors) so every floor is honored; only the fill phase keeps n_action_max as the target. The result may exceed n_action_max when floors demand it (correct semantics).

2. Overflow-graph visualization is now non-fatal in run_analysis_step2_graph. Its rendering goes through alphaDeesp + external tooling (graphviz); when that fails (e.g. AssertionError in display_geo) it must not abort step-2 — action discovery only needs the graph data, not the picture. Wrapped in try/except with a warning.

Tests: test_min_action_counts.py gains test_floors_honored_when_min_sum_exceeds_total and its _run_two_pass helper mirrors min_phase_cap. Existing MIN_* and discoverer tests still pass (132).

https://claude.ai/code/session_01WWXPyDhGHq6bZ6WNhUnneL