### PR TITLE
Show readable voltage-level names as overflow-graph node labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Readable voltage-level names as overflow-graph node labels
+
+For PyPSA-derived networks the substation/voltage-level IDs are opaque
+(`VL_way_...`) while a human-readable name (e.g. `"Saucats 400kV"`) is carried
+in the network's voltage-level `name` column. The overflow-graph visualization
+now renders that readable name as the node label.
+
+- **New** `get_zone_voltage_level_names(env_path)` in
+  `graph_analysis/visualization.py` — returns `{vl_id: readable_name}` from the
+  network, keeping only entries whose `name` is non-empty and differs from the
+  ID (cached per file path + mtime, like `get_zone_voltage_levels`).
+- `make_overflow_graph_visualization` sets the Graphviz `label` node attribute
+  from that mapping. **Node identity is left untouched** — the SVG `<title>` /
+  `data-name` keep the stable VL ID, so Co-Study4Grid pin overlays, geo-layout
+  matching and SLD lookups keep working; only the rendered text changes.
+- **New** config flag `USE_VOLTAGE_LEVEL_NAMES_IN_GRAPH` (default `True`).
+  Networks without separate readable names (the usual RTE case, `name == id`)
+  yield an empty mapping and are rendered unchanged. Name-lookup failures
+  degrade gracefully to IDs without aborting the render.
+
 ---
 
 ## [0.2.4] - 2026-06-15

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+---
+
+## [0.2.4.post1] - 2026-06-17
+
 ### Readable voltage-level names as overflow-graph node labels
 
 For PyPSA-derived networks the substation/voltage-level IDs are opaque
@@ -26,8 +30,31 @@ now renders that readable name as the node label.
   matching and SLD lookups keep working; only the rendered text changes.
 - **New** config flag `USE_VOLTAGE_LEVEL_NAMES_IN_GRAPH` (default `True`).
   Networks without separate readable names (the usual RTE case, `name == id`)
-  yield an empty mapping and are rendered unchanged. Name-lookup failures
-  degrade gracefully to IDs without aborting the render.
+  yield an empty mapping and are rendered unchanged.
+
+### Bug Fixes
+
+- **Overflow graph blank on zipped (`.zip`) network paths**: the visualization
+  re-loads the network from `config.ENV_PATH`, which for the game-mode
+  `network.xiidm.zip` is a raw zip that `pypowsybl.network.load` cannot read —
+  the resolver fell through to a bogus `<path>/grid.xiidm` and raised, aborting
+  the whole render (so suggestions appeared but no graph). New
+  `_resolve_network_file` / `_extract_network_zip` decompress a zipped network
+  to a cached sibling `.xiidm` (temp-dir fallback if read-only), and also
+  resolve a directory / companion `.zip`. Both `get_zone_voltage_levels` and
+  `get_zone_voltage_level_names` route through it.
+- **Readable labels never break the render**: label text is sanitized
+  (`_sanitize_graph_label`) so embedded double quotes / backslashes / newlines
+  can't produce malformed DOT (older `pydot` mis-escapes them and crashes
+  Graphviz). As a safety net, if `plot()` still fails with labels applied they
+  are stripped and the plot retried once, so a presentational nicety can never
+  remove the core graph.
+
+### Tests
+
+- `test_visualization_filtering.py`: name-loader filtering, label application
+  with preserved identity, the sanitizer, the retry-without-labels fallback,
+  and zip / directory / companion-zip path resolution + zip extraction reuse.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -176,6 +176,7 @@ DO_VISUALIZATION = True
 CHECK_ACTION_SIMULATION = True
 IGNORE_RECONNECTIONS = False
 N_PRIORITIZED_ACTIONS = 5
+USE_VOLTAGE_LEVEL_NAMES_IN_GRAPH = True  # readable VL names as overflow-graph node labels (v0.2.4+)
 
 # Lines monitoring flags (v0.1.3+)
 IGNORE_LINES_MONITORING = False     # bypass lines monitoring limits

--- a/expert_op4grid_recommender/__init__.py
+++ b/expert_op4grid_recommender/__init__.py
@@ -15,7 +15,7 @@ corrective measures to alleviate line overloads.
 
 import logging
 
-__version__ = "0.2.4"
+__version__ = "0.2.4.post1"
 
 _logger = logging.getLogger(__name__)
 

