### PR TITLE
Add Generalized Superposition Theorem (GST) for injection-aware action pairs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+---
+
+## [0.2.4] - 2026-06-15
+
 ### Generalized Superposition Theorem (GST) — injection-aware action pairs
 
 `utils/superposition.py` now combines a topology action with an **injection**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,15 @@ changes with each other — previously these pairs were skipped. Based on
 - `compute_all_pairs_superposition` no longer filters out injection actions and
   passes the injection flags per pair.
 - **Tests**: `tests/test_superposition_gst.py` validates every injection-bearing
-  pair shape against ground-truth grid2op DC simulations (~1e-6 MW).
+  pair shape against ground-truth grid2op DC simulations (~1e-6 MW), plus a
+  `TestGstIsAcAnchored` class pinning that the beta RHS and the reconstruction
+  read the (AC) observation values verbatim.
+- **Docs**: `docs/superposition_module.md` §10 now documents the AC-anchoring of
+  the GST (AC values used throughout; the superposition law is DC-exact only, so
+  the AC residual is structural) and the accuracy profile (topology+injection ≡
+  topology-only EST; the global max-rho line can flip between near-equal low-flow
+  corridor lines while the on-target overload is predicted correctly;
+  injection+injection is lower-confidence).
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,9 @@ changes with each other — previously these pairs were skipped. Based on
   the AC residual is structural) and the accuracy profile (topology+injection ≡
   topology-only EST; the global max-rho line can flip between near-equal low-flow
   corridor lines while the on-target overload is predicted correctly;
-  injection+injection is lower-confidence).
+  injection+injection is lower-confidence), plus a **"Known larger-error cases"**
+  catalog tabulating the two larger-error patterns with their measured small-grid
+  examples, root cause and how to read them.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Generalized Superposition Theorem (GST) — injection-aware action pairs
+
+`utils/superposition.py` now combines a topology action with an **injection**
+change (load shedding / renewable curtailment / redispatch), and two injection
+changes with each other — previously these pairs were skipped. Based on
+`compute_flows_GST_from_unit_act_obs` in
+[Topology_Superposition_Theorem](https://github.com/marota/Topology_Superposition_Theorem).
+
+- **New** `is_injection_action(action_id, action_desc, classifier)` — detects
+  load shedding / curtailment / redispatch by id prefix or classifier type.
+- **New** `compute_combined_pair_gst(...)` — the injection's flow response enters
+  in pure superposition while the topology action keeps an injection-shifted EST
+  beta (RHS-only shift of the 1×1 EST system). `compute_combined_pair_superposition`
+  gains `act1_is_injection` / `act2_is_injection` and routes to the GST when set.
+- **Key identity**: an injection action is reported with `beta = 1.0`, so the
+  standard `(1 − Σβ)·start + β₁·act1 + β₂·act2` reconstruction reproduces the
+  exact GST flows — the rho estimators (and downstream consumers) are unchanged.
+- `compute_all_pairs_superposition` no longer filters out injection actions and
+  passes the injection flags per pair.
+- **Tests**: `tests/test_superposition_gst.py` validates every injection-bearing
+  pair shape against ground-truth grid2op DC simulations (~1e-6 MW).
+
 ---
 
 ## [0.2.3.post2] - 2026-06-11

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -371,7 +371,7 @@ See `MIGRATION_PLAN.md` for details. The goal is to remove `grid2op` dependency.
 
 - **Load Shedding & Renewable Curtailment** (`v0.1.9`): `find_relevant_load_shedding` and `find_relevant_renewable_curtailment` in `action_evaluation/discovery.py` identify candidates on downstream nodes of constrained paths. Controlled by `MIN_LOAD_SHEDDING`, `MIN_RENEWABLE_CURTAILMENT`, `LOAD_SHEDDING_MARGIN`, `RENEWABLE_CURTAILMENT_MARGIN`, `RENEWABLE_ENERGY_SOURCES`. Deeply optimized for large networks (#76).
 - **Pathlib migration** (`v0.1.9`): all base directories and file paths use `pathlib.Path` for cross-platform robustness.
-- **Superposition Theorem** (`v0.1.8`): `utils/superposition.py` quantifies topological and PST action impacts using virtual flows and delta-theta. Integrated into analysis results.
+- **Superposition Theorem** (`v0.1.8`): `utils/superposition.py` quantifies topological and PST action impacts using virtual flows and delta-theta. Integrated into analysis results. **Generalized Superposition Theorem (GST)** (unreleased): `compute_combined_pair_gst` + `is_injection_action` extend pair estimation to load shedding / curtailment / redispatch (injection changes), reported with `beta=1.0` so the existing reconstruction is unchanged. See `docs/superposition_module.md` §10.
 - **Islanding MW impact** (`v0.1.8`): islanding detection now reports disconnected MW.
 - **PST Support** (`v0.1.7+`): phase-shifter transformer tap variations, atomized PST actions from REPAS JSON. `find_relevant_pst_actions` in discovery. Grid2Op conversion support. PST asset-ID matching handles REPAS quirks (leading dots, `_inc1`/`_dec2` suffixes).
 - **Direct XIIDM loading** (`v0.1.8_post1`): `main.py` accepts a direct `.xiidm` file path.

--- a/docs/release-notes/v0.2.4.md
+++ b/docs/release-notes/v0.2.4.md
@@ -1,0 +1,97 @@
+# v0.2.4 — Generalized Superposition Theorem (GST): injection-aware combined-pair estimation
+
+A minor feature release on top of `0.2.3.post2`. Extends the
+superposition-theorem estimation in `utils/superposition.py` so that combined
+**action pairs that involve an injection change** — load shedding,
+renewable curtailment, redispatch — can be estimated without a full
+simulation, alongside the existing topology pairs. Based on
+`compute_flows_GST_from_unit_act_obs` from
+[Topology_Superposition_Theorem](https://github.com/marota/Topology_Superposition_Theorem).
+No breaking changes — every existing call site keeps its current behaviour
+with default arguments.
+
+## Highlights
+
+- **Injection-aware pair estimation (GST)**
+  (`utils/superposition.py`). Previously the combined-pair superposition was
+  topology-only and explicitly **skipped** load shedding / curtailment /
+  redispatch. It now handles the two injection-bearing pair shapes:
+  - **topology + injection** — the injection's flow response enters in *pure
+    superposition* while the topology action keeps an injection-shifted
+    Extended-Superposition-Theorem (EST) beta (a right-hand-side-only shift of
+    the unchanged 1×1 EST system: `beta_T = x(obs_inj) / x(obs_start)`);
+  - **injection + injection** — both terms in pure superposition.
+
+- **New API surface**
+  - `is_injection_action(action_id, action_desc, classifier)` — detects an
+    injection change by id prefix (`load_shedding_` / `curtail_` /
+    `redispatch_`) or classifier type (`load_power_reduction` /
+    `gen_power_reduction` / `gen_redispatch` / `open_load` / `open_gen`).
+  - `compute_combined_pair_gst(...)` — the GST pair computation.
+  - `compute_combined_pair_superposition(...)` gains
+    `act1_is_injection` / `act2_is_injection` (default `False`) and routes to
+    the GST when either is set.
+
+- **Zero-friction reconstruction.** An injection action is reported with
+  `beta = 1.0`, so the standard `(1 − Σβ)·start + β₁·act1 + β₂·act2`
+  reconstruction reproduces the exact GST flows for both `p_or` and `p_ex`.
+  The rho estimators — and downstream consumers such as Co-Study4Grid's
+  `compute_combined_rho` — therefore need **no GST-specific code path**.
+
+- **AC anchoring + accuracy documentation**
+  (`docs/superposition_module.md` §10). The estimate is AC-anchored: both the
+  injection superposition term and the injection-shifted beta read the AC
+  load-flow observation values. The superposition *law* is DC-exact only, so
+  the AC residual is structural (not a DC-input artefact). The section adds an
+  accuracy profile and a **"Known larger-error cases"** catalog — with measured
+  small-grid examples, root cause and how to read each — for (1) disconnection
+  of a heavily-loaded line onto a low-flow meshed corridor (off-target
+  global-max line flip) and (2) injection+injection relief over-prediction.
+  Both are verified DC-exact (0 MW via a direct `run_dc` check), i.e.
+  AC-nonlinearity, not bugs.
+
+## Compatibility
+
+- **No public-API break.** `compute_combined_pair_superposition` keeps its
+  signature; the two new flags default to `False` (the existing EST path).
+- **Behavioural addition** (not a break): `compute_all_pairs_superposition` no
+  longer filters out load-shedding / curtailment / redispatch actions, so its
+  result now also contains pairs that involve those actions. Callers that
+  previously relied on injection pairs being absent will see additional pair
+  keys.
+- Injection + injection pairs are lower-confidence estimates (AC nonlinearity
+  compounds for two large injections) — prefer a full simulation for those.
+
+## Tests
+
+- `tests/test_superposition_gst.py` (new):
+  - every injection-bearing pair shape (line disco/reco + injection, node
+    split/merge + injection, injection + injection, reversed ordering)
+    validated against ground-truth grid2op DC simulations (~1e-6 MW);
+  - `TestGstIsAcAnchored` pins that the beta right-hand side equals the
+    injection's `p_or` ratio and that the reconstruction superposes the AC
+    `p_or` *and* `p_ex` values verbatim;
+  - `is_injection_action` detection (prefix + classifier type);
+  - `compute_all_pairs_superposition` now includes injection pairs.
+
+## Files touched
+
+- `expert_op4grid_recommender/utils/superposition.py`: `is_injection_action`,
+  `compute_combined_pair_gst`, `_resolve_topology_element`,
+  `_topology_beta_gst`; `act*_is_injection` on
+  `compute_combined_pair_superposition`; injection actions kept (no longer
+  filtered) in `compute_all_pairs_superposition`.
+- `tests/test_superposition_gst.py`: new GST + AC-anchoring test suite.
+- `docs/superposition_module.md`: §10 GST documentation (AC anchoring,
+  accuracy profile, "Known larger-error cases" catalog) + §11 test-coverage
+  row.
+- `CLAUDE.md`: GST mention on the superposition feature note.
+- `pyproject.toml`, `expert_op4grid_recommender/__init__.py`: version bump
+  `0.2.3.post2` → `0.2.4`.
+- `CHANGELOG.md`, `docs/release-notes/v0.2.4.md`: this release documentation.
+
+## Companion
+
+The GST is plugged into **Co-Study4Grid** (combined-pair estimation now works
+for load-shedding / curtailment / redispatch in the Explore Pairs tab) — see
+that project's PR for the backend/frontend integration.

--- a/docs/superposition_module.md
+++ b/docs/superposition_module.md
@@ -358,6 +358,24 @@ estimate's purpose.
   gap is larger — mean ~4 pts, and the on-target line can be mispredicted). Treat
   these estimates as lower-confidence and prefer a full simulation.
 
+### Known larger-error cases
+
+All errors below are **DC-exact** (verified to 0 MW by a direct `run_dc` check)
+and are therefore **AC-nonlinearity, not bugs**. They are catalogued so the
+estimate can be read correctly. Reproduce with
+`Co-Study4Grid/scripts/gst_estimation_vs_simulation_small_grid.py` (small grid,
+contingency `P.SAOL31RONCI`).
+
+| # | Trigger | Symptom | Measured (small grid) | Root cause | How to read it |
+|---|---|---|---|---|---|
+| 1 | Disconnecting a **heavily-loaded** line that dumps its flow onto a **low-flow meshed parallel corridor** | global `max_rho` **line flips** between two near-equally-loaded lines; few-% gap on the max | `disco_BEON L31CPVAN + load_shedding_P.SAO3TR312`: est **74.5 % on C.FOUL31MERVA** vs sim **70.0 % on PYMONL31SAISS**. Per-line: C.FOUL over-estimated ~15 pts, PYMON/FRON5 under-estimated. mean rho gap ~1.6 pts, max ~15 pts | BEON↔C.FOUL are tightly coupled (DC LODF = 1.0); the AC split of BEON's ~25 MW across the low-flow corridor (lines at ~7–25 MW) is operating-point dependent | Trust `target_max_rho` (on-target overload `BEON` is correctly predicted resolved, ~0.4 %); treat the off-target global max as indicative. **Not GST-specific** — pure-topology EST pairs (`reco + disco`) show the identical ~+4.7 MW C.FOUL error |
+| 2 | **Injection + injection** (two large `load_shedding` / `curtail` together), especially when both target the same constrained area | combined relief **over-predicted**; the on-target line itself can be mispredicted | `load_shedding_P.SAO3TR312 + load_shedding_BEON3 TR311`: est `BEON` **5.6 %** vs sim **38.1 %**. mean rho gap ~4.1 pts, max ~32.8 pts; flow gap up to ~18 MW | Two large injections each set a load/gen to 0; the AC responses compound (voltage/reactive), and pure superposition (β = 1.0 each) misses the sub-additivity of stacked injections | **Lower-confidence — prefer a full simulation.** A `low_confidence` flag for injection+injection pairs is a reasonable UI follow-up |
+
+The shared driver of #1 is the **disconnection redistribution onto low-flow
+lines**, not the injection: a few-MW AC error is invisible on a 400 MW line but
+is ~15 rho-points on a 30 MW line, which is exactly what reorders two ~75 %
+neighbours. #2 is specific to stacking two large injection changes.
+
 ---
 
 ## 11. Test Coverage

--- a/docs/superposition_module.md
+++ b/docs/superposition_module.md
@@ -307,11 +307,56 @@ This identity means the rho estimators (`_estimate_rho_from_p`, the default
 direct rho superposition) **and Co-Study4Grid's `compute_combined_rho`** need no
 GST-specific code path.
 
+### AC anchoring (which state values feed the GST)
+
+The GST is **AC-anchored**: every quantity it reads comes from the *AC* load-flow
+observations, not from a recomputed DC model.
+
+- The **injection superposition term** is `obs_inj.p_or − obs_start.p_or` (and the
+  same for `p_ex`), with both observations being AC states.
+- The **injection-shifted beta** is `beta_T = x(obs_inj) / x(obs_start)`, where `x`
+  is the AC `p_or` (disconnection / node split) or the AC `delta_theta` from
+  `theta_or − theta_ex` (reconnection / node merge), read on the switched element.
+
+So the estimate is anchored at the true AC operating point. **But using AC inputs
+does not make it AC-exact** — the superposition *law* it applies
+(`PF = α·ref + Σβ·unit + Σ injection`, betas from a linear ratio system) is exact
+only under **DC linearity**. Feeding AC values into a DC-derived linear law yields
+an *AC-anchored linear superposition*: better than a pure DC estimate, but it
+cannot reproduce AC nonlinearities (reactive / voltage coupling, loss
+redistribution, operating-point-dependent flow splits). There is also a second,
+AC-independent approximation: the injection response is captured at the
+**reference topology** and added in full, while in the combined target the
+topology has also changed — the topology betas absorb that coupling through the
+right-hand side (first-order-exact in DC, approximate in AC). Re-evaluating the
+injection in the combined topology would need an extra simulation, defeating the
+estimate's purpose.
+
 ### Accuracy
 
-Validated against ground-truth combined simulations (grid2op DC,
-`l2rpn_case14_sandbox`) to ~1e-6 MW for line disco/reco, node split/merge, and
-injection+injection pairs — see `test_superposition_gst.py`.
+- **DC: exact.** Validated against ground-truth combined simulations (grid2op DC,
+  `l2rpn_case14_sandbox`) to ~1e-6 MW for line disco/reco, node split/merge, and
+  injection+injection pairs (`test_superposition_gst.py`). A direct pypowsybl
+  `run_dc` check on the small grid reconstructs the flagged
+  `disco_BEON L31CPVAN + load_shedding_P.SAO3TR312` pair to **0.0000 MW** on every
+  line (`Co-Study4Grid/scripts/gst_estimation_vs_simulation_small_grid.py`).
+- **AC topology + injection: same accuracy as topology-only EST.** On the small
+  AC grid, a load-shedding (GST) pair and a pure-topology (EST) pair share the
+  same per-line rho error (~1–2 pts mean, occasionally ~15 pts). The injection
+  term (β = 1.0) adds nothing on top of the inherent EST/AC limit.
+- **Where the visible gap comes from.** A few-MW AC flow-split error is negligible
+  on heavily-loaded high-limit lines but, on **low-flow lines of a meshed parallel
+  corridor** (where disconnecting a loaded line dumps its flow), it becomes a
+  sizable rho-% error. When two such lines sit at near-equal loading, it **flips
+  which is reported as the global max** (e.g. estimate picks `C.FOUL31MERVA`,
+  simulation picks `PYMONL31SAISS`, both ~70–75 %). The decision-relevant number —
+  the effect on the operator's actual overload — is predicted correctly (that is
+  what `target_max_rho` surfaces). This is *not* GST-specific: pure-topology EST
+  pairs show the identical effect.
+- **AC injection + injection: weaker.** Two large injection changes compound the
+  AC nonlinearity, so the combined relief is over-predicted (DC-exact, but the AC
+  gap is larger — mean ~4 pts, and the on-target line can be mispredicted). Treat
+  these estimates as lower-confidence and prefer a full simulation.
 
 ---
 
@@ -323,4 +368,4 @@ injection+injection pairs — see `test_superposition_gst.py`.
 | `test_superposition_action_types.py` | All action type pair combinations (line+line, sub+sub, line+sub), reversed ordering, helper functions, no-op detection |
 | `test_superposition_rho_estimation.py` | P-based and delta-theta-based rho estimation, fallbacks, action-type-aware routing |
 | `test_superposition_extended.py` | Edge cases: no elements, multiple elements, singular systems, beta range validation |
-| `test_superposition_gst.py` | GST: topology+injection and injection+injection pairs vs ground truth, `is_injection_action` detection, `compute_all_pairs` inclusion of injection pairs |
+| `test_superposition_gst.py` | GST: topology+injection and injection+injection pairs vs ground truth (DC-exact), AC-anchoring (`TestGstIsAcAnchored`: beta RHS + reconstruction use the AC observation values), `is_injection_action` detection, `compute_all_pairs` inclusion of injection pairs |

--- a/docs/superposition_module.md
+++ b/docs/superposition_module.md
@@ -254,7 +254,68 @@ The key difference is that a disconnection sets `p_or → 0` while a PST tap cha
 
 ---
 
-## 10. Test Coverage
+## 10. Generalized Superposition Theorem (GST): injection-aware pairs
+
+The Extended Superposition Theorem (EST) above combines two **topology** actions.
+The **GST** extends it to pairs where at least one action is an **injection**
+change — load shedding (`set_load_p`), renewable curtailment / redispatch
+(`set_gen_p`). These change only nodal injections, not the topology.
+
+### Detection
+
+`is_injection_action(action_id, action_desc, classifier)` flags an action as an
+injection change by id prefix (`load_shedding_` / `curtail_` / `redispatch_`) or
+classifier type (`load_power_reduction` / `gen_power_reduction` / `gen_redispatch`
+/ `open_load` / `open_gen`). `compute_combined_pair_superposition` routes a pair
+to `compute_combined_pair_gst` whenever either `act*_is_injection` is set, and
+`compute_all_pairs_superposition` now **keeps** injection actions (previously
+skipped) and pairs them with topology actions and with each other.
+
+### Formula (adapted from Topology_Superposition_Theorem)
+
+An injection action enters in **pure superposition** — its flow response
+`obs_inj.p_or − obs_start.p_or` is added in full. A topology action keeps an EST
+beta that the injection shifts **only through the right-hand side** of the
+(unchanged) 1×1 EST system:
+
+```
+beta_T = x(P_tgt, T_ref) / x(P_ref, T_ref)
+       = x(obs_inj) / x(obs_start)        # single injection on the switched asset
+```
+
+with `x = p_or` for disconnection / node split (non-zero reference flow) and
+`x = delta_theta` for reconnection / node merge (zero reference flow).
+
+### The `beta = 1.0` convention (why nothing downstream changes)
+
+`compute_combined_pair_gst` reports an injection action with **`beta = 1.0`** and
+a topology action with its solved `beta_T`. Because each injection term
+`(obs_inj − obs_start)` equals `1.0·obs_inj − 1.0·obs_start`, the `−obs_start`
+parts fold into the `(1 − sum(betas))` weight, so the **standard EST
+reconstruction** reproduces the exact GST flows:
+
+```
+p_combined = (1 − sum(betas)) · obs_start.p + betas[0]·p_act1 + betas[1]·p_act2
+```
+
+| Pair shape | betas | reconstruction |
+|---|---|---|
+| topology + injection | `[beta_T, 1.0]` | `−beta_T·start + beta_T·topo + inj` |
+| injection + injection | `[1.0, 1.0]` | `inj1 + inj2 − start` (DC-exact) |
+
+This identity means the rho estimators (`_estimate_rho_from_p`, the default
+direct rho superposition) **and Co-Study4Grid's `compute_combined_rho`** need no
+GST-specific code path.
+
+### Accuracy
+
+Validated against ground-truth combined simulations (grid2op DC,
+`l2rpn_case14_sandbox`) to ~1e-6 MW for line disco/reco, node split/merge, and
+injection+injection pairs — see `test_superposition_gst.py`.
+
+---
+
+## 11. Test Coverage
 
 | Test File | Focus |
 |---|---|
@@ -262,3 +323,4 @@ The key difference is that a disconnection sets `p_or → 0` while a PST tap cha
 | `test_superposition_action_types.py` | All action type pair combinations (line+line, sub+sub, line+sub), reversed ordering, helper functions, no-op detection |
 | `test_superposition_rho_estimation.py` | P-based and delta-theta-based rho estimation, fallbacks, action-type-aware routing |
 | `test_superposition_extended.py` | Edge cases: no elements, multiple elements, singular systems, beta range validation |
+| `test_superposition_gst.py` | GST: topology+injection and injection+injection pairs vs ground truth, `is_injection_action` detection, `compute_all_pairs` inclusion of injection pairs |

--- a/expert_op4grid_recommender/__init__.py
+++ b/expert_op4grid_recommender/__init__.py
@@ -15,7 +15,7 @@ corrective measures to alleviate line overloads.
 
 import logging
 
-__version__ = "0.2.3.post2"
+__version__ = "0.2.4"
 
 _logger = logging.getLogger(__name__)
 

--- a/expert_op4grid_recommender/utils/superposition.py
+++ b/expert_op4grid_recommender/utils/superposition.py
@@ -6,11 +6,22 @@ This module adapts the superposition theorem from
 https://github.com/marota/Topology_Superposition_Theorem
 to work with the pypowsybl-based observations used in expert_op4grid_recommender.
 
-The key formula:
-  p_or_combined = (1 - sum(betas)) * obs_start.p_or + sum(betas[i] * obs_unit[i].p_or)
+Two regimes are supported:
 
-where betas are solved from a linear system using p_or and delta_theta values
-at the lines/substations involved in each action.
+* **Extended Superposition Theorem (EST)** — pairs of *topology* actions (line
+  disconnection / reconnection, node split / merge, PST). The combined flow is
+
+      p_or_combined = (1 - sum(betas)) * obs_start.p_or + sum(betas[i] * obs_unit[i].p_or)
+
+  where ``betas`` solve a linear system built from p_or and delta_theta values
+  at the lines / substations involved in each action.
+
+* **Generalized Superposition Theorem (GST)** — pairs where at least one action
+  is an *injection* change (load shedding, renewable curtailment, redispatch).
+  The injection enters in pure superposition (its flow response is added in
+  full) while the topology action keeps an injection-shifted EST beta. Reporting
+  an injection action with ``beta = 1.0`` lets the SAME reconstruction formula
+  above produce the exact GST flows — see :func:`compute_combined_pair_gst`.
 """
 
 import numpy as np
@@ -605,6 +616,226 @@ def _estimate_rho_from_delta_theta(dt_combined, obs_start, obs_act1, obs_act2):
 
 
 # =============================================================================
+# Generalized Superposition Theorem (GST): injection-aware action pairs
+# =============================================================================
+#
+# The Extended Superposition Theorem (EST) above combines *topology* actions
+# (line disconnection / reconnection, node split / merge, PST). The GST extends
+# it to action pairs that also involve an *injection* change -- load shedding,
+# renewable curtailment or redispatch -- which only modifies ``load_p`` /
+# ``gen_p`` (no topology change).
+#
+# Adapted from ``compute_flows_GST_from_unit_act_obs`` in
+# Topology_Superposition_Theorem. An injection action enters in *pure
+# superposition* (its flow response ``obs_inj.p_or - obs_start.p_or`` is added
+# in full), while a topology action keeps an EST beta that the injection shifts
+# only through the right-hand side of the (unchanged) EST linear system:
+#
+#     beta_T = x(P_tgt, T_ref) / x(P_ref, T_ref)
+#
+# with ``x = p_or`` on disconnected / split assets (non-zero reference flow),
+# ``x = delta_theta`` on reconnected / merged assets (zero reference flow), and
+# ``x(P_tgt, T_ref) = x(P_ref, T_ref) + sum_k (x(obs_inj_k) - x(obs_start))``.
+#
+# Key identity used throughout: reporting an injection action with ``beta = 1.0``
+# makes the *standard* reconstruction
+#
+#     p_combined = (1 - sum(betas)) * obs_start.p + betas[0]*p_act1 + betas[1]*p_act2
+#
+# reproduce the exact GST flows, because each injection term
+# ``(obs_inj.p - obs_start.p)`` equals ``1.0*obs_inj.p - 1.0*obs_start.p`` and the
+# ``-obs_start.p`` parts fold into the ``(1 - sum(betas))`` weight. As a result
+# the downstream rho estimators (and Co-Study4Grid's ``compute_combined_rho``)
+# need no change for injection pairs.
+
+# Action types and id prefixes that denote a pure injection change.
+INJECTION_ACTION_TYPES = frozenset({
+    "load_power_reduction", "gen_power_reduction", "gen_redispatch",
+    "open_load", "open_gen",
+})
+INJECTION_ID_PREFIXES = ("load_shedding_", "curtail_", "redispatch_")
+
+
+def is_injection_action(action_id: str, action_desc: Optional[dict] = None,
+                        classifier: Optional[Any] = None) -> bool:
+    """Return True if an action is a pure injection change.
+
+    Injection actions (load shedding ``set_load_p``, renewable curtailment /
+    redispatch ``set_gen_p``) change only nodal injections, not the topology,
+    and are handled by the Generalized Superposition Theorem. Detection is by
+    action-id prefix (``load_shedding_`` / ``curtail_`` / ``redispatch_``) and,
+    when available, by the classifier's action type.
+    """
+    if action_id and action_id.startswith(INJECTION_ID_PREFIXES):
+        return True
+    if classifier is not None and action_desc is not None:
+        try:
+            atype = classifier.identify_action_type(action_desc, by_description=True)
+        except Exception:
+            atype = None
+        if atype in INJECTION_ACTION_TYPES:
+            return True
+    return False
+
+
+def _resolve_topology_element(obs_start, obs_topo, line_idxs: List[int],
+                              sub_idxs: List[int]):
+    """Describe the switched element of a topology action.
+
+    Returns ``(kind, idx, is_ref, ind_sub)`` where ``kind`` is ``"line"`` or
+    ``"sub"``, ``is_ref`` flags a substation that starts in reference (single-bus)
+    topology, and ``ind_sub`` are the node-1 element ids (for substations).
+    Returns ``None`` when no element could be identified.
+    """
+    if line_idxs:
+        return ("line", line_idxs[0], None, None)
+    if sub_idxs:
+        sid = sub_idxs[0]
+        is_ref = _is_sub_reference_topology(obs_start, sid)
+        # node-1 element ids are read from the split observation (its bus map
+        # reflects the post-split topology); for a merge, obs_start is split.
+        ind_sub = get_sub_node1_idsflow(obs_topo if is_ref else obs_start, sid)
+        return ("sub", sid, is_ref, ind_sub)
+    return None
+
+
+def _topology_beta_gst(obs_start, obs_inj, kind: str, idx: int,
+                       is_ref: Optional[bool], ind_sub) -> float:
+    """GST topology coefficient ``beta_T = x_inj / x_start`` on the switched asset.
+
+    ``x`` is the active flow for a disconnection / node split (non-zero reference
+    flow) or the angle difference for a reconnection / node merge (zero reference
+    flow), evaluated on the switched element at ``obs_start`` and at the injection
+    observation ``obs_inj``. Returns 1.0 when the reference quantity is
+    numerically negligible (the injection then leaves that sensitivity unchanged).
+    """
+    p_threshold = 1.0       # MW
+    dth_threshold = 1e-9    # rad
+    if kind == "line":
+        p_start = float(obs_start.p_or[idx])
+        if abs(p_start) > p_threshold:                      # disconnection
+            return float(obs_inj.p_or[idx]) / p_start
+        dth_start = get_delta_theta_line(obs_start, idx)    # reconnection
+        if abs(dth_start) > dth_threshold:
+            return get_delta_theta_line(obs_inj, idx) / dth_start
+        return 1.0
+    # substation virtual line
+    il, ip, ilor, ilex = ind_sub
+    if is_ref:                                              # node split
+        v_start = get_virtual_line_flow(obs_start, il, ip, ilor, ilex)
+        if abs(v_start) > p_threshold:
+            return get_virtual_line_flow(obs_inj, il, ip, ilor, ilex) / v_start
+        return 1.0
+    dth_start = get_delta_theta_sub_2nodes(obs_start, idx)  # node merge
+    if abs(dth_start) > dth_threshold:
+        return get_delta_theta_sub_2nodes(obs_inj, idx) / dth_start
+    return 1.0
+
+
+def compute_combined_pair_gst(
+        obs_start,
+        obs_act1,
+        obs_act2,
+        act1_line_idxs: List[int],
+        act1_sub_idxs: List[int],
+        act2_line_idxs: List[int],
+        act2_sub_idxs: List[int],
+        act1_is_injection: bool,
+        act2_is_injection: bool,
+        obs_combined: Optional[Any] = None,
+) -> Dict[str, Any]:
+    """Generalized Superposition Theorem for a pair with >=1 injection action.
+
+    Handles the three injection-bearing pair shapes:
+
+    * **topology + injection** -- the topology action gets ``beta_T`` (computed
+      from the injection observation through the EST right-hand side), the
+      injection gets ``beta = 1.0``;
+    * **injection + injection** -- both get ``beta = 1.0`` (pure injection
+      superposition, exact in DC);
+
+    and returns the same structure as :func:`compute_combined_pair_superposition`
+    (``betas``, ``p_or_combined``, ``p_ex_combined``, islanding fields) so the
+    standard reconstruction and the rho estimators work unchanged.
+    """
+    inj_flags = [bool(act1_is_injection), bool(act2_is_injection)]
+    obs_list = [obs_act1, obs_act2]
+    line_idxs = [act1_line_idxs, act2_line_idxs]
+    sub_idxs = [act1_sub_idxs, act2_sub_idxs]
+
+    if not (inj_flags[0] or inj_flags[1]):
+        return {"error": "GST path requires at least one injection action."}
+
+    # Beta per action: injection -> 1.0 (pure superposition term); topology ->
+    # GST coefficient computed against the *other* action's (injection) state.
+    betas = [1.0, 1.0]
+    for i in range(2):
+        if inj_flags[i]:
+            continue
+        j = 1 - i
+        if not inj_flags[j]:
+            # both topology -> not a GST pair (caller should use the EST path)
+            return {"error": "GST path requires at least one injection action."}
+        spec = _resolve_topology_element(obs_start, obs_list[i], line_idxs[i], sub_idxs[i])
+        if spec is None:
+            return {"error": f"Cannot identify switched element for topology action {i + 1}."}
+        kind, idx, is_ref, ind_sub = spec
+        betas[i] = _topology_beta_gst(obs_start, obs_list[j], kind, idx, is_ref, ind_sub)
+
+    # No-op detection: an injection with no flow response is meaningless.
+    noop_mw = 0.1
+    p_or_start = np.asarray(obs_start.p_or, dtype=float)
+    for i in range(2):
+        if inj_flags[i]:
+            e = float(np.max(np.abs(np.asarray(obs_list[i].p_or, dtype=float) - p_or_start)))
+            if e < noop_mw:
+                return {"error": f"No-op injection action detected (action {i + 1} has no flow effect)."}
+
+    betas_arr = np.array(betas, dtype=float)
+    if np.any(np.isnan(betas_arr)):
+        return {"error": "Singular system — cannot compute GST betas", "betas": betas}
+
+    beta_min, beta_max = -2.0, 3.0
+    if np.any(betas_arr < beta_min) or np.any(betas_arr > beta_max):
+        return {
+            "error": (
+                f"Unreliable GST superposition: betas {np.round(betas_arr, 3).tolist()} "
+                f"are outside the physically meaningful range [{beta_min}, {beta_max}]. "
+                f"The topology and injection actions are too strongly coupled."
+            ),
+            "betas": betas,
+        }
+
+    # Reconstruction — identical to the EST formula thanks to the beta=1.0
+    # convention for injection terms (see the module-level note above).
+    w_start = 1.0 - float(np.sum(betas_arr))
+    p_or_combined = w_start * p_or_start
+    p_ex_combined = w_start * np.asarray(obs_start.p_ex, dtype=float)
+    for i in range(2):
+        p_or_combined = p_or_combined + betas[i] * np.asarray(obs_list[i].p_or, dtype=float)
+        p_ex_combined = p_ex_combined + betas[i] * np.asarray(obs_list[i].p_ex, dtype=float)
+
+    # Islanding detection (if the actual combined observation is provided)
+    is_islanded = False
+    disconnected_mw = 0.0
+    if obs_combined is not None and hasattr(obs_combined, "n_components"):
+        if obs_combined.n_components > obs_start.n_components:
+            is_islanded = True
+            if hasattr(obs_combined, "main_component_load_mw") and hasattr(obs_start, "main_component_load_mw"):
+                disconnected_mw = float(max(
+                    0.0, obs_start.main_component_load_mw - obs_combined.main_component_load_mw))
+
+    return {
+        "betas": betas,
+        "p_or_combined": p_or_combined.tolist(),
+        "p_ex_combined": p_ex_combined.tolist(),
+        "is_islanded": is_islanded,
+        "disconnected_mw": disconnected_mw,
+        "is_gst": True,
+    }
+
+
+# =============================================================================
 # Pair superposition computation
 # =============================================================================
 
@@ -619,8 +850,15 @@ def compute_combined_pair_superposition(
         obs_combined: Optional[Any] = None,
         act1_is_pst: bool = False,
         act2_is_pst: bool = False,
+        act1_is_injection: bool = False,
+        act2_is_injection: bool = False,
 ) -> Dict[str, Any]:
     """Compute the superposition theorem for a pair of unitary actions.
+
+    Topology-only pairs use the Extended Superposition Theorem (EST). When at
+    least one action is an injection change (load shedding / curtailment /
+    redispatch — flagged via ``act*_is_injection``), the call is routed to the
+    Generalized Superposition Theorem (:func:`compute_combined_pair_gst`).
 
     Args:
         obs_start: Base observation (N-1 state)
@@ -633,10 +871,25 @@ def compute_combined_pair_superposition(
         obs_combined: Optional actual combined observation (for islanding detection)
         act1_is_pst: True if action 1 is a phase shifter tap change
         act2_is_pst: True if action 2 is a phase shifter tap change
+        act1_is_injection: True if action 1 is an injection change (GST path)
+        act2_is_injection: True if action 2 is an injection change (GST path)
 
     Returns:
         Dict with betas, p_or_combined, p_ex_combined, rho_combined
     """
+    # Generalized Superposition Theorem: an injection action (load shedding,
+    # renewable curtailment, redispatch) on either side is handled by the GST
+    # path, which combines a pure-superposition injection term with the
+    # (injection-shifted) EST beta of the topology action.
+    if act1_is_injection or act2_is_injection:
+        return compute_combined_pair_gst(
+            obs_start, obs_act1, obs_act2,
+            act1_line_idxs, act1_sub_idxs,
+            act2_line_idxs, act2_sub_idxs,
+            act1_is_injection, act2_is_injection,
+            obs_combined=obs_combined,
+        )
+
     # Total number of elements must equal 2 (one per action)
     n_elements_act1 = len(act1_line_idxs) + len(act1_sub_idxs)
     n_elements_act2 = len(act2_line_idxs) + len(act2_sub_idxs)
@@ -902,27 +1155,17 @@ def compute_all_pairs_superposition(
     if dict_action is None:
         dict_action = {}
 
-    # Filter to converged actions only, excluding load shedding and curtailment
-    converged_ids = []
-    for aid, details in detailed_actions.items():
-        if details.get("non_convergence") is not None:
-            continue
-        
-        # Identify action type to skip load shedding and curtailment
-        action_desc = dict_action.get(aid, {})
-        action_type = classifier.identify_action_type(action_desc, by_description=True)
-        
-        # Skip if it's load shedding or curtailment (open_load, open_gen, or prefix match)
-        if (action_type in ["open_load", "open_gen"] or 
-            aid.startswith("load_shedding_") or 
-            aid.startswith("curtail_")):
-            continue
-            
-        converged_ids.append(aid)
+    # Filter to converged actions only. Injection actions (load shedding,
+    # curtailment, redispatch) are KEPT — the Generalized Superposition Theorem
+    # combines them with topology actions (and with each other).
+    converged_ids = [
+        aid for aid, details in detailed_actions.items()
+        if details.get("non_convergence") is None
+    ]
 
     if len(converged_ids) < 2:
-        if converged_ids: # Don't print if it was already empty
-            print(f"[Superposition] Only {len(converged_ids)} combinable converged action(s) (excluding LS/RC), "
+        if converged_ids:  # Don't print if it was already empty
+            print(f"[Superposition] Only {len(converged_ids)} combinable converged action(s), "
                   f"need at least 2 for pair combination.")
         return {}
 
@@ -930,9 +1173,10 @@ def compute_all_pairs_superposition(
           f"{len(converged_ids) - 1} / 2 = "
           f"{len(converged_ids) * (len(converged_ids) - 1) // 2} pairs")
 
-    # Pre-compute element indices and PST flags for each action
+    # Pre-compute element indices and PST / injection flags for each action
     action_elements = {}
     action_is_pst = {}
+    action_is_injection = {}
     for aid in converged_ids:
         action_obj = detailed_actions[aid]["action"]
         line_idxs, sub_idxs = _identify_action_elements(
@@ -947,6 +1191,9 @@ def compute_all_pairs_superposition(
             or "pst_tap" in aid
             or "pst_" in aid
         )
+        # Detect injection actions (GST path): load shedding / curtailment /
+        # redispatch. These carry no topology element.
+        action_is_injection[aid] = is_injection_action(aid, action_desc, classifier)
 
     # Monitoring setup for max_rho computation
     from expert_op4grid_recommender import config
@@ -973,11 +1220,14 @@ def compute_all_pairs_superposition(
     for aid1, aid2 in combinations(converged_ids, 2):
         line_idxs1, sub_idxs1 = action_elements[aid1]
         line_idxs2, sub_idxs2 = action_elements[aid2]
+        inj1 = action_is_injection.get(aid1, False)
+        inj2 = action_is_injection.get(aid2, False)
 
-        # Skip if we can't identify elements for either action
-        if len(line_idxs1) + len(sub_idxs1) == 0:
+        # Topology actions need an identified switched element; injection
+        # actions (handled by the GST in pure superposition) do not.
+        if not inj1 and len(line_idxs1) + len(sub_idxs1) == 0:
             continue
-        if len(line_idxs2) + len(sub_idxs2) == 0:
+        if not inj2 and len(line_idxs2) + len(sub_idxs2) == 0:
             continue
 
         obs_act1 = detailed_actions[aid1]["observation"]
@@ -994,6 +1244,8 @@ def compute_all_pairs_superposition(
                 act2_sub_idxs=sub_idxs2,
                 act1_is_pst=action_is_pst.get(aid1, False),
                 act2_is_pst=action_is_pst.get(aid2, False),
+                act1_is_injection=inj1,
+                act2_is_injection=inj2,
             )
         except Exception as e:
             print(f"[Superposition] Error computing pair {aid1}+{aid2}: {e}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "expert_op4grid_recommender"
-version = "0.2.3.post2"
+version = "0.2.4"
 authors = [
     { name="RTE", email="rte@rte-france.com" },
 ]

--- a/tests/test_superposition_gst.py
+++ b/tests/test_superposition_gst.py
@@ -193,6 +193,15 @@ class TestGstActionTypeSuperposition(unittest.TestCase):
     # injection + injection
     # =========================================================================
     def test_injection_plus_injection(self):
+        """Two injection changes combined.
+
+        In DC this is exact (injection superposition is linear), which is why
+        the assertion below holds to solver precision. The larger est-vs-sim
+        gaps observed for injection+injection on an AC grid are therefore a
+        structural AC-nonlinearity effect (two large injections compound the
+        reactive / voltage coupling), NOT a formula error — see
+        ``docs/superposition_module.md`` §10.
+        """
         self.env.set_id(self.chronic_id)
         self.env.reset()
         obs_start, *_ = self.env.step(self.env.action_space({}))
@@ -317,6 +326,70 @@ class TestComputeAllPairsWithInjection(unittest.TestCase):
         self.assertNotIn("error", res)
         # injection reported with beta = 1.0
         self.assertAlmostEqual(res["betas"][1], 1.0, places=6)
+
+
+class _AcObs:
+    """Minimal observation carrying AC-like flows (p_or != -p_ex, i.e. with
+    line losses). Enough for the line-disconnection GST path, which reads only
+    ``p_or`` / ``p_ex``."""
+
+    def __init__(self, p_or, p_ex):
+        self.p_or = np.array(p_or, dtype=float)
+        self.p_ex = np.array(p_ex, dtype=float)
+
+
+class TestGstIsAcAnchored(unittest.TestCase):
+    """The GST is *AC-anchored*: both the injection superposition term and the
+    injection-shifted beta right-hand side are read straight from the
+    (AC) observation values — no DC quantity is recomputed. See
+    ``docs/superposition_module.md`` §10.
+    """
+
+    def test_beta_rhs_and_reconstruction_use_observation_values(self):
+        # AC-like states: p_or != -p_ex (losses present), arbitrary magnitudes.
+        obs_start = _AcObs([100.0, 50.0, 30.0], [-99.0, -49.5, -29.7])
+        obs_topo = _AcObs([0.0, 80.0, 45.0], [0.0, -79.0, -44.5])      # line 0 disconnected
+        obs_inj = _AcObs([120.0, 40.0, 25.0], [-119.0, -39.6, -24.8])  # injection shifts flows
+        sw = 0  # switched line: connected in obs_start (p_or=100 > 1 MW) -> p_or branch
+
+        res = compute_combined_pair_gst(
+            obs_start, obs_topo, obs_inj,
+            act1_line_idxs=[sw], act1_sub_idxs=[],
+            act2_line_idxs=[], act2_sub_idxs=[],
+            act1_is_injection=False, act2_is_injection=True,
+        )
+        self.assertNotIn("error", res)
+
+        # Q2: the beta RHS is the injection's AC p_or ratio on the switched line.
+        beta_t_expected = obs_inj.p_or[sw] / obs_start.p_or[sw]  # 120/100 = 1.2
+        self.assertAlmostEqual(res["betas"][0], beta_t_expected, places=9)
+        self.assertEqual(res["betas"][1], 1.0)  # injection term added in full
+
+        # Q1: the reconstruction superposes the AC p_or AND p_ex values verbatim.
+        w = 1.0 - sum(res["betas"])
+        exp_por = w * obs_start.p_or + res["betas"][0] * obs_topo.p_or + res["betas"][1] * obs_inj.p_or
+        exp_pex = w * obs_start.p_ex + res["betas"][0] * obs_topo.p_ex + res["betas"][1] * obs_inj.p_ex
+        np.testing.assert_allclose(res["p_or_combined"], exp_por, atol=1e-9)
+        np.testing.assert_allclose(res["p_ex_combined"], exp_pex, atol=1e-9)
+
+        # p_ex is carried independently of p_or — only meaningful in AC, where
+        # p_or != -p_ex. This confirms AC (not DC-symmetric) values flow through.
+        self.assertFalse(np.allclose(res["p_ex_combined"], -np.asarray(res["p_or_combined"])))
+
+    def test_equivalent_to_explicit_gst_reconstruction(self):
+        """The reported flows equal alpha*start + beta*topo + (inj - start)."""
+        obs_start = _AcObs([80.0, 60.0], [-79.2, -59.4])
+        obs_topo = _AcObs([0.0, 95.0], [0.0, -94.0])
+        obs_inj = _AcObs([72.0, 64.0], [-71.3, -63.4])
+        sw = 0
+        res = compute_combined_pair_gst(
+            obs_start, obs_topo, obs_inj, [sw], [], [], [],
+            act1_is_injection=False, act2_is_injection=True)
+        beta_t = obs_inj.p_or[sw] / obs_start.p_or[sw]
+        # GST form: alpha*start + beta_t*topo + pure-superposition injection term
+        explicit = ((1.0 - beta_t) * obs_start.p_or + beta_t * obs_topo.p_or
+                    + (obs_inj.p_or - obs_start.p_or))
+        np.testing.assert_allclose(res["p_or_combined"], explicit, atol=1e-9)
 
 
 if __name__ == "__main__":

--- a/tests/test_superposition_gst.py
+++ b/tests/test_superposition_gst.py
@@ -1,0 +1,323 @@
+# Copyright (c) 2025-2026, RTE (https://www.rte-france.com)
+# See AUTHORS.txt
+# This Source Code Form is subject to the terms of the Mozilla Public License, version 2.0.
+# If a copy of the Mozilla Public License, version 2.0 was not distributed with this file,
+# you can obtain one at http://mozilla.org/MPL/2.0/.
+# SPDX-License-Identifier: MPL-2.0
+# This file is part of expert_op4grid_recommender
+
+"""
+Tests for the Generalized Superposition Theorem (GST) — action pairs that
+combine a topology action with an *injection* change (load shedding / renewable
+curtailment / redispatch), or two injection changes.
+
+Mirrors the structure of:
+  https://github.com/marota/Topology_Superposition_Theorem/blob/master/superposition_theorem/tests/test_generalized_superposition.py
+
+Each test verifies that ``compute_combined_pair_superposition`` (routed to the
+GST path via ``act*_is_injection``) produces ``p_or`` / ``p_ex`` matching the
+ground-truth combined-action simulation. The injection is a balanced grid2op
+redispatch, which stands in for the load-shedding / curtailment / redispatch
+``set_load_p`` / ``set_gen_p`` injection actions of the pypowsybl backend.
+"""
+
+import warnings
+import numpy as np
+import unittest
+from unittest.mock import MagicMock
+
+import grid2op
+from grid2op.Parameters import Parameters
+from lightsim2grid import LightSimBackend
+
+from expert_op4grid_recommender.utils.superposition import (
+    compute_combined_pair_superposition,
+    compute_combined_pair_gst,
+    compute_all_pairs_superposition,
+    is_injection_action,
+)
+from expert_op4grid_recommender.action_evaluation.classifier import ActionClassifier
+
+
+class TestGstActionTypeSuperposition(unittest.TestCase):
+
+    def setUp(self) -> None:
+        env_name = "l2rpn_case14_sandbox"
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore")
+            params = Parameters()
+            params.NO_OVERFLOW_DISCONNECTION = True
+            params.LIMIT_INFEASIBLE_CURTAILMENT_STORAGE_ACTION = True
+            params.ENV_DC = True
+            params.MAX_LINE_STATUS_CHANGED = 99999
+            params.MAX_SUB_CHANGED = 99999
+            self.env = grid2op.make(env_name, backend=LightSimBackend(), param=params, test=True)
+            self.env.set_max_iter(20)
+
+        self.chronic_id = 0
+        self.tol = 1e-3
+        # Balanced redispatch — stands in for an injection action (LS / RC / redispatch)
+        self.redisp = [(0, +5.0), (5, -5.0)]
+
+    def tearDown(self) -> None:
+        self.env.close()
+        return super().tearDown()
+
+    def _assert_accuracy(self, obs_target, result):
+        self.assertNotIn("error", result, f"GST returned error: {result.get('error')}")
+        p_computed = np.array(result["p_or_combined"])
+        max_diff = np.max(np.abs(obs_target.p_or - p_computed))
+        self.assertLessEqual(
+            max_diff, self.tol,
+            f"max |p_or_target - p_or_computed| = {max_diff:.2e} > tol {self.tol:.2e}")
+        p_ex_computed = np.array(result["p_ex_combined"])
+        max_diff_ex = np.max(np.abs(obs_target.p_ex - p_ex_computed))
+        self.assertLessEqual(
+            max_diff_ex, self.tol,
+            f"max |p_ex_target - p_ex_computed| = {max_diff_ex:.2e} > tol {self.tol:.2e}")
+
+    # =========================================================================
+    # line disconnection + injection
+    # =========================================================================
+    def test_line_disconnection_plus_injection(self):
+        self.env.set_id(self.chronic_id)
+        self.env.reset()
+        obs_start, *_ = self.env.step(self.env.action_space({}))
+        id_l = 3
+        obs_topo = obs_start.simulate(self.env.action_space({"set_line_status": [(id_l, -1)]}), 0)[0]
+        obs_inj = obs_start.simulate(self.env.action_space({"redispatch": self.redisp}), 0)[0]
+        obs_target = obs_start.simulate(
+            self.env.action_space({"set_line_status": [(id_l, -1)], "redispatch": self.redisp}), 0)[0]
+
+        result = compute_combined_pair_superposition(
+            obs_start, obs_topo, obs_inj,
+            act1_line_idxs=[id_l], act1_sub_idxs=[],
+            act2_line_idxs=[], act2_sub_idxs=[],
+            act1_is_injection=False, act2_is_injection=True,
+        )
+        self._assert_accuracy(obs_target, result)
+        # injection is reported with beta = 1.0
+        self.assertAlmostEqual(result["betas"][1], 1.0, places=6)
+        self.assertTrue(result.get("is_gst"))
+
+    # =========================================================================
+    # injection + line disconnection  (reversed order)
+    # =========================================================================
+    def test_injection_plus_line_disconnection_reversed(self):
+        self.env.set_id(self.chronic_id)
+        self.env.reset()
+        obs_start, *_ = self.env.step(self.env.action_space({}))
+        id_l = 3
+        obs_topo = obs_start.simulate(self.env.action_space({"set_line_status": [(id_l, -1)]}), 0)[0]
+        obs_inj = obs_start.simulate(self.env.action_space({"redispatch": self.redisp}), 0)[0]
+        obs_target = obs_start.simulate(
+            self.env.action_space({"set_line_status": [(id_l, -1)], "redispatch": self.redisp}), 0)[0]
+
+        # act1 = injection, act2 = topology
+        result = compute_combined_pair_superposition(
+            obs_start, obs_inj, obs_topo,
+            act1_line_idxs=[], act1_sub_idxs=[],
+            act2_line_idxs=[id_l], act2_sub_idxs=[],
+            act1_is_injection=True, act2_is_injection=False,
+        )
+        self._assert_accuracy(obs_target, result)
+        self.assertAlmostEqual(result["betas"][0], 1.0, places=6)
+
+    # =========================================================================
+    # line reconnection + injection
+    # =========================================================================
+    def test_line_reconnection_plus_injection(self):
+        self.env.set_id(self.chronic_id)
+        self.env.reset()
+        id_l = 3
+        obs_start, *_ = self.env.step(self.env.action_space({"set_line_status": [(id_l, -1)]}))
+        obs_topo = obs_start.simulate(self.env.action_space({"set_line_status": [(id_l, +1)]}), 0)[0]
+        obs_inj = obs_start.simulate(self.env.action_space({"redispatch": self.redisp}), 0)[0]
+        obs_target = obs_start.simulate(
+            self.env.action_space({"set_line_status": [(id_l, +1)], "redispatch": self.redisp}), 0)[0]
+
+        result = compute_combined_pair_superposition(
+            obs_start, obs_topo, obs_inj,
+            act1_line_idxs=[id_l], act1_sub_idxs=[],
+            act2_line_idxs=[], act2_sub_idxs=[],
+            act1_is_injection=False, act2_is_injection=True,
+        )
+        self._assert_accuracy(obs_target, result)
+
+    # =========================================================================
+    # node split + injection
+    # =========================================================================
+    def test_node_split_plus_injection(self):
+        self.env.set_id(self.chronic_id)
+        self.env.reset()
+        obs_start, *_ = self.env.step(self.env.action_space({}))
+        id_sub = 5
+        act_s = {"set_bus": {"substations_id": [(5, (1, 1, 2, 2, 1, 2, 2))]}}
+        obs_topo = obs_start.simulate(self.env.action_space(act_s), 0)[0]
+        obs_inj = obs_start.simulate(self.env.action_space({"redispatch": self.redisp}), 0)[0]
+        obs_target = obs_start.simulate(
+            self.env.action_space(act_s) + self.env.action_space({"redispatch": self.redisp}), 0)[0]
+
+        result = compute_combined_pair_superposition(
+            obs_start, obs_topo, obs_inj,
+            act1_line_idxs=[], act1_sub_idxs=[id_sub],
+            act2_line_idxs=[], act2_sub_idxs=[],
+            act1_is_injection=False, act2_is_injection=True,
+        )
+        self._assert_accuracy(obs_target, result)
+
+    # =========================================================================
+    # node merge + injection
+    # =========================================================================
+    def test_node_merge_plus_injection(self):
+        self.env.set_id(self.chronic_id)
+        self.env.reset()
+        id_sub = 5
+        split = self.env.action_space({"set_bus": {"substations_id": [(5, (1, 1, 2, 2, 1, 2, 2))]}})
+        obs_start, *_ = self.env.step(split)
+        merge = {"set_bus": {"substations_id": [(5, (1, 1, 1, 1, 1, 1, 1))]}}
+        obs_topo = obs_start.simulate(self.env.action_space(merge), 0)[0]
+        obs_inj = obs_start.simulate(self.env.action_space({"redispatch": self.redisp}), 0)[0]
+        obs_target = obs_start.simulate(
+            self.env.action_space(merge) + self.env.action_space({"redispatch": self.redisp}), 0)[0]
+
+        result = compute_combined_pair_superposition(
+            obs_start, obs_topo, obs_inj,
+            act1_line_idxs=[], act1_sub_idxs=[id_sub],
+            act2_line_idxs=[], act2_sub_idxs=[],
+            act1_is_injection=False, act2_is_injection=True,
+        )
+        self._assert_accuracy(obs_target, result)
+
+    # =========================================================================
+    # injection + injection
+    # =========================================================================
+    def test_injection_plus_injection(self):
+        self.env.set_id(self.chronic_id)
+        self.env.reset()
+        obs_start, *_ = self.env.step(self.env.action_space({}))
+        dP1 = [(0, +5.0), (5, -5.0)]
+        dP2 = [(1, +5.0), (5, -5.0)]
+        obs_i1 = obs_start.simulate(self.env.action_space({"redispatch": dP1}), 0)[0]
+        obs_i2 = obs_start.simulate(self.env.action_space({"redispatch": dP2}), 0)[0]
+        obs_target = obs_start.simulate(
+            self.env.action_space({"redispatch": [(0, +5.0), (1, +5.0), (5, -10.0)]}), 0)[0]
+
+        result = compute_combined_pair_superposition(
+            obs_start, obs_i1, obs_i2,
+            act1_line_idxs=[], act1_sub_idxs=[],
+            act2_line_idxs=[], act2_sub_idxs=[],
+            act1_is_injection=True, act2_is_injection=True,
+        )
+        self._assert_accuracy(obs_target, result)
+        self.assertEqual(result["betas"], [1.0, 1.0])
+
+    # =========================================================================
+    # GST direct entry point matches the routed call
+    # =========================================================================
+    def test_gst_direct_entrypoint_matches(self):
+        self.env.set_id(self.chronic_id)
+        self.env.reset()
+        obs_start, *_ = self.env.step(self.env.action_space({}))
+        id_l = 3
+        obs_topo = obs_start.simulate(self.env.action_space({"set_line_status": [(id_l, -1)]}), 0)[0]
+        obs_inj = obs_start.simulate(self.env.action_space({"redispatch": self.redisp}), 0)[0]
+
+        routed = compute_combined_pair_superposition(
+            obs_start, obs_topo, obs_inj, [id_l], [], [], [],
+            act1_is_injection=False, act2_is_injection=True)
+        direct = compute_combined_pair_gst(
+            obs_start, obs_topo, obs_inj, [id_l], [], [], [],
+            act1_is_injection=False, act2_is_injection=True)
+        np.testing.assert_allclose(routed["p_or_combined"], direct["p_or_combined"])
+        self.assertEqual(routed["betas"], direct["betas"])
+
+
+class TestIsInjectionAction(unittest.TestCase):
+    """Detection of injection actions by id prefix and classifier type."""
+
+    def setUp(self):
+        self.classifier = ActionClassifier()
+
+    def test_prefix_detection(self):
+        self.assertTrue(is_injection_action("load_shedding_LOAD_5"))
+        self.assertTrue(is_injection_action("curtail_GEN_2"))
+        self.assertTrue(is_injection_action("redispatch_GEN_7"))
+        self.assertFalse(is_injection_action("disco_LINE_3"))
+        self.assertFalse(is_injection_action("reco_LINE_1"))
+        self.assertFalse(is_injection_action("node_merging_SUB_4"))
+
+    def test_classifier_type_detection(self):
+        # load shedding via set_load_p
+        self.assertTrue(is_injection_action(
+            "x", {"set_load_p": {"L1": 0.0}}, self.classifier))
+        # curtailment via set_gen_p
+        self.assertTrue(is_injection_action(
+            "x", {"set_gen_p": {"G1": 0.0}}, self.classifier))
+        # redispatch via action_mode
+        self.assertTrue(is_injection_action(
+            "x", {"set_gen_p": {"G1": 50.0}, "action_mode": "redispatch"}, self.classifier))
+        # a plain topology action is not an injection
+        self.assertFalse(is_injection_action(
+            "x", {"description_unitaire": "Ouverture ligne LINE_3"}, self.classifier))
+
+
+class TestComputeAllPairsWithInjection(unittest.TestCase):
+    """compute_all_pairs_superposition now includes injection-bearing pairs."""
+
+    def test_injection_pairs_are_computed(self):
+        env = MagicMock()
+        env.name_line = ["LINE1", "LINE2", "LINE3"]
+
+        def _obs(rho, p_or):
+            o = MagicMock()
+            o.rho = np.array(rho)
+            o.p_or = np.array(p_or)
+            o.p_ex = -np.array(p_or)
+            return o
+
+        obs_start = _obs([1.1, 0.5, 0.5], [100.0, 50.0, 50.0])
+        obs_disco = _obs([1.0, 0.6, 0.6], [0.0, 60.0, 60.0])      # disconnect LINE1
+        obs_shed = _obs([0.95, 0.45, 0.45], [85.0, 45.0, 45.0])   # load shedding
+
+        detailed_actions = {
+            "disco_LINE1": {"action": MagicMock(), "observation": obs_disco,
+                            "description_unitaire": "Open LINE1", "non_convergence": None},
+            "load_shedding_L7": {"action": MagicMock(), "observation": obs_shed,
+                                 "description_unitaire": "Shed L7", "non_convergence": None},
+        }
+
+        classifier = MagicMock(spec=ActionClassifier)
+        classifier.identify_action_type.return_value = "open_line"
+        classifier._action_space = MagicMock()
+
+        from expert_op4grid_recommender.utils import superposition
+        orig_identify = superposition._identify_action_elements
+        try:
+            # disco_LINE1 -> line idx 0; load shedding -> no element
+            superposition._identify_action_elements = MagicMock(
+                side_effect=lambda action, aid, *a: ([0], []) if aid == "disco_LINE1" else ([], []))
+            results = compute_all_pairs_superposition(
+                obs_start=obs_start,
+                detailed_actions=detailed_actions,
+                classifier=classifier,
+                env=env,
+                lines_overloaded_ids=[0],
+                lines_we_care_about=["LINE1", "LINE2", "LINE3"],
+                pre_existing_rho={},
+                dict_action={},
+            )
+        finally:
+            superposition._identify_action_elements = orig_identify
+
+        # The topology+injection pair must now be present (previously skipped).
+        pair_id = "disco_LINE1+load_shedding_L7"
+        self.assertIn(pair_id, results)
+        res = results[pair_id]
+        self.assertNotIn("error", res)
+        # injection reported with beta = 1.0
+        self.assertAlmostEqual(res["betas"][1], 1.0, places=6)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Extends the superposition theorem framework to handle action pairs involving **injection changes** (load shedding, renewable curtailment, redispatch) in addition to topology-only pairs. Implements the Generalized Superposition Theorem (GST) adapted from [Topology_Superposition_Theorem](https://github.com/marota/Topology_Superposition_Theorem), enabling accurate flow estimation for mixed topology+injection and injection+injection action combinations.

## Key Changes

### Core GST Implementation (`utils/superposition.py`)
- **New `is_injection_action()`** — Detects load shedding / curtailment / redispatch by id prefix (`load_shedding_`, `curtail_`, `redispatch_`) or classifier action type
- **New `compute_combined_pair_gst()`** — Implements the GST formula where:
  - An injection action enters in **pure superposition** (its flow response is added in full)
  - A topology action keeps an EST beta that is **injection-shifted only through the RHS** of the 1×1 EST linear system
  - Both are reported with a `beta = 1.0` convention so the standard reconstruction formula `(1 − Σβ)·start + β₁·act1 + β₂·act2` reproduces exact GST flows
- **New `_resolve_topology_element()` and `_topology_beta_gst()`** — Helper functions to identify switched elements and compute injection-shifted betas
- **Updated `compute_combined_pair_superposition()`** — Routes to GST path when `act1_is_injection` or `act2_is_injection` flags are set
- **Updated `compute_all_pairs_superposition()`** — Now **keeps** injection actions (previously filtered out) and pairs them with topology actions and with each other; passes injection flags per pair

### Test Suite (`tests/test_superposition_gst.py`)
- **396 lines of comprehensive tests** validating all injection-bearing pair shapes:
  - Line disconnection/reconnection + injection
  - Node split/merge + injection
  - Injection + injection (two injection changes)
  - Reversed action order (injection first)
- **Accuracy validation** — All tests verify `p_or` / `p_ex` match ground-truth grid2op DC simulations to ~1e-3 MW tolerance
- **AC-anchoring tests** — `TestGstIsAcAnchored` confirms that beta RHS and reconstruction read AC observation values verbatim (not recomputed DC quantities)
- **Integration tests** — `TestComputeAllPairsWithInjection` confirms injection pairs are now computed in `compute_all_pairs_superposition`

### Documentation (`docs/superposition_module.md`)
- **New §10** — Comprehensive GST documentation covering:
  - Detection mechanism (id prefix and classifier type)
  - Mathematical formula and the `beta = 1.0` convention
  - AC-anchoring explanation (why AC values are used, what approximations remain)
  - Accuracy analysis (DC-exact, AC topology+injection matches EST, AC injection+injection weaker)
  - Known larger-error cases with root causes and how to interpret them
  - Comparison table of pair shapes and their betas/reconstruction

### Changelog
- Added entry documenting the GST feature, new functions, key identity, and test coverage

## Implementation Details

### The `beta = 1.0` Convention (Why Nothing Downstream Changes)
The GST reports an injection action with `beta = 1.0` and a topology action with its solved `beta_T`. Because each injection term `(obs_inj − obs_start)` equals `1.0·obs_inj − 1.0·obs_start`, the `−obs_start` parts fold into the `(1 − sum(betas))` weight. This means:
- The standard EST reconstruction formula works unchanged
- Rho estimators (`_estimate_rho_from_p`, direct rho superposition) need no GST-specific code
- Co-Study4Grid's `compute_combined_rho` is unaffected

###

https://claude.ai/code/session_01UQxnPH6uCbL616aWMR5muF