--- a/expert_op4grid_recommender/config.py
+++ b/expert_op4grid_recommender/config.py
@@ -111,6 +111,15 @@ class Settings(BaseSettings):
     # static PDF (default); "html" saves the interactive HTML viewer
     # introduced by ExpertOp4Grid PR #74.
     VISUALIZATION_FORMAT: Literal["pdf", "html"] = "pdf"
+    # Use human-readable voltage-level names (the ``name`` column of the
+    # network's voltage levels) as the displayed node labels in the
+    # overflow graph instead of the raw voltage-level IDs. Useful for
+    # PyPSA-derived networks where the IDs look like ``VL_way_...`` while a
+    # readable name (e.g. ``"Saucats 400kV"``) is available. The node
+    # identity stays the VL ID (so pin overlays / SLD lookups keep working);
+    # only the rendered text changes. When a VL has no name, or its name
+    # equals its ID, the ID is kept as-is.
+    USE_VOLTAGE_LEVEL_NAMES_IN_GRAPH: bool = True
     # Only possible for now with the pypowsybl backend.
     MAX_RHO_BOTH_EXTREMITIES: bool = True
     # Factor applied to permanent thermal limits when loading from

--- a/expert_op4grid_recommender/graph_analysis/visualization.py
+++ b/expert_op4grid_recommender/graph_analysis/visualization.py
@@ -117,6 +117,26 @@ def get_zone_voltage_level_names(env_path):
     return result
 
 
+def _sanitize_graph_label(text):
+    """Make a readable name safe to use as a Graphviz node label.
+
+    Older ``pydot`` (< 2.0) does **not** escape embedded double quotes in
+    attribute values, so a voltage-level name such as
+    ``LAAT "SET Gurrea - SET Sabiñánigo"`` serializes to malformed DOT
+    (``label="LAAT "SET Gurrea ..."``) that makes ``dot`` / ``neato``
+    crash — which aborts the *entire* overflow-graph render. We therefore
+    neutralise the characters that can break DOT across pydot versions:
+    double quotes and backslashes become harmless equivalents, control
+    characters / newlines collapse to single spaces, and a leading ``<`` is
+    pushed in so Graphviz can't mistake the value for an HTML-like label.
+    """
+    s = str(text).replace('"', "'").replace("\\", "/")
+    s = " ".join(s.split())  # collapse newlines / control chars / whitespace runs
+    if s.startswith("<"):
+        s = " " + s
+    return s
+
+
 def get_graph_file_name(lines_defaut, chronic_name, timestep, use_dc_load_flow):
     """
     Loads voltage level information for substations from a PowSyBl network file.
@@ -244,17 +264,19 @@ def make_overflow_graph_visualization(env, overflow_sim, g_overflow, hubs, obs_s
     # *rendered* text) and leave the node identity untouched, so the SVG
     # ``<title>`` / ``data-name`` — and therefore pin overlays, SLD lookups
     # and search — keep using the stable ID.
+    applied_label_nodes = []
     if getattr(config, "USE_VOLTAGE_LEVEL_NAMES_IN_GRAPH", True):
         try:
             vl_name_map = get_zone_voltage_level_names(config.ENV_PATH)
             if vl_name_map:
                 label_map = {
-                    node: vl_name_map[str(node)]
+                    node: _sanitize_graph_label(vl_name_map[str(node)])
                     for node in g_overflow.g.nodes
                     if str(node) in vl_name_map
                 }
                 if label_map:
                     nx.set_node_attributes(g_overflow.g, label_map, "label")
+                    applied_label_nodes = list(label_map.keys())
         except Exception as exc:
             # Readable labels are a presentational nicety — never let a
             # name-lookup failure abort the (otherwise valid) graph render.
@@ -334,14 +356,35 @@ def make_overflow_graph_visualization(env, overflow_sim, g_overflow, hubs, obs_s
         )
     # Generate and save visualization
     tmp_save_folder = os.path.join(save_folder, graph_file_name)
-    svg = g_overflow.plot(
-        custom_layout,
-        save_folder=tmp_save_folder,
-        fontsize=fontsize,
-        without_gray_edges=DRAW_ONLY_SIGNIFICANT_EDGES,
-        node_thickness=node_thickness,
-        rescale_factor=rescale_factor
-    )
+
+    def _plot():
+        return g_overflow.plot(
+            custom_layout,
+            save_folder=tmp_save_folder,
+            fontsize=fontsize,
+            without_gray_edges=DRAW_ONLY_SIGNIFICANT_EDGES,
+            node_thickness=node_thickness,
+            rescale_factor=rescale_factor
+        )
+
+    try:
+        svg = _plot()
+    except Exception as exc:
+        # The readable-name labels must never be able to break the graph
+        # render: some Graphviz/pydot combos choke on label text that the
+        # local stack here tolerates. If the labelled render fails, drop the
+        # display labels (node identity is unchanged) and retry once so the
+        # operator still gets the graph — just with VL IDs as text.
+        if applied_label_nodes:
+            print(
+                "Overflow-graph render failed with readable node labels "
+                f"({type(exc).__name__}: {exc}); retrying with VL IDs."
+            )
+            for node in applied_label_nodes:
+                g_overflow.g.nodes[node].pop("label", None)
+            svg = _plot()
+        else:
+            raise
 
     # Pick output format from config ("pdf" default, or "html" from PR #74).
     output_format = getattr(config, "VISUALIZATION_FORMAT", "pdf").lower()

--- a/expert_op4grid_recommender/graph_analysis/visualization.py
+++ b/expert_op4grid_recommender/graph_analysis/visualization.py
@@ -29,6 +29,84 @@ from expert_op4grid_recommender.config import DRAW_ONLY_SIGNIFICANT_EDGES, USE_G
 _zone_voltage_levels_cache = {}
 
 
+def _extract_network_zip(zip_path):
+    """Extract the first ``.xiidm`` / ``.xml`` member of ``zip_path`` and
+    return the path to the decompressed file.
+
+    The member is written next to the archive (so it is cached and reused
+    across calls); if that directory is read-only we fall back to a temp
+    dir. This mirrors Co-Study4Grid's ``network_service`` behaviour so the
+    recommender can load a zipped network (e.g. the game-mode
+    ``network.xiidm.zip``) on its own.
+    """
+    import os
+    import tempfile
+    import zipfile
+    from pathlib import Path
+
+    with zipfile.ZipFile(str(zip_path)) as zf:
+        members = [n for n in zf.namelist() if n.lower().endswith((".xiidm", ".xml", ".iidm"))]
+        if not members:
+            raise FileNotFoundError(f"No .xiidm/.xml member found inside {zip_path}")
+        member = members[0]
+        out_name = os.path.basename(member)
+        out_dir = os.path.dirname(os.path.abspath(str(zip_path)))
+        out_path = os.path.join(out_dir, out_name)
+        if os.path.isfile(out_path):
+            return Path(out_path)  # already decompressed — reuse
+        data = zf.read(member)
+        try:
+            with open(out_path, "wb") as f:
+                f.write(data)
+        except OSError:
+            out_path = os.path.join(tempfile.mkdtemp(prefix="eo4g_net_"), out_name)
+            with open(out_path, "wb") as f:
+                f.write(data)
+        return Path(out_path)
+
+
+def _resolve_network_file(env_path):
+    """Resolve ``env_path`` to a pypowsybl-loadable network file.
+
+    ``env_path`` may be a direct network file (``.xiidm`` / ``.iidm`` /
+    ``.xml``), a **zip archive** of one (``pypowsybl.network.load`` cannot
+    read an arbitrary ``.zip``, so we decompress it), or a directory
+    containing ``grid.xiidm`` (the Grid2Op-style layout).
+
+    The previous logic only recognised ``.xiidm`` / ``.iidm`` / ``.xml`` as
+    files, so a zipped network (e.g. the game-mode ``network.xiidm.zip``)
+    fell through to the directory branch and produced a bogus
+    ``network.xiidm.zip/grid.xiidm`` path that failed to load — aborting
+    the whole overflow-graph render even though action discovery (which
+    reuses the already-extracted network) succeeded.
+    """
+    from pathlib import Path
+    env_path = Path(env_path)
+
+    if env_path.is_file():
+        if env_path.suffix.lower() == ".zip":
+            return _extract_network_zip(env_path)
+        return env_path
+
+    if env_path.is_dir():
+        grid = env_path / "grid.xiidm"
+        if grid.is_file():
+            return grid
+        direct = [f for f in env_path.iterdir() if f.suffix.lower() in (".xiidm", ".iidm", ".xml")]
+        if direct:
+            return direct[0]
+        zips = [f for f in env_path.iterdir() if f.suffix.lower() == ".zip"]
+        if zips:
+            return _extract_network_zip(zips[0])
+        return grid
+
+    # Missing path: try a sibling/companion .zip (``foo.xiidm`` -> ``foo.xiidm.zip``).
+    for cand in (Path(str(env_path) + ".zip"), env_path.with_suffix(".zip")):
+        if cand.is_file():
+            return _extract_network_zip(cand)
+    return env_path / "grid.xiidm"
+
+
 def get_zone_voltage_levels(env_path):
     """
     Loads voltage level information for substations from a PowSyBl network file.
@@ -38,16 +116,7 @@ def get_zone_voltage_levels(env_path):
     voltage-level -> nominal-voltage mapping, so re-parsing the whole
     network each time is pure waste.
     """
-    from pathlib import Path
-    env_path = Path(env_path)
-
-    # If env_path is already a network file, use it directly
-    if env_path.is_file() and env_path.suffix.lower() in ['.xiidm', '.iidm', '.xml']:
-        network_file_path = env_path
-    else:
-        # Otherwise, look for grid.xiidm in the directory
-        file_iidm = "grid.xiidm"
-        network_file_path = env_path / file_iidm
+    network_file_path = _resolve_network_file(env_path)
 
     try:
         cache_key = (str(network_file_path), os.path.getmtime(network_file_path))
@@ -86,14 +155,7 @@ def get_zone_voltage_level_names(env_path):
     case, where ``name == id``) the result is empty and the graph is left
     unchanged. The result is cached per (file path, mtime).
     """
-    from pathlib import Path
-    env_path = Path(env_path)
-
-    # If env_path is already a network file, use it directly
-    if env_path.is_file() and env_path.suffix.lower() in ['.xiidm', '.iidm', '.xml']:
-        network_file_path = env_path
-    else:
-        network_file_path = env_path / "grid.xiidm"
+    network_file_path = _resolve_network_file(env_path)
 
     try:
         cache_key = (str(network_file_path), os.path.getmtime(network_file_path))

--- a/expert_op4grid_recommender/graph_analysis/visualization.py
+++ b/expert_op4grid_recommender/graph_analysis/visualization.py
@@ -13,6 +13,7 @@ import os
 import glob
 import shutil
 import numpy as np
+import networkx as nx
 import pypowsybl as pp
 
 # STEP 1: Import your config module
@@ -61,6 +62,58 @@ def get_zone_voltage_levels(env_path):
     if cache_key is not None:
         _zone_voltage_levels_cache.clear()  # keep at most the current network
         _zone_voltage_levels_cache[cache_key] = result
+    return result
+
+
+# Memoized result of get_zone_voltage_level_names keyed by (resolved network
+# file path, mtime). Same rationale as `_zone_voltage_levels_cache`: the
+# voltage-level name table is static within a study, so re-parsing the whole
+# .xiidm on every visualization call is wasted work.
+_zone_voltage_level_names_cache = {}
+
+
+def get_zone_voltage_level_names(env_path):
+    """Return ``{voltage_level_id: human_readable_name}`` from the network.
+
+    PyPSA-derived networks expose machine voltage-level IDs (``VL_way_...``)
+    as the node identity (``obs.name_sub``) while carrying a readable name
+    (e.g. ``"Saucats 400kV"``) in the voltage-level ``name`` column. This
+    helper extracts that mapping so the overflow-graph visualization can
+    relabel node *display text* without touching node identity.
+
+    Only entries whose ``name`` is non-empty AND differs from the ID are
+    returned: when a network has no separate readable names (the usual RTE
+    case, where ``name == id``) the result is empty and the graph is left
+    unchanged. The result is cached per (file path, mtime).
+    """
+    from pathlib import Path
+    env_path = Path(env_path)
+
+    # If env_path is already a network file, use it directly
+    if env_path.is_file() and env_path.suffix.lower() in ['.xiidm', '.iidm', '.xml']:
+        network_file_path = env_path
+    else:
+        network_file_path = env_path / "grid.xiidm"
+
+    try:
+        cache_key = (str(network_file_path), os.path.getmtime(network_file_path))
+    except OSError:
+        cache_key = None
+    if cache_key is not None and cache_key in _zone_voltage_level_names_cache:
+        return _zone_voltage_level_names_cache[cache_key]
+
+    n_zone = pp.network.load(str(network_file_path))
+    df_volt = n_zone.get_voltage_levels()
+    result = {}
+    if "name" in df_volt.columns:
+        for vl_id, name in zip(df_volt.index, df_volt["name"]):
+            name = "" if name is None else str(name)
+            if name and name != "nan" and name != str(vl_id):
+                result[str(vl_id)] = name
+
+    if cache_key is not None:
+        _zone_voltage_level_names_cache.clear()  # keep at most the current network
+        _zone_voltage_level_names_cache[cache_key] = result
     return result
 
 
@@ -182,6 +235,33 @@ def make_overflow_graph_visualization(env, overflow_sim, g_overflow, hubs, obs_s
     number_nodal_dict = {sub_name: len(set(obs_simu.sub_topology(i)) - {-1}) for i, sub_name in
                          enumerate(obs_simu.name_sub)}
     g_overflow.set_electrical_node_number(number_nodal_dict)
+
+    # Use human-readable voltage-level names as the displayed node labels.
+    # The graph nodes are identified by their voltage-level ID (from
+    # ``obs.name_sub``); for PyPSA-derived networks those IDs are opaque
+    # (``VL_way_...``) while a readable name is available in the network.
+    # We set the Graphviz ``label`` node attribute (which controls the
+    # *rendered* text) and leave the node identity untouched, so the SVG
+    # ``<title>`` / ``data-name`` — and therefore pin overlays, SLD lookups
+    # and search — keep using the stable ID.
+    if getattr(config, "USE_VOLTAGE_LEVEL_NAMES_IN_GRAPH", True):
+        try:
+            vl_name_map = get_zone_voltage_level_names(config.ENV_PATH)
+            if vl_name_map:
+                label_map = {
+                    node: vl_name_map[str(node)]
+                    for node in g_overflow.g.nodes
+                    if str(node) in vl_name_map
+                }
+                if label_map:
+                    nx.set_node_attributes(g_overflow.g, label_map, "label")
+        except Exception as exc:
+            # Readable labels are a presentational nicety — never let a
+            # name-lookup failure abort the (otherwise valid) graph render.
+            print(
+                "Could not apply voltage-level name labels to the overflow "
+                f"graph (keeping IDs): {type(exc).__name__}: {exc}"
+            )
 
     # Add hubs
     g_overflow.set_hubs_shape(hubs, shape_hub=shape_hub)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "expert_op4grid_recommender"
-version = "0.2.4"
+version = "0.2.4.post1"
 authors = [
     { name="RTE", email="rte@rte-france.com" },
 ]

--- a/tests/test_visualization_filtering.py
+++ b/tests/test_visualization_filtering.py
@@ -107,6 +107,24 @@ def test_get_zone_voltage_level_names_filters_ids_and_empty():
     assert result == {"VL_way_1": "Saucats 400kV"}
 
 
+def test_sanitize_graph_label_neutralizes_dot_breaking_chars():
+    """Embedded quotes / backslashes / newlines must not survive into the
+    label (older pydot mis-escapes them and crashes Graphviz)."""
+    from expert_op4grid_recommender.graph_analysis.visualization import (
+        _sanitize_graph_label,
+    )
+
+    assert _sanitize_graph_label('LAAT "SET Gurrea - SET Sabiñánigo"') == \
+        "LAAT 'SET Gurrea - SET Sabiñánigo'"
+    assert '"' not in _sanitize_graph_label('a "b" c')
+    assert "\\" not in _sanitize_graph_label("a\\b")
+    assert "\n" not in _sanitize_graph_label("line1\nline2")
+    # A value that would otherwise be read as an HTML-like label is defused.
+    assert not _sanitize_graph_label("<html>").startswith("<")
+    # Plain names with accents / dashes pass through unchanged.
+    assert _sanitize_graph_label("Subestación 220kV") == "Subestación 220kV"
+
+
 def test_visualization_sets_readable_node_labels():
     """Graph node `label` attribute is set to the readable VL name while the
     node identity (ID) is preserved."""
@@ -164,6 +182,63 @@ def test_visualization_sets_readable_node_labels():
     assert "label" not in real_g.nodes["VL_way_2"]
     # Node identities are unchanged (still the VL IDs).
     assert set(real_g.nodes) == {"VL_way_1", "VL_way_2"}
+
+
+def test_visualization_retries_without_labels_when_plot_fails():
+    """If the labelled render crashes (e.g. a Graphviz/pydot quirk), the
+    labels are dropped and the plot retried so the operator still gets a
+    graph."""
+    import networkx as nx
+    from expert_op4grid_recommender.graph_analysis.visualization import (
+        make_overflow_graph_visualization,
+    )
+
+    env = MagicMock()
+    env.name_line = np.array(["line1"])
+    overflow_sim = MagicMock()
+    overflow_sim.obs_linecut.rho = np.array([0.5])
+    overflow_sim.ltc = np.array([0])
+
+    real_g = nx.MultiDiGraph()
+    real_g.add_node("VL_way_1")
+    real_g.add_edge("VL_way_1", "VL_way_1", key=0, name="line1", color="blue")
+
+    g_overflow = MagicMock()
+    g_overflow.g = real_g
+    # First plot call raises (labels present), second succeeds.
+    g_overflow.plot.side_effect = [RuntimeError("graphviz boom"), "svg-data"]
+
+    obs_simu = MagicMock()
+    obs_simu.rho = np.array([0.5])
+    obs_simu.name_sub = ["VL_way_1"]
+    obs_simu.sub_topology.return_value = [1]
+    obs_simu._obs_env._parameters.ENV_DC = False
+
+    with patch("expert_op4grid_recommender.graph_analysis.visualization.get_zone_voltage_levels", return_value={}), \
+         patch("expert_op4grid_recommender.graph_analysis.visualization.get_zone_voltage_level_names",
+               return_value={"VL_way_1": "Saucats 400kV"}), \
+         patch("expert_op4grid_recommender.graph_analysis.visualization.config") as mock_config, \
+         patch("os.makedirs"), patch("shutil.move"), patch("shutil.rmtree"), \
+         patch("glob.glob", return_value=["/dummy/save/test_graph/Base graph/plot.pdf"]), \
+         patch("builtins.print"):
+
+        mock_config.ENV_PATH = "/dummy/path"
+        mock_config.USE_VOLTAGE_LEVEL_NAMES_IN_GRAPH = True
+        mock_config.DRAW_ONLY_SIGNIFICANT_EDGES = False
+        mock_config.USE_GRID_LAYOUT = False
+        mock_config.DO_CONSOLIDATE_GRAPH = False
+        mock_config.VISUALIZATION_FORMAT = "pdf"
+
+        svg = make_overflow_graph_visualization(
+            env, overflow_sim, g_overflow, hubs=[], obs_simu=obs_simu,
+            save_folder="/dummy/save", graph_file_name="test_graph",
+            lines_swapped=[], monitoring_factor_thermal_limits=1.0,
+        )
+
+    # Retried (two plot calls) and the label was stripped before the retry.
+    assert g_overflow.plot.call_count == 2
+    assert "label" not in real_g.nodes["VL_way_1"]
+    assert svg == "svg-data"
 
 
 if __name__ == "__main__":

--- a/tests/test_visualization_filtering.py
+++ b/tests/test_visualization_filtering.py
@@ -46,6 +46,7 @@ def test_make_overflow_graph_visualization_filtering():
     
     # 5. Patch external dependencies
     with patch("expert_op4grid_recommender.graph_analysis.visualization.get_zone_voltage_levels") as mock_get_volt, \
+         patch("expert_op4grid_recommender.graph_analysis.visualization.get_zone_voltage_level_names", return_value={}), \
          patch("expert_op4grid_recommender.graph_analysis.visualization.config") as mock_config, \
          patch("os.path.join", side_effect=os.path.join), \
          patch("os.makedirs"), \
@@ -85,6 +86,85 @@ def test_make_overflow_graph_visualization_filtering():
         
         # Check that line3 is NOT included (low rho and grey)
         assert "line3" not in dict_highlight
+
+def test_get_zone_voltage_level_names_filters_ids_and_empty():
+    """Only VLs with a readable name that differs from the ID are returned."""
+    import pandas as pd
+    from expert_op4grid_recommender.graph_analysis import visualization
+
+    df = pd.DataFrame(
+        {"name": ["Saucats 400kV", "VL_way_2", "", None]},
+        index=["VL_way_1", "VL_way_2", "VL_way_3", "VL_way_4"],
+    )
+    fake_network = MagicMock()
+    fake_network.get_voltage_levels.return_value = df
+
+    with patch.object(visualization.pp.network, "load", return_value=fake_network), \
+         patch("os.path.getmtime", side_effect=OSError):  # disable caching
+        result = visualization.get_zone_voltage_level_names("/some/grid.xiidm")
+
+    # Readable, distinct name kept; name==id, empty and None dropped.
+    assert result == {"VL_way_1": "Saucats 400kV"}
+
+
+def test_visualization_sets_readable_node_labels():
+    """Graph node `label` attribute is set to the readable VL name while the
+    node identity (ID) is preserved."""
+    import networkx as nx
+    from expert_op4grid_recommender.graph_analysis.visualization import (
+        make_overflow_graph_visualization,
+    )
+
+    env = MagicMock()
+    env.name_line = np.array(["line1"])
+
+    overflow_sim = MagicMock()
+    overflow_sim.obs_linecut.rho = np.array([0.5])
+    overflow_sim.ltc = np.array([0])
+
+    # Real graph so set_node_attributes actually mutates it.
+    real_g = nx.MultiDiGraph()
+    real_g.add_node("VL_way_1")
+    real_g.add_node("VL_way_2")
+    real_g.add_edge("VL_way_1", "VL_way_2", key=0, name="line1", color="blue")
+
+    g_overflow = MagicMock()
+    g_overflow.g = real_g
+
+    obs_simu = MagicMock()
+    obs_simu.rho = np.array([0.5])
+    obs_simu.name_sub = ["VL_way_1", "VL_way_2"]
+    obs_simu.sub_topology.return_value = [1]
+    obs_simu._obs_env._parameters.ENV_DC = False
+
+    with patch("expert_op4grid_recommender.graph_analysis.visualization.get_zone_voltage_levels", return_value={}), \
+         patch("expert_op4grid_recommender.graph_analysis.visualization.get_zone_voltage_level_names",
+               return_value={"VL_way_1": "Saucats 400kV"}), \
+         patch("expert_op4grid_recommender.graph_analysis.visualization.config") as mock_config, \
+         patch("os.makedirs"), patch("shutil.move"), patch("shutil.rmtree"), \
+         patch("glob.glob", return_value=["/dummy/save/test_graph/Base graph/plot.pdf"]), \
+         patch("builtins.print"):
+
+        mock_config.ENV_PATH = "/dummy/path"
+        mock_config.USE_VOLTAGE_LEVEL_NAMES_IN_GRAPH = True
+        mock_config.DRAW_ONLY_SIGNIFICANT_EDGES = False
+        mock_config.USE_GRID_LAYOUT = False
+        mock_config.DO_CONSOLIDATE_GRAPH = False
+        mock_config.VISUALIZATION_FORMAT = "pdf"
+
+        make_overflow_graph_visualization(
+            env, overflow_sim, g_overflow, hubs=[], obs_simu=obs_simu,
+            save_folder="/dummy/save", graph_file_name="test_graph",
+            lines_swapped=[], monitoring_factor_thermal_limits=1.0,
+        )
+
+    # Readable label applied to the matching node, identity untouched.
+    assert real_g.nodes["VL_way_1"]["label"] == "Saucats 400kV"
+    # Node without a readable name keeps no label override (renders its ID).
+    assert "label" not in real_g.nodes["VL_way_2"]
+    # Node identities are unchanged (still the VL IDs).
+    assert set(real_g.nodes) == {"VL_way_1", "VL_way_2"}
+
 
 if __name__ == "__main__":
     pytest.main([__file__])

--- a/tests/test_visualization_filtering.py
+++ b/tests/test_visualization_filtering.py
@@ -107,6 +107,35 @@ def test_get_zone_voltage_level_names_filters_ids_and_empty():
     assert result == {"VL_way_1": "Saucats 400kV"}
 
 
+def test_resolve_network_file_handles_zip_and_dir(tmp_path):
+    """A zipped network is decompressed; a directory falls back to its
+    xiidm; a plain file is used as-is."""
+    import zipfile
+    from expert_op4grid_recommender.graph_analysis.visualization import (
+        _resolve_network_file,
+    )
+
+    # Plain file used as-is.
+    xiidm = tmp_path / "net.xiidm"
+    xiidm.write_text("<network/>")
+    assert _resolve_network_file(xiidm) == xiidm
+
+    # Zip archive -> extracted sibling .xiidm (pypowsybl can't read the .zip).
+    zip_path = tmp_path / "network.xiidm.zip"
+    with zipfile.ZipFile(zip_path, "w") as zf:
+        zf.writestr("network.xiidm", "<network/>")
+    resolved = _resolve_network_file(zip_path)
+    assert resolved.suffix == ".xiidm"
+    assert resolved.is_file()
+    assert resolved.read_text() == "<network/>"
+
+    # Directory with grid.xiidm.
+    d = tmp_path / "envdir"
+    d.mkdir()
+    (d / "grid.xiidm").write_text("<network/>")
+    assert _resolve_network_file(d) == d / "grid.xiidm"
+
+
 def test_sanitize_graph_label_neutralizes_dot_breaking_chars():
     """Embedded quotes / backslashes / newlines must not survive into the
     label (older pydot mis-escapes them and crashes Graphviz)."""

--- a/tests/test_visualization_filtering.py
+++ b/tests/test_visualization_filtering.py
@@ -136,6 +136,83 @@ def test_resolve_network_file_handles_zip_and_dir(tmp_path):
     assert _resolve_network_file(d) == d / "grid.xiidm"
 
 
+def test_extract_network_zip_extracts_and_reuses(tmp_path):
+    """The zip member is extracted next to the archive and reused on a
+    second call (no re-extraction)."""
+    import zipfile
+    from expert_op4grid_recommender.graph_analysis.visualization import (
+        _extract_network_zip,
+    )
+
+    zip_path = tmp_path / "network.xiidm.zip"
+    with zipfile.ZipFile(zip_path, "w") as zf:
+        zf.writestr("network.xiidm", "<network>v1</network>")
+
+    out1 = _extract_network_zip(zip_path)
+    assert out1.is_file()
+    assert out1.parent == tmp_path
+    assert out1.read_text() == "<network>v1</network>"
+
+    # Reuse path: the extracted sibling already exists, so a second call
+    # returns it without rewriting (even if the zip member differs).
+    out2 = _extract_network_zip(zip_path)
+    assert out2 == out1
+
+
+def test_extract_network_zip_raises_without_xiidm_member(tmp_path):
+    import zipfile
+    from expert_op4grid_recommender.graph_analysis.visualization import (
+        _extract_network_zip,
+    )
+
+    zip_path = tmp_path / "bogus.zip"
+    with zipfile.ZipFile(zip_path, "w") as zf:
+        zf.writestr("readme.txt", "no network here")
+    with pytest.raises(FileNotFoundError):
+        _extract_network_zip(zip_path)
+
+
+def test_resolve_network_file_companion_zip(tmp_path):
+    """A missing ``foo.xiidm`` resolves to its companion ``foo.xiidm.zip``."""
+    import zipfile
+    from expert_op4grid_recommender.graph_analysis.visualization import (
+        _resolve_network_file,
+    )
+
+    zip_path = tmp_path / "network.xiidm.zip"
+    with zipfile.ZipFile(zip_path, "w") as zf:
+        zf.writestr("network.xiidm", "<network/>")
+
+    resolved = _resolve_network_file(tmp_path / "network.xiidm")  # does not exist
+    assert resolved.suffix == ".xiidm"
+    assert resolved.is_file()
+
+
+def test_get_zone_voltage_level_names_loads_through_zip(tmp_path):
+    """get_zone_voltage_level_names decompresses a .zip before loading
+    (pypowsybl can't read the archive directly)."""
+    import zipfile
+    import pandas as pd
+    from expert_op4grid_recommender.graph_analysis import visualization
+
+    zip_path = tmp_path / "network.xiidm.zip"
+    with zipfile.ZipFile(zip_path, "w") as zf:
+        zf.writestr("network.xiidm", "<network/>")
+
+    df = pd.DataFrame({"name": ["Readable A"]}, index=["VL_way_1"])
+    fake_network = MagicMock()
+    fake_network.get_voltage_levels.return_value = df
+
+    with patch.object(visualization.pp.network, "load", return_value=fake_network) as mock_load:
+        result = visualization.get_zone_voltage_level_names(zip_path)
+
+    # Loaded from the extracted .xiidm, NOT the raw .zip.
+    loaded_arg = str(mock_load.call_args[0][0])
+    assert loaded_arg.endswith(".xiidm")
+    assert not loaded_arg.endswith(".zip")
+    assert result == {"VL_way_1": "Readable A"}
+
+
 def test_sanitize_graph_label_neutralizes_dot_breaking_chars():
     """Embedded quotes / backslashes / newlines must not survive into the
     label (older pydot mis-escapes them and crashes Graphviz)."""


### PR DESCRIPTION
For PyPSA-derived networks the voltage-level IDs are opaque (VL_way_...)
while a readable name lives in the network's voltage-level `name` column.
The overflow-graph nodes now render that readable name.

- Add get_zone_voltage_level_names(env_path): {vl_id: readable_name},
  keeping only names that are non-empty and differ from the ID
  (cached per file path + mtime).
- make_overflow_graph_visualization sets the Graphviz `label` node
  attribute from that mapping. Node identity (SVG <title> / data-name)
  is preserved as the VL ID, so Co-Study4Grid pin overlays, geo-layout
  matching and SLD lookups keep working; only the rendered text changes.
- Add config flag USE_VOLTAGE_LEVEL_NAMES_IN_GRAPH (default True).
  Networks where name == id render unchanged; lookup failures degrade
  gracefully to IDs.
- Tests for the name loader and label application.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01SxDmpV5a1RZBgPd8gAuSvy