### PR TITLE
Add antenna (islanded-pocket) overflow graph support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Antenna (islanded-pocket) overflow graph
+
+When a contingency leaves a radial pocket fed by a single overloaded line,
+disconnecting that line breaks the grid apart, so the normal overflow-graph
+pipeline cannot read a flow redistribution. Antenna mode now builds the pocket
+graph through the **standard ExpertOp4Grid machinery** instead of a hand-rolled
+synthetic graph.
+
+- **Rewrote** `graph_analysis/antenna_graph.py::build_antenna_overflow_graph` to
+  feed `OverFlowGraph` + `Structured_Overload_Distribution_Graph` the
+  post-disconnection state implied by the islanding — the initial
+  post-contingency flows with every line incident to the pocket zeroed — and to
+  compute the same per-line `delta_flows` frame as
+  `alphaDeesp.Simulation.create_df`. alphaDeesp then decides edge colour,
+  orientation and the amont/aval split from the **real signed flows**.
+- **Handles both sub-cases**: a consumer pocket (downstream / aval) and a
+  producer pocket feeding the grid up through the overload (upstream / amont)
+  now both render with physical flow directions — fixing the previous inverted /
+  looping rendering and the "whole pocket = aval" misclassification.
+- **Removed** the synthetic `__GRID_SOURCE__` anchor and the BFS edge
+  orientation. The analysis graph spans the full grid (the gray healthy lines
+  anchor the root for `find_hubs`); the viewer renders a pocket-focused copy via
+  the new `focus_overflow_graph_on_pocket`.
+- **Injection targeting** (`action_evaluation/discovery/_orchestrator.py`): in
+  antenna mode load shedding / curtailment / redispatch now target the pocket
+  substations directly (from `antenna_meta`) rather than `n_aval()`, so a
+  producer pocket — correctly amont now — still gets candidates.
+- See `docs/antenna_overflow_graph.md`.
+
 ---
 
 ## [0.2.4.post1] - 2026-06-17

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,34 +9,49 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Antenna (islanded-pocket) overflow graph
+---
 
-When a contingency leaves a radial pocket fed by a single overloaded line,
-disconnecting that line breaks the grid apart, so the normal overflow-graph
-pipeline cannot read a flow redistribution. Antenna mode now builds the pocket
-graph through the **standard ExpertOp4Grid machinery** instead of a hand-rolled
-synthetic graph.
+## [0.2.5] - 2026-06-19
 
-- **Rewrote** `graph_analysis/antenna_graph.py::build_antenna_overflow_graph` to
-  feed `OverFlowGraph` + `Structured_Overload_Distribution_Graph` the
-  post-disconnection state implied by the islanding — the initial
-  post-contingency flows with every line incident to the pocket zeroed — and to
-  compute the same per-line `delta_flows` frame as
-  `alphaDeesp.Simulation.create_df`. alphaDeesp then decides edge colour,
-  orientation and the amont/aval split from the **real signed flows**.
-- **Handles both sub-cases**: a consumer pocket (downstream / aval) and a
-  producer pocket feeding the grid up through the overload (upstream / amont)
-  now both render with physical flow directions — fixing the previous inverted /
-  looping rendering and the "whole pocket = aval" misclassification.
-- **Removed** the synthetic `__GRID_SOURCE__` anchor and the BFS edge
-  orientation. The analysis graph spans the full grid (the gray healthy lines
-  anchor the root for `find_hubs`); the viewer renders a pocket-focused copy via
-  the new `focus_overflow_graph_on_pocket`.
-- **Injection targeting** (`action_evaluation/discovery/_orchestrator.py`): in
-  antenna mode load shedding / curtailment / redispatch now target the pocket
-  substations directly (from `antenna_meta`) rather than `n_aval()`, so a
-  producer pocket — correctly amont now — still gets candidates.
-- See `docs/antenna_overflow_graph.md`.
+### Antenna (islanded-pocket) recommendations
+
+A new analysis mode for the case where a contingency leaves a **radial pocket**
+of substations fed by a single overloaded line — so disconnecting that line
+**breaks the grid apart** (no `lines_overloaded_ids_kept`). Previously the
+analysis gave up ("Overload breaks the grid apart. No topological solution
+without load shedding."). It now describes the islanded pocket, builds a proper
+overflow graph for it, and recommends the **injection actions** that can relieve
+the overload.
+
+- **Detection** (`graph_analysis/processor.py`): `extract_antenna_context`
+  identifies the pocket islanded by removing the max overload — its constraint
+  line, root (main-grid) and entry (pocket) substations, and the full pocket
+  substation set. Gated by `config.ENABLE_ANTENNA_RECOMMENDATIONS` (default
+  `True`); falls back to the legacy "no solution" message when off or when the
+  pocket is not a clean single-feed antenna.
+- **Overflow graph** (`graph_analysis/antenna_graph.py`): the pocket graph is
+  built through the **standard ExpertOp4Grid machinery** (`OverFlowGraph` +
+  `Structured_Overload_Distribution_Graph`), fed the post-disconnection state
+  implied by the islanding — the initial post-contingency flows with every line
+  incident to the pocket zeroed — and the same per-line `delta_flows` frame as
+  `alphaDeesp.Simulation.create_df`. alphaDeesp decides edge colour, orientation
+  and the amont/aval split from the **real signed flows**, so a **consumer
+  pocket** (downstream / aval) and a **producer pocket** feeding the grid up
+  through the overload (upstream / amont) both render with physical flow
+  directions — no inversion, no looping.
+- **Injection-only discovery** (`action_evaluation/discovery/_orchestrator.py`):
+  in antenna mode the topological families are filtered out and only load
+  shedding / renewable curtailment / redispatch are discovered, targeting the
+  **pocket substations directly** (via `antenna_meta`) so a producer pocket —
+  correctly classified amont — still gets candidates. Both redispatch directions
+  are offered; the per-action simulation check keeps only the ones that help.
+- **Result payload**: `run_analysis` results carry `antenna_meta` (pocket
+  substations, total prod/load/net MW, `direction`) so UIs can phrase the
+  recommendation; `antenna_mode` flags the case.
+- **Visualization** (`main.py`): the analysis graph spans the full grid (the
+  gray healthy lines anchor the root for `find_hubs`); the viewer renders a
+  pocket-focused copy via `focus_overflow_graph_on_pocket`.
+- See `docs/antenna_overflow_graph.md`. Tests in `tests/test_antenna_graph.py`.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -318,6 +318,8 @@ tests/
 ├── test_min_action_counts.py            # MIN_* enforcement
 ├── test_islanding_mw.py                 # Islanding MW quantification (v0.1.8+)
 ├── test_environment_detection.py        # Env detection logic
+├── test_antenna_graph.py                # Antenna (islanded-pocket) overflow graph
+│                                        # (see docs/antenna_overflow_graph.md)
 └── test_visualization_filtering.py      # Visualization filters
 ```
 
@@ -409,6 +411,7 @@ See `MIGRATION_PLAN.md` for details. The goal is to remove `grid2op` dependency.
 | Modify expert rules | `action_evaluation/rules.py` |
 | Modify action scoring | `action_evaluation/discovery.py` |
 | Change graph analysis | `graph_analysis/builder.py`, `processor.py` |
+| Antenna (islanded-pocket) graph | `graph_analysis/antenna_graph.py`, `processor.py` (`extract_antenna_context`, `pre_process_antenna_graph`); see `docs/antenna_overflow_graph.md` |
 | pypowsybl migration | `pypowsybl_backend/*`, `environment_pypowsybl.py` |
 | Adjust rho calculation | `pypowsybl_backend/observation.py`, `overflow_analysis.py` |
 | Configure monitoring | `config.py` (`LINES_MONITORING_FILE`, `IGNORE_LINES_MONITORING`) |

--- a/docs/antenna_overflow_graph.md
+++ b/docs/antenna_overflow_graph.md
@@ -1,0 +1,198 @@
+# Design: Antenna (islanded-pocket) overflow graph
+
+> **Version**: 0.2.4+ (unreleased)
+> **Author**: RTE / Expert Op4Grid Recommender
+> **Modules**: `graph_analysis/antenna_graph.py`, `graph_analysis/processor.py`,
+> `action_evaluation/discovery/_orchestrator.py`, `main.py`
+
+---
+
+## 1. Problem
+
+The normal overflow-graph pipeline (`build_overflow_graph` /
+`build_overflow_graph_pypowsybl`) simulates **disconnecting the overloaded
+line** and reads how power *redistributes* across the rest of the grid. That
+redistribution is what colours the edges and feeds action discovery.
+
+When a contingency leaves a **radial pocket** of substations fed by a single
+overloaded line, disconnecting that line **breaks the grid apart** — the pocket
+islands. The load flow on the cut grid then diverges (the pocket has no slack
+and simply blacks out), so there is no meaningful redistribution to read. This
+is detected upstream in step 1:
+
+```
+identify_overload_lines_to_keep_overflow_graph_connected(...) -> ids_kept is empty
+extract_antenna_context(obs, lines_overloaded_ids)            -> pocket description
+```
+
+`extract_antenna_context` returns the pocket: the **constraint line**, its
+**root** substation (on the main grid) and its **entry** substation (inside the
+pocket), plus the full list of pocket substation ids. When it finds a pocket the
+analysis switches to **antenna mode** (`context["antenna_mode"] = True`).
+
+There are **two** physical sub-cases, and both must be handled:
+
+| Sub-case | Pocket net | Power flow on the constraint | Pocket side |
+|----------|-----------|------------------------------|-------------|
+| **Consumer pocket** | load > prod | main grid → pocket | downstream (**aval**) |
+| **Producer pocket** | prod > load | pocket → main grid | upstream (**amont**) |
+
+A producer pocket feeds the rest of the grid *up* through the overload (the case
+an RTE operator flagged: "flow comes from G.ROUP6 up to SOULLP6").
+
+---
+
+## 2. Principle: reuse the standard pipeline with a synthetic "after" state
+
+Rather than hand-build a graph, we feed the **standard ExpertOp4Grid machinery**
+the post-disconnection state implied by the islanding:
+
+> **new_flows = initial post-contingency flows, with every line incident to the
+> islanded pocket set to 0.**
+
+Modelling the pocket as simply blacking out (no internal redistribution; the
+healthy grid untouched) gives, per line:
+
+```
+delta_flows = new_flows - init_flows
+            = 0                         on the healthy grid   (gray, trimmed)
+            = -init_flows (signed)      on the pocket lines   (blue / coral)
+```
+
+From these explicit `new_flows` we compute **the exact same per-line
+`delta_flows` frame** as `alphaDeesp.Simulation.create_df` — branch-direction
+swap, `new_flows_swapped` handling, the gray-edge threshold — and then build the
+graph with the genuine `OverFlowGraph` + `Structured_Overload_Distribution_Graph`,
+identical to the standard builders minus the (diverging) load flow.
+
+Because the frame carries the **real signed flows**, alphaDeesp decides edge
+colour, orientation and the amont/aval split itself — so consumer and producer
+pockets both come out with physical directions, no looping, no inversion.
+
+```
+   Consumer pocket (aval):    [root] ──black──▶ [entry] ──blue──▶ [pocket loads]
+   Producer pocket (amont):   [pocket gens] ──blue──▶ [entry] ──black──▶ [root]
+```
+
+---
+
+## 3. Implementation
+
+### 3.1 `build_antenna_overflow_graph(obs, constraint_line_id, antenna_sub_ids, root_sub_id)`
+
+`graph_analysis/antenna_graph.py`. Returns the same 7-tuple as the standard
+builders **plus** `antenna_meta`:
+
+```
+(df_of_g, overflow_sim=None, g_overflow, real_hubs,
+ g_distribution_graph, node_name_mapping, antenna_meta)
+```
+
+Steps:
+
+1. `new_flows = obs.p_or` copied, then zeroed on `_islanded_line_mask(...)`
+   (every line with **at least one endpoint in the pocket** — the internal
+   branches *and* the constraint line).
+2. `_compute_delta_flow_frame(...)` — vectorised twin of alphaDeesp's
+   `create_df` (and of the pypowsybl backend's
+   `compute_flow_changes_after_disconnection`): produces the `idx_or, idx_ex,
+   init_flows, new_flows, new_flows_swapped, delta_flows, gray_edges, line_name`
+   frame, one row per line, in line order.
+3. `_inhibit_swapped_flows(df)` — same correction as the standard builders.
+4. `OverFlowGraph(topo, [constraint_line_id], df)` — the constraint row is the
+   black cut edge; relabel nodes to substation names.
+5. `Structured_Overload_Distribution_Graph(...)` + `get_hubs()`.
+6. Build `antenna_meta` (pocket prod/load/net MW, `direction`).
+
+`node_name_mapping` is the plain full-grid identity `{sub_id: name}` (no
+synthetic node), so `pre_process_antenna_graph` reverts node names back to real
+substation indices for action discovery.
+
+### 3.2 Full graph for analysis, focused copy for the viewer
+
+The analysis graph is kept over the **full grid**. The healthy lines carry zero
+delta (gray) but they **anchor the root** so alphaDeesp's `find_hubs` does not
+drop it as an isolate (a root left with only its single black constraint edge
+crashes `find_hubs`). This is why we do **not** trim the analysis graph.
+
+For the operator-facing render, `focus_overflow_graph_on_pocket(g_overflow, obs,
+root_sub_id, antenna_sub_ids)` returns a **copy** restricted to `{root} ∪
+pocket`. The visualization never rebuilds the structured-overload graph, so
+trimming the root down to its black edge there is safe. `main._make_antenna_visualization`
+renders this focused copy.
+
+### 3.3 Action targeting (`_orchestrator.py`)
+
+In antenna mode only injection families are discovered (`ls`, `rc`,
+`redispatch`); topological families are filtered out (a radial pocket has no
+loops / couplings to act on).
+
+Injection candidates are taken **directly from the pocket** substation ids
+(`antenna_meta["antenna_sub_ids"]`), *not* from `n_aval()` — because a producer
+pocket is now correctly classified **amont**, so aval-only targeting would miss
+it. Both redispatch directions (raise / lower) are offered; the per-action
+simulation check keeps only the ones that actually relieve the overload.
+
+---
+
+## 4. `antenna_meta`
+
+```python
+{
+  "constraint_line_id":  int,
+  "constraint_line_name": str,
+  "root_sub_id":   int,            # main-grid endpoint of the constraint
+  "root_sub_name": str,
+  "antenna_sub_ids":   List[int],  # pocket substation ids
+  "antenna_sub_names": List[str],
+  "n_subs":   int,
+  "total_prod_mw": float,          # summed over the pocket
+  "total_load_mw": float,
+  "net_mw":   float,               # prod - load
+  "direction": "producer" | "consumer",
+}
+```
+
+`direction` is derived from the pocket's net injection (`net_mw > 0` →
+producer). It is independent of the *graph* orientation (which alphaDeesp derives
+from the flows); both should agree on a physically consistent case, but
+`direction` is the robust signal the UI uses to phrase the recommendation
+("curtail / redispatch-down" for a producer, "load-shed / redispatch-up" for a
+consumer). Surfaced to Co-Study4Grid via the result payload (`antenna_meta`).
+
+---
+
+## 5. Tests
+
+`tests/test_antenna_graph.py` (self-contained — hand-built grid2op-compatible
+observation, no pypowsybl / real env):
+
+- **Pocket detection** — `extract_antenna_context` finds the pocket / returns
+  `None` when there is no overload.
+- **Graph correctness** — consumer pocket: constraint black, branches blue,
+  oriented root→pocket, healthy grid gray; producer (exporting) pocket:
+  branches oriented pocket→root, pocket classified **amont**.
+- **Helpers** — `_islanded_line_mask`, `_build_topo` (prod/load per sub, full
+  edge list), `_compute_delta_flow_frame` (collapse → `-init` on the pocket,
+  zero elsewhere; gray threshold relative to the constraint report), full
+  alphaDeesp column set on `df_of_g`.
+- **Robustness** — negative constraint `p_or` (branch-direction swap),
+  `focus_overflow_graph_on_pocket` preserves edge styling, skips out-of-range
+  ids and leaves the analysis graph untouched.
+- **Discovery** — antenna mode runs injection families only; injection
+  targeting hits the pocket even when it is amont; `pre_process_antenna_graph`
+  reverts to integer ids without losing the constrained path; the full analysis
+  graph survives `find_hubs`.
+
+---
+
+## 6. Limitations / future work
+
+- The "blackout collapse" model ignores any redistribution **within** the
+  healthy grid when the pocket is lost — the healthy grid is shown at zero
+  delta. This is intentional (it focuses the graph on the pocket) and matches
+  the operator's mental model, but it is an approximation of the true post-cut
+  flows on the main grid.
+- A single-feed pocket is assumed (`extract_antenna_context` bails out if the
+  constraint does not cleanly bridge exactly one pocket-to-grid boundary).
+  Multi-feed islanded regions are out of scope.

--- a/docs/release-notes/v0.2.5.md
+++ b/docs/release-notes/v0.2.5.md
@@ -1,0 +1,121 @@
+# v0.2.5 — Antenna (islanded-pocket) recommendations
+
+A minor feature release on top of `0.2.4.post1`. Adds a new analysis mode for
+the case where an N-1 contingency leaves a **radial pocket** of substations fed
+by a single overloaded line — disconnecting that line **breaks the grid apart**.
+The recommender previously gave up on this case ("Overload breaks the grid
+apart. No topological solution without load shedding."). It now describes the
+islanded pocket, builds a proper overflow graph for it, and recommends the
+**injection actions** (load shedding / renewable curtailment / redispatch) that
+can relieve the overload.
+
+No breaking changes — the new mode is additive and only engages when a pocket is
+detected; it is gated by `config.ENABLE_ANTENNA_RECOMMENDATIONS` (default
+`True`).
+
+## Highlights
+
+- **Pocket detection** (`graph_analysis/processor.py::extract_antenna_context`).
+  When the island-prevention guard keeps no overloads (`lines_overloaded_ids_kept`
+  is empty), the contingency islands a radial pocket. The detector returns the
+  pocket: the **constraint** line, its **root** (main-grid endpoint) and
+  **entry** (pocket endpoint) substations, and the full pocket substation set.
+  Bails out (legacy "no solution" path) when antenna mode is disabled or the
+  pocket is not a clean single-feed antenna.
+
+- **Overflow graph via the standard pipeline**
+  (`graph_analysis/antenna_graph.py::build_antenna_overflow_graph`). Instead of a
+  hand-rolled synthetic graph, the pocket graph is built through the genuine
+  `OverFlowGraph` + `Structured_Overload_Distribution_Graph`. The trick: feed
+  alphaDeesp the post-disconnection state implied by the islanding —
+
+  > `new_flows = initial post-contingency flows, with every line incident to the
+  > pocket set to 0` (the pocket blacks out; the healthy grid is untouched).
+
+  From that we compute **the same per-line `delta_flows` frame** as
+  `alphaDeesp.Simulation.create_df` (branch-direction swap, `new_flows_swapped`
+  handling, gray-edge threshold). alphaDeesp then decides edge colour,
+  orientation and the **amont/aval split** from the real *signed* flows.
+
+- **Both physical sub-cases handled.** A **consumer pocket** (load > prod) is
+  downstream / **aval**; a **producer pocket** (prod > load) feeding the grid up
+  through the overload is upstream / **amont**. Both now render with physical
+  flow directions — fixing a previous rendering that inverted producer pockets,
+  looped branches, and misclassified the whole pocket as aval.
+
+- **Injection-only discovery**
+  (`action_evaluation/discovery/_orchestrator.py`). In antenna mode the
+  topological families (reconnection, splitting/merging, line disconnection,
+  PST) are filtered out — a radial pocket has nothing to act on topologically.
+  Load shedding / curtailment / redispatch target the **pocket substations
+  directly** (from `antenna_meta`), not `n_aval()`, so a producer pocket —
+  correctly amont now — still gets candidates. Both redispatch directions are
+  offered; the per-action simulation check keeps only the ones that relieve the
+  overload.
+
+- **`antenna_meta` in the result payload.** `run_analysis` results carry
+  `antenna_meta` (constraint line, root/pocket substations, total
+  prod/load/net MW, `direction` ∈ {`producer`, `consumer`}) and the
+  `antenna_mode` flag, so a UI can phrase the recommendation
+  ("curtail / redispatch-down" for a producer, "load-shed / redispatch-up" for a
+  consumer).
+
+- **Full graph for analysis, focused copy for the viewer.** The analysis graph
+  spans the full grid (the gray, zero-delta healthy lines anchor the root so
+  alphaDeesp's `find_hubs` does not drop it as an isolate). The viewer renders a
+  pocket-focused copy via the new `focus_overflow_graph_on_pocket`, so the
+  operator sees a clean pocket instead of the whole network.
+
+## Compatibility
+
+- **Additive.** The mode only engages when `extract_antenna_context` finds a
+  pocket; non-antenna analyses are unchanged.
+- **New config flags**: `ENABLE_ANTENNA_RECOMMENDATIONS` (default `True`),
+  `DO_FORCE_OVERLOAD_GRAPH_EVEN_IF_GRAPH_BROKEN_APART` (default `False`).
+- **Result payload addition**: `antenna_meta` / `antenna_mode` keys. Existing
+  consumers that ignore unknown keys are unaffected.
+- The "blackout collapse" model shows the healthy grid at zero delta (focused on
+  the pocket); it is an approximation of the true post-cut main-grid flows.
+  Single-feed pockets only.
+
+## Tests
+
+- `tests/test_antenna_graph.py` (self-contained — hand-built grid2op-compatible
+  observation, no pypowsybl / real env):
+  - pocket detection; consumer vs producer (exporting) orientation and
+    amont/aval classification;
+  - helper units — `_islanded_line_mask`, `_build_topo`,
+    `_compute_delta_flow_frame` (collapse → `-init` on the pocket / `0` on the
+    healthy grid; gray threshold relative to the constraint report), full
+    alphaDeesp column set;
+  - robustness — negative constraint `p_or` (branch-direction swap),
+    `focus_overflow_graph_on_pocket` (edge styling preserved, out-of-range ids
+    skipped, analysis graph untouched);
+  - discovery — injection-only in antenna mode, pocket targeting even when
+    amont, `pre_process_antenna_graph` reversion, `find_hubs` survival.
+
+## Files touched
+
+- `expert_op4grid_recommender/graph_analysis/antenna_graph.py`:
+  `build_antenna_overflow_graph` (standard-pipeline rewrite), `_build_topo`,
+  `_islanded_line_mask`, `_compute_delta_flow_frame`, `_inhibit_swapped_flows`,
+  `focus_overflow_graph_on_pocket`.
+- `expert_op4grid_recommender/graph_analysis/processor.py`:
+  `extract_antenna_context`, `pre_process_antenna_graph`.
+- `expert_op4grid_recommender/action_evaluation/discovery/_orchestrator.py`:
+  injection-only gating + pocket-direct targeting in antenna mode.
+- `expert_op4grid_recommender/main.py`: antenna step-1 detection / step-2 graph
+  build, `_make_antenna_visualization` (focused render), `antenna_meta` in the
+  result payload.
+- `tests/test_antenna_graph.py`: antenna test suite.
+- `docs/antenna_overflow_graph.md`: design doc.
+- `CHANGELOG.md`, `CLAUDE.md`, `docs/release-notes/v0.2.5.md`: release docs.
+- `pyproject.toml`, `expert_op4grid_recommender/__init__.py`: version bump
+  `0.2.4.post1` → `0.2.5`.
+
+## Companion
+
+The antenna mode is consumed by **Co-Study4Grid**: it surfaces the islanded
+pocket and the injection recommendations in the UI (banner + `antenna_meta`),
+and includes a step-2 fix for the islanding case
+(`lines_overloaded_ids_kept = None`). See that project's branch.

--- a/expert_op4grid_recommender/__init__.py
+++ b/expert_op4grid_recommender/__init__.py
@@ -15,7 +15,7 @@ corrective measures to alleviate line overloads.
 
 import logging
 
-__version__ = "0.2.4.post1"
+__version__ = "0.2.5"
 
 _logger = logging.getLogger(__name__)
 

--- a/expert_op4grid_recommender/action_evaluation/discovery/_base.py
+++ b/expert_op4grid_recommender/action_evaluation/discovery/_base.py
@@ -54,6 +54,8 @@ class DiscovererBase:
         check_rho_reduction_func: Optional[Callable] = None,
         create_default_action_func: Optional[Callable] = None,
         obs_linecut: Optional[Any] = None,
+        antenna_mode: bool = False,
+        antenna_meta: Optional[Dict] = None,
     ):
         """
         Initializes the ActionDiscoverer with the necessary context and parameters.
@@ -90,6 +92,12 @@ class DiscovererBase:
         self.obs = obs
         self.obs_defaut = obs_defaut
         self.obs_linecut = obs_linecut
+        # Antenna mode: the overflow graph is a synthetic downstream graph of an
+        # islanded radial pocket. Discovery is restricted to injection actions
+        # (load shedding / renewable curtailment / redispatch); topological
+        # actions are skipped (see OrchestratorMixin.discover_and_prioritize).
+        self.antenna_mode = antenna_mode
+        self.antenna_meta = antenna_meta
         self.action_space = env.action_space
         self.timestep = timestep
         self.lines_defaut = lines_defaut

--- a/expert_op4grid_recommender/action_evaluation/discovery/_orchestrator.py
+++ b/expert_op4grid_recommender/action_evaluation/discovery/_orchestrator.py
@@ -60,6 +60,13 @@ class OrchestratorMixin:
         from expert_op4grid_recommender import config as _cfg
         _allowed_types = set(getattr(_cfg, "ALLOWED_ACTION_TYPES", []) or [])
 
+        # Antenna mode: the overflow graph is a synthetic downstream graph of an
+        # islanded radial pocket — only injection actions make sense there, so
+        # topological families are filtered out regardless of ALLOWED_ACTION_TYPES.
+        antenna_mode = getattr(self, "antenna_mode", False)
+        if antenna_mode:
+            _allowed_types = {"ls", "rc", "redispatch"}
+
         def _type_allowed(token: str) -> bool:
             return not _allowed_types or token in _allowed_types
 
@@ -99,9 +106,15 @@ class OrchestratorMixin:
             else:
                 red_loop_paths_names = []
 
-            _, nodes_dispatch_loop_indices = (
-                self.g_distribution_graph.get_dispatch_edges_nodes(only_loop_paths=True)
-            )
+            if antenna_mode:
+                # A radial pocket is a pure tree: no parallel red dispatch loops.
+                # Skip get_dispatch_edges_nodes(only_loop_paths=True), which
+                # additionally raises on an empty red_loops DataFrame.
+                nodes_dispatch_loop_indices = []
+            else:
+                _, nodes_dispatch_loop_indices = (
+                    self.g_distribution_graph.get_dispatch_edges_nodes(only_loop_paths=True)
+                )
             nodes_dispatch_loop_names = list(
                 name_sub_arr[
                     [idx for idx in nodes_dispatch_loop_indices if idx < n_subs]
@@ -174,6 +187,11 @@ class OrchestratorMixin:
             (set(nodes_blue_path_indices) - set(nodes_aval_indices))
             | set(nodes_dispatch_loop_indices)
         )
+        if antenna_mode:
+            # A radial pocket is a pure tree with no dispatch loops: every node
+            # is downstream (aval). Curtailment must still be able to target the
+            # pocket's renewable generators (relevant for a net-producer pocket).
+            nodes_rc_indices = list(nodes_aval_indices)
         if _type_allowed("rc") and nodes_rc_indices:
             with Timer("Verifying relevant renewable curtailment"):
                 print("\n--- Verifying relevant renewable curtailment ---")
@@ -191,6 +209,12 @@ class OrchestratorMixin:
         nodes_down_indices = list(
             set(nodes_blue_path_indices) - set(nodes_aval_indices)
         )
+        if antenna_mode:
+            # In a radial pocket, raising production (net-consumer pocket) and
+            # lowering production (net-producer pocket) both target the pocket
+            # itself. Offer both; the per-action simulation check keeps only the
+            # ones that actually reduce the overload.
+            nodes_down_indices = list(set(nodes_down_indices) | set(nodes_aval_indices))
         if _type_allowed("redispatch") and (nodes_up_indices or nodes_down_indices):
             with Timer("Verifying relevant redispatching"):
                 print("\n--- Verifying relevant redispatching ---")

--- a/expert_op4grid_recommender/action_evaluation/discovery/_orchestrator.py
+++ b/expert_op4grid_recommender/action_evaluation/discovery/_orchestrator.py
@@ -178,6 +178,17 @@ class OrchestratorMixin:
         nodes_aval_indices = (
             list(constrained_path.n_aval()) if constrained_path is not None else []
         )
+        if antenna_mode and getattr(self, "antenna_meta", None):
+            # The islanded pocket can sit on EITHER side of the constraint: a
+            # consumer pocket is downstream (aval), a producer pocket — feeding
+            # the rest of the grid up through the overload — is upstream (amont).
+            # Injection actions always target the pocket itself, so address it
+            # directly by its substation ids rather than the amont/aval split
+            # (which now correctly reflects the real flow direction). The
+            # per-action simulation check keeps only the ones that help.
+            pocket_ids = [int(s) for s in self.antenna_meta.get("antenna_sub_ids", [])]
+            if pocket_ids:
+                nodes_aval_indices = pocket_ids
         if _type_allowed("ls") and nodes_aval_indices:
             with Timer("Verifying relevant load shedding"):
                 print("\n--- Verifying relevant load shedding ---")

--- a/expert_op4grid_recommender/config.py
+++ b/expert_op4grid_recommender/config.py
@@ -101,6 +101,14 @@ class Settings(BaseSettings):
     DRAW_ONLY_SIGNIFICANT_EDGES: bool = True
     USE_GRID_LAYOUT: bool = False
     DO_FORCE_OVERLOAD_GRAPH_EVEN_IF_GRAPH_BROKEN_APART: bool = False
+    # When the contingency islands a radial ("antenne") pocket of substations
+    # — i.e. disconnecting even the single max overload breaks the grid apart —
+    # build a synthetic downstream overflow graph of that pocket (each branch
+    # carrying the lost pre-disconnection flow as a negative delta) and let the
+    # recommender propose injection actions (load shedding / renewable
+    # curtailment / redispatch) on it. Topological actions are filtered out for
+    # this case. Set to False to restore the legacy "no solution" early return.
+    ENABLE_ANTENNA_RECOMMENDATIONS: bool = True
     DO_SAVE_DATA_FOR_TEST: bool = False
     CHECK_ACTION_SIMULATION: bool = False
     N_PRIORITIZED_ACTIONS: int = Field(default=20, ge=0)

--- a/expert_op4grid_recommender/graph_analysis/antenna_graph.py
+++ b/expert_op4grid_recommender/graph_analysis/antenna_graph.py
@@ -204,12 +204,15 @@ def focus_overflow_graph_on_pocket(g_overflow: Any, obs: Any, root_sub_id: int,
     safe (it would crash ``find_hubs``, which is why the analysis graph keeps the
     full grid).
 
-    ``g_overflow.g`` nodes must already be substation *names*. Nodes absent from
-    the graph (e.g. a node-renaming step ran) are silently skipped.
+    ``g_overflow.g`` nodes must already be substation *names*. Substation ids
+    out of range, and names absent from the graph (e.g. a node-renaming step
+    ran), are silently skipped.
     """
     import copy as _copy
 
-    keep = {obs.name_sub[root_sub_id]} | {obs.name_sub[s] for s in antenna_sub_ids}
+    n_sub = len(obs.name_sub)
+    keep = {obs.name_sub[s] for s in [root_sub_id, *antenna_sub_ids]
+            if 0 <= int(s) < n_sub}
     keep &= set(g_overflow.g.nodes())
     focused = _copy.copy(g_overflow)
     focused.g = g_overflow.g.subgraph(keep).copy()

--- a/expert_op4grid_recommender/graph_analysis/antenna_graph.py
+++ b/expert_op4grid_recommender/graph_analysis/antenna_graph.py
@@ -7,34 +7,39 @@
 # you can obtain one at http://mozilla.org/MPL/2.0/.
 # SPDX-License-Identifier: MPL-2.0
 # This file is part of expert_op4grid_recommender, Expert system analyzer based on ExpertOp4Grid principles.
-"""Synthetic overflow graph for an islanded radial ("antenne") pocket.
+"""Overflow graph for an islanded radial ("antenne") pocket.
 
 When a contingency islands a radial pocket of substations — disconnecting even
 the single most-loaded overloaded line breaks the grid apart — the regular
-``build_overflow_graph`` pipeline cannot run: ``alphaDeesp`` computes a flow
-*redistribution* that has no meaning on a pocket that simply blacks out.
+``build_overflow_graph`` pipeline cannot run a meaningful flow *redistribution*:
+the load flow on the cut grid diverges (the pocket has no slack and simply
+blacks out).
 
-Instead we build a synthetic downstream ("aval") overflow graph by hand:
+Rather than hand-building a synthetic graph, we feed the **standard ExpertOp4Grid
+machinery** the post-disconnection state implied by the islanding, modelled as:
 
-* the constraint (overloaded) line becomes the **black** constrained edge,
-  oriented from its root substation (on the main grid) into the pocket;
-* every branch inside the pocket becomes a **blue** edge, oriented away from the
-  root (root → leaves) and carrying ``-|p_or|`` as its reported flow — the
-  *negative delta* of the flow it would lose if the constraint were cut.
+    new_flows = initial post-contingency flows, with every line incident to the
+                islanded pocket set to 0 (the pocket blacks out; the healthy
+                grid is left untouched — the operator-chosen approximation).
 
-Because ``OverFlowGraph`` colours an edge blue when its reported flow is
-negative, every pocket branch lands on the constrained / downstream path, and
-``Structured_Overload_Distribution_Graph`` classifies the whole pocket as
-"aval". The recommender's injection-action discovery (load shedding, renewable
-curtailment, redispatch) then targets those downstream nodes directly.
+From that we compute the exact same per-line ``delta_flows`` frame as
+``alphaDeesp.Grid2opSimulation.create_df`` (signed report, swapped-flow
+handling, gray-edge threshold), then build the graph with
+``OverFlowGraph`` + ``Structured_Overload_Distribution_Graph`` — identical to
+``build_overflow_graph`` / ``build_overflow_graph_pypowsybl`` minus the load
+flow. Edge colour (blue / coral), orientation and the amont/aval split are
+therefore decided by ExpertOp4Grid from the *real signed* flows, so a producer
+pocket (amont of the overload islanded) and a consumer pocket (aval islanded)
+both render with physical directions. The healthy grid carries ``delta_flows =
+0`` → gray → trimmed by ``keep_overloads_components``, leaving the pocket plus
+the black constraint edge.
 
 The function returns the same 6-tuple shape as
 :func:`expert_op4grid_recommender.graph_analysis.builder.build_overflow_graph`
-(with ``overflow_sim = None``, since no ``Grid2opSimulation`` is involved) plus
-an ``antenna_meta`` dict describing the pocket.
+(with ``overflow_sim = None``) plus an ``antenna_meta`` dict describing the
+pocket.
 """
 
-from collections import deque
 from typing import Any, Dict, List, Tuple
 
 import networkx as nx
@@ -42,206 +47,231 @@ import numpy as np
 import pandas as pd
 from alphaDeesp.core.graphsAndPaths import OverFlowGraph, Structured_Overload_Distribution_Graph
 
-# Name of the synthetic upstream node injected to anchor the constrained path's
-# "amont" side (see build_antenna_overflow_graph). Consumers that render the
-# graph can hide nodes/edges carrying this sentinel name.
+from expert_op4grid_recommender.config import PARAM_OPTIONS_EXPERT_OP
+
+# Retained for backward compatibility (older consumers / the viewer's optional
+# node-hiding hook). The current builder no longer injects a synthetic source
+# node, so this name is not present in the produced graph.
 SOURCE_NODE_NAME = "__GRID_SOURCE__"
 
 
-def _sub_injections(obs: Any, sub_ids: List[int]) -> Tuple[Dict[int, float], Dict[int, float]]:
-    """Aggregate production and load (MW) per substation id."""
-    prod_by_sub: Dict[int, float] = {sid: 0.0 for sid in sub_ids}
-    load_by_sub: Dict[int, float] = {sid: 0.0 for sid in sub_ids}
-    sub_set = set(sub_ids)
+def _sub_injections(obs: Any) -> Tuple[np.ndarray, np.ndarray]:
+    """Per-substation production and load (MW), indexed by substation id."""
+    n_sub = len(obs.name_sub)
+    prod = np.zeros(n_sub, dtype=float)
+    load = np.zeros(n_sub, dtype=float)
 
     gen_p = getattr(obs, "gen_p", None)
     gen_to_subid = getattr(obs, "gen_to_subid", None)
     if gen_p is not None and gen_to_subid is not None:
         for p, sid in zip(gen_p, gen_to_subid):
-            sid = int(sid)
-            if sid in sub_set:
-                prod_by_sub[sid] += float(p)
+            prod[int(sid)] += float(p)
 
     load_p = getattr(obs, "load_p", None)
     load_to_subid = getattr(obs, "load_to_subid", None)
     if load_p is not None and load_to_subid is not None:
         for p, sid in zip(load_p, load_to_subid):
-            sid = int(sid)
-            if sid in sub_set:
-                load_by_sub[sid] += float(p)
+            load[int(sid)] += float(p)
 
-    return prod_by_sub, load_by_sub
+    return prod, load
 
 
-def _orient_pocket(obs: Any, node_sub_ids: List[int], root_sub_id: int,
-                   constraint_line_id: int) -> List[Tuple[int, int, int]]:
-    """Return pocket branches as (from_sub, to_sub, line_id), oriented root→leaf.
+def _build_topo(obs: Any) -> Dict[str, Any]:
+    """Full-grid topology dict in the shape ``OverFlowGraph`` expects.
 
-    Orientation is purely *topological* (breadth-first distance from the root),
-    so the pocket forms a clean DAG pointing away from the constraint regardless
-    of whether the pocket is a net consumer or producer. The constraint line
-    itself is excluded — it is added separately as the black edge.
+    Mirrors ``AlphaDeespAdapter._build_topo`` / ``Grid2opSimulation.topo``:
+    one entry per line (original orientation) and per substation (prod/load).
     """
-    sub_set = set(node_sub_ids)
-    # Build undirected adjacency over connected lines internal to the pocket.
-    adj: Dict[int, List[Tuple[int, int]]] = {sid: [] for sid in node_sub_ids}
-    line_status = obs.line_status
-    for lid in range(len(obs.name_line)):
-        if lid == constraint_line_id or not line_status[lid]:
-            continue
-        a = int(obs.line_or_to_subid[lid])
-        b = int(obs.line_ex_to_subid[lid])
-        if a in sub_set and b in sub_set and a != b:
-            adj[a].append((b, lid))
-            adj[b].append((a, lid))
+    n = len(obs.name_line)
+    idx_or = [int(obs.line_or_to_subid[i]) for i in range(n)]
+    idx_ex = [int(obs.line_ex_to_subid[i]) for i in range(n)]
+    prod, load = _sub_injections(obs)
+    return {
+        "edges": {"idx_or": idx_or, "idx_ex": idx_ex},
+        "nodes": {
+            "are_prods": (prod > 0).tolist(),
+            "are_loads": (load > 0).tolist(),
+            "prods_values": prod.tolist(),
+            "loads_values": load.tolist(),
+            "names": list(obs.name_sub),
+        },
+    }
 
-    # BFS depth from the root substation.
-    depth: Dict[int, int] = {root_sub_id: 0}
-    queue = deque([root_sub_id])
-    while queue:
-        cur = queue.popleft()
-        for nxt, _lid in adj.get(cur, []):
-            if nxt not in depth:
-                depth[nxt] = depth[cur] + 1
-                queue.append(nxt)
 
-    branches: List[Tuple[int, int, int]] = []
-    seen_lines = set()
-    for sid in node_sub_ids:
-        for nxt, lid in adj[sid]:
-            if lid in seen_lines:
-                continue
-            seen_lines.add(lid)
-            d_a = depth.get(sid, np.inf)
-            d_b = depth.get(nxt, np.inf)
-            # Orient from the endpoint closer to the root toward the leaf.
-            if d_a <= d_b:
-                branches.append((sid, nxt, lid))
-            else:
-                branches.append((nxt, sid, lid))
-    return branches
+def _islanded_line_mask(obs: Any, antenna_sub_ids: List[int]) -> np.ndarray:
+    """Lines that lose all flow once the pocket islands.
+
+    Any line with at least one endpoint inside the pocket (the internal pocket
+    branches AND the constraint line bridging the pocket to the main grid) goes
+    to zero flow when the pocket blacks out.
+    """
+    pocket = set(int(s) for s in antenna_sub_ids)
+    n = len(obs.name_line)
+    or_sub = np.array([int(obs.line_or_to_subid[i]) for i in range(n)])
+    ex_sub = np.array([int(obs.line_ex_to_subid[i]) for i in range(n)])
+    return np.array([(or_sub[i] in pocket) or (ex_sub[i] in pocket) for i in range(n)])
+
+
+def _compute_delta_flow_frame(obs: Any, new_flows_arr: np.ndarray,
+                              constraint_line_id: int, threshold: float) -> pd.DataFrame:
+    """Replicate ``alphaDeesp.Simulation.create_df`` from explicit new flows.
+
+    Vectorised twin of ``OverflowSimulator.compute_flow_changes_after_disconnection``
+    (pypowsybl backend) — the only difference is that ``new_flows_arr`` is
+    supplied by the caller (the islanding "collapse" state) instead of read from
+    a load flow that would diverge. The output columns and sign conventions are
+    byte-for-byte what ``OverFlowGraph`` consumes.
+    """
+    line_names = list(obs.name_line)
+    n = len(line_names)
+    idx_or = np.array([int(obs.line_or_to_subid[i]) for i in range(n)], dtype=int)
+    idx_ex = np.array([int(obs.line_ex_to_subid[i]) for i in range(n)], dtype=int)
+
+    init_flows = np.asarray(obs.p_or, dtype=float).copy()
+    init_flows = np.where(np.isnan(init_flows), 0.0, init_flows)
+    new_arr = np.where(np.isnan(new_flows_arr), 0.0, new_flows_arr.astype(float))
+
+    # STEP 2: branch_direction_swaps — canonicalise so init_flows >= 0.
+    swap_mask = (init_flows < 0) & (init_flows != 0.0)
+    idx_or_s = np.where(swap_mask, idx_ex, idx_or)
+    idx_ex_s = np.where(swap_mask, idx_or, idx_ex)
+    idx_or = idx_or_s
+    idx_ex = idx_ex_s
+    init_abs = np.where(swap_mask, np.abs(init_flows), init_flows)
+
+    # STEP 3: apply the same swap to new flows.
+    new_flows = np.where(swap_mask, -new_arr, new_arr)
+
+    # STEP 4: new_flows_swapped — reversed and stronger.
+    new_flows_swapped = (new_flows < 0) & (np.abs(new_flows) > np.abs(init_abs))
+
+    # STEP 5: delta_flows.
+    abs_new = np.abs(new_flows)
+    abs_init = np.abs(init_abs)
+    delta = abs_new - abs_init
+    case1 = new_flows_swapped
+    delta = np.where(case1, abs_new + abs_init, delta)
+    idx_or = np.where(case1, idx_ex, idx_or)
+    idx_ex = np.where(case1, idx_or_s, idx_ex)
+    sign_new = np.sign(new_flows)
+    sign_init = np.sign(init_abs)
+    case2 = (sign_new != sign_init) & (new_flows != 0) & (init_abs != 0) & ~case1
+    delta = np.where(case2, -(abs_new + abs_init), delta)
+
+    # STEP 6: gray edges, relative to the constraint (cut) line's report.
+    ltc_report = np.abs(delta[constraint_line_id]) if 0 <= constraint_line_id < n else np.abs(delta).max()
+    max_overload = ltc_report * float(threshold)
+    gray_edges = np.abs(delta) < max_overload
+
+    df = pd.DataFrame({
+        "idx_or": idx_or,
+        "idx_ex": idx_ex,
+        "init_flows": init_abs,
+        "line_name": line_names,
+        "swapped": swap_mask,
+        "new_flows": new_flows,
+        "new_flows_swapped": new_flows_swapped,
+        "delta_flows": delta,
+        "gray_edges": gray_edges,
+    })
+    return df
+
+
+def _inhibit_swapped_flows(df: pd.DataFrame) -> pd.DataFrame:
+    """Negate delta + swap or/ex for rows whose new flow reversed direction.
+
+    Same correction as ``builder.inhibit_swapped_flows`` /
+    ``overflow_analysis._inhibit_swapped_flows``.
+    """
+    mask = df.new_flows_swapped
+    if not mask.any():
+        return df
+    df.loc[mask, "delta_flows"] = -df.loc[mask, "delta_flows"]
+    idx_or = df.loc[mask, "idx_or"].copy()
+    df.loc[mask, "idx_or"] = df.loc[mask, "idx_ex"]
+    df.loc[mask, "idx_ex"] = idx_or
+    return df
+
+
+def focus_overflow_graph_on_pocket(g_overflow: Any, obs: Any, root_sub_id: int,
+                                   antenna_sub_ids: List[int]) -> Any:
+    """Return a copy of ``g_overflow`` restricted to the root + pocket nodes.
+
+    The analysis graph is built over the full grid (the gray healthy lines
+    anchor the root for ``find_hubs``); for the operator-facing render we want a
+    clean pocket view. Visualization never rebuilds the structured-overload
+    graph, so trimming the root down to its single black constraint edge here is
+    safe (it would crash ``find_hubs``, which is why the analysis graph keeps the
+    full grid).
+
+    ``g_overflow.g`` nodes must already be substation *names*. Nodes absent from
+    the graph (e.g. a node-renaming step ran) are silently skipped.
+    """
+    import copy as _copy
+
+    keep = {obs.name_sub[root_sub_id]} | {obs.name_sub[s] for s in antenna_sub_ids}
+    keep &= set(g_overflow.g.nodes())
+    focused = _copy.copy(g_overflow)
+    focused.g = g_overflow.g.subgraph(keep).copy()
+    return focused
 
 
 def build_antenna_overflow_graph(obs: Any, constraint_line_id: int,
                                  antenna_sub_ids: List[int], root_sub_id: int,
                                  float_precision: str = "%.0f"):
-    """Build a synthetic downstream overflow graph for an islanded pocket.
+    """Build the overflow graph for an islanded pocket via the standard pipeline.
 
     Args:
         obs: Grid2Op-compatible observation (post-contingency state, where the
             constraint line is still connected and overloaded).
         constraint_line_id (int): index of the overloaded line feeding the pocket.
         antenna_sub_ids (list[int]): substation ids inside the pocket.
-        root_sub_id (int): the constraint endpoint on the main grid.
+        root_sub_id (int): the constraint endpoint on the main grid (kept for the
+            returned ``antenna_meta``; orientation is now derived from the flows).
         float_precision (str): edge-label precision passed to ``OverFlowGraph``.
 
     Returns:
-        tuple: ``(df, overflow_sim, g_overflow, real_hubs, g_distribution_graph,
-        node_name_mapping, antenna_meta)`` — mirrors ``build_overflow_graph``'s
-        return (``overflow_sim is None``) with ``antenna_meta`` appended.
-        ``g_overflow.g`` nodes are substation names; ``node_name_mapping`` is
-        ``{real_substation_id: name}`` so the downstream
-        ``pre_process_graph_alphadeesp`` reverts to real substation indices.
+        tuple: ``(df_of_g, overflow_sim, g_overflow, real_hubs,
+        g_distribution_graph, node_name_mapping, antenna_meta)`` — mirrors
+        ``build_overflow_graph``'s return (``overflow_sim is None``) with
+        ``antenna_meta`` appended. ``g_overflow.g`` nodes are substation names;
+        ``node_name_mapping`` is ``{real_substation_id: name}`` so the downstream
+        ``pre_process_antenna_graph`` reverts to real substation indices.
     """
-    # Compact, contiguous node ids: root first, then the pocket substations.
-    # ``OverFlowGraph.build_nodes`` always numbers nodes 0..k-1, so we build
-    # with these compact ids and later relabel to substation names — exactly
-    # like the real ``build_overflow_graph``. The returned ``node_name_mapping``
-    # is keyed by the *real* grid2op substation id (matching the real builder's
-    # contract), so ``pre_process_graph_alphadeesp`` reverts the names back to
-    # real substation indices that the injection-action discovery uses to index
-    # ``obs.name_sub`` / ``obs.load_p`` / ``obs.gen_p``.
-    node_sub_ids: List[int] = [root_sub_id] + [s for s in antenna_sub_ids if s != root_sub_id]
+    threshold = float(PARAM_OPTIONS_EXPERT_OP.get("ThresholdReportOfLine", 0.05))
 
-    # Synthetic upstream "grid source" feeding the root, modelling the rest of
-    # the grid that supplies the overloaded line. Beyond being physically the
-    # "amont" of the constrained path, it is REQUIRED: without it the root has
-    # only the black constraint edge, so alphaDeesp's ``find_hubs`` removes it
-    # as an isolate (after deleting the black edge) and then crashes calling
-    # ``out_edges(root)`` once the graph is reverted to integer node ids — the
-    # space the discovery actually runs in. Its id is a sentinel ``>= n_subs``
-    # so every ``idx < n_subs`` guard in the discovery filters it out.
-    n_subs_total = len(obs.name_sub)
-    source_id = n_subs_total
-    source_name = SOURCE_NODE_NAME
+    # Post-disconnection collapse state: initial flows everywhere, zeroed on
+    # every line incident to the islanded pocket.
+    init_flows = np.asarray(obs.p_or, dtype=float).copy()
+    init_flows = np.where(np.isnan(init_flows), 0.0, init_flows)
+    new_flows = init_flows.copy()
+    new_flows[_islanded_line_mask(obs, antenna_sub_ids)] = 0.0
 
-    sub_to_idx: Dict[int, int] = {sid: i for i, sid in enumerate(node_sub_ids)}
-    sub_to_idx[source_id] = len(node_sub_ids)
-    compact_to_name: Dict[int, str] = {i: obs.name_sub[sid] for i, sid in enumerate(node_sub_ids)}
-    compact_to_name[len(node_sub_ids)] = source_name
-    node_name_mapping: Dict[int, str] = {sid: obs.name_sub[sid] for sid in node_sub_ids}
-    node_name_mapping[source_id] = source_name
+    df_of_g = _compute_delta_flow_frame(obs, new_flows, constraint_line_id, threshold)
+    df_of_g = _inhibit_swapped_flows(df_of_g)
 
-    prod_by_sub, load_by_sub = _sub_injections(obs, node_sub_ids)
+    topo = _build_topo(obs)
 
-    # topo["nodes"]: arrays indexed by compact node id (0..k). build_nodes
-    # pulls from prods_values / loads_values only where are_prods / are_loads.
-    # The trailing source node is neither prod nor load (a neutral anchor).
-    are_prods, are_loads, prods_values, loads_values = [], [], [], []
-    for sid in node_sub_ids:
-        prod = prod_by_sub.get(sid, 0.0)
-        load = load_by_sub.get(sid, 0.0)
-        are_prods.append(prod > 0)
-        are_loads.append(load > 0)
-        if prod > 0:
-            prods_values.append(prod)
-        if load > 0:
-            loads_values.append(load)
-    are_prods.append(False)
-    are_loads.append(False)
+    # The constraint line is the cut (black) edge. Row index == line index, so
+    # ``OverFlowGraph`` paints row ``constraint_line_id`` black.
+    g_overflow = OverFlowGraph(topo, [int(constraint_line_id)], df_of_g,
+                               float_precision=float_precision)
 
-    topo = {
-        "nodes": {
-            "are_prods": are_prods,
-            "are_loads": are_loads,
-            "prods_values": prods_values,
-            "loads_values": loads_values,
-        },
-        "edges": {"idx_or": [], "idx_ex": [], "init_flows": []},
-    }
+    node_name_mapping: Dict[int, str] = {i: name for i, name in enumerate(obs.name_sub)}
+    g_overflow.g = nx.relabel_nodes(g_overflow.g, node_name_mapping, copy=True)
 
-    p_or = obs.p_or
-    # Row 0 is the constraint (black) edge, root → pocket entry.
-    or_sub = int(obs.line_or_to_subid[constraint_line_id])
-    ex_sub = int(obs.line_ex_to_subid[constraint_line_id])
-    entry_sub = ex_sub if or_sub == root_sub_id else or_sub
-    constraint_flow = abs(float(p_or[constraint_line_id]))
-    rows = [{
-        "idx_or": sub_to_idx[root_sub_id],
-        "idx_ex": sub_to_idx[entry_sub],
-        "delta_flows": -constraint_flow,
-        "gray_edges": False,
-        "line_name": obs.name_line[constraint_line_id],
-    }, {
-        # Amont anchor: grid source → root (blue), mirroring the constraint flow.
-        "idx_or": sub_to_idx[source_id],
-        "idx_ex": sub_to_idx[root_sub_id],
-        "delta_flows": -constraint_flow,
-        "gray_edges": False,
-        "line_name": source_name,
-    }]
-
-    # Pocket branches: blue (negative delta = lost report), oriented root→leaf.
-    for from_sub, to_sub, lid in _orient_pocket(obs, node_sub_ids, root_sub_id, constraint_line_id):
-        rows.append({
-            "idx_or": sub_to_idx[from_sub],
-            "idx_ex": sub_to_idx[to_sub],
-            "delta_flows": -abs(float(p_or[lid])),
-            "gray_edges": False,
-            "line_name": obs.name_line[lid],
-        })
-
-    df = pd.DataFrame(rows, columns=["idx_or", "idx_ex", "delta_flows", "gray_edges", "line_name"])
-
-    # The constraint line (row 0) is the only "cut" line → coloured black.
-    g_overflow = OverFlowGraph(topo, [0], df, float_precision=float_precision)
-    g_overflow.g = nx.relabel_nodes(g_overflow.g, compact_to_name, copy=True)
-
+    # NB: the graph is intentionally kept over the full grid. The healthy lines
+    # carry zero delta (gray); they anchor the root substation so alphaDeesp's
+    # ``find_hubs`` (run by the downstream discovery via
+    # ``pre_process_antenna_graph``) does not drop it as an isolate. The
+    # visualization focuses a *copy* on the pocket for a clean operator view
+    # (see ``main._make_antenna_visualization`` / ``focus_overflow_graph_on_pocket``).
     g_distribution_graph = Structured_Overload_Distribution_Graph(g_overflow.g)
     real_hubs = g_distribution_graph.get_hubs()
 
-    total_prod = sum(prod_by_sub.get(s, 0.0) for s in antenna_sub_ids)
-    total_load = sum(load_by_sub.get(s, 0.0) for s in antenna_sub_ids)
+    prod, load = _sub_injections(obs)
+    total_prod = float(sum(prod[s] for s in antenna_sub_ids))
+    total_load = float(sum(load[s] for s in antenna_sub_ids))
     net_mw = total_prod - total_load
     antenna_meta = {
         "constraint_line_id": int(constraint_line_id),
@@ -251,12 +281,12 @@ def build_antenna_overflow_graph(obs: Any, constraint_line_id: int,
         "antenna_sub_ids": list(antenna_sub_ids),
         "antenna_sub_names": [obs.name_sub[s] for s in antenna_sub_ids],
         "n_subs": len(antenna_sub_ids),
-        "total_prod_mw": round(float(total_prod), 2),
-        "total_load_mw": round(float(total_load), 2),
-        "net_mw": round(float(net_mw), 2),
+        "total_prod_mw": round(total_prod, 2),
+        "total_load_mw": round(total_load, 2),
+        "net_mw": round(net_mw, 2),
         # Net exporter (prod > load) → curtailment / redispatch-down help;
         # net importer (load > prod) → load shedding / redispatch-up help.
         "direction": "producer" if net_mw > 0 else "consumer",
     }
 
-    return df, None, g_overflow, real_hubs, g_distribution_graph, node_name_mapping, antenna_meta
+    return df_of_g, None, g_overflow, real_hubs, g_distribution_graph, node_name_mapping, antenna_meta

--- a/expert_op4grid_recommender/graph_analysis/antenna_graph.py
+++ b/expert_op4grid_recommender/graph_analysis/antenna_graph.py
@@ -42,6 +42,11 @@ import numpy as np
 import pandas as pd
 from alphaDeesp.core.graphsAndPaths import OverFlowGraph, Structured_Overload_Distribution_Graph
 
+# Name of the synthetic upstream node injected to anchor the constrained path's
+# "amont" side (see build_antenna_overflow_graph). Consumers that render the
+# graph can hide nodes/edges carrying this sentinel name.
+SOURCE_NODE_NAME = "__GRID_SOURCE__"
+
 
 def _sub_injections(obs: Any, sub_ids: List[int]) -> Tuple[Dict[int, float], Dict[int, float]]:
     """Aggregate production and load (MW) per substation id."""
@@ -134,16 +139,44 @@ def build_antenna_overflow_graph(obs: Any, constraint_line_id: int,
         tuple: ``(df, overflow_sim, g_overflow, real_hubs, g_distribution_graph,
         node_name_mapping, antenna_meta)`` — mirrors ``build_overflow_graph``'s
         return (``overflow_sim is None``) with ``antenna_meta`` appended.
+        ``g_overflow.g`` nodes are substation names; ``node_name_mapping`` is
+        ``{real_substation_id: name}`` so the downstream
+        ``pre_process_graph_alphadeesp`` reverts to real substation indices.
     """
     # Compact, contiguous node ids: root first, then the pocket substations.
+    # ``OverFlowGraph.build_nodes`` always numbers nodes 0..k-1, so we build
+    # with these compact ids and later relabel to substation names — exactly
+    # like the real ``build_overflow_graph``. The returned ``node_name_mapping``
+    # is keyed by the *real* grid2op substation id (matching the real builder's
+    # contract), so ``pre_process_graph_alphadeesp`` reverts the names back to
+    # real substation indices that the injection-action discovery uses to index
+    # ``obs.name_sub`` / ``obs.load_p`` / ``obs.gen_p``.
     node_sub_ids: List[int] = [root_sub_id] + [s for s in antenna_sub_ids if s != root_sub_id]
+
+    # Synthetic upstream "grid source" feeding the root, modelling the rest of
+    # the grid that supplies the overloaded line. Beyond being physically the
+    # "amont" of the constrained path, it is REQUIRED: without it the root has
+    # only the black constraint edge, so alphaDeesp's ``find_hubs`` removes it
+    # as an isolate (after deleting the black edge) and then crashes calling
+    # ``out_edges(root)`` once the graph is reverted to integer node ids — the
+    # space the discovery actually runs in. Its id is a sentinel ``>= n_subs``
+    # so every ``idx < n_subs`` guard in the discovery filters it out.
+    n_subs_total = len(obs.name_sub)
+    source_id = n_subs_total
+    source_name = SOURCE_NODE_NAME
+
     sub_to_idx: Dict[int, int] = {sid: i for i, sid in enumerate(node_sub_ids)}
-    node_name_mapping: Dict[int, str] = {i: obs.name_sub[sid] for i, sid in enumerate(node_sub_ids)}
+    sub_to_idx[source_id] = len(node_sub_ids)
+    compact_to_name: Dict[int, str] = {i: obs.name_sub[sid] for i, sid in enumerate(node_sub_ids)}
+    compact_to_name[len(node_sub_ids)] = source_name
+    node_name_mapping: Dict[int, str] = {sid: obs.name_sub[sid] for sid in node_sub_ids}
+    node_name_mapping[source_id] = source_name
 
     prod_by_sub, load_by_sub = _sub_injections(obs, node_sub_ids)
 
-    # topo["nodes"]: arrays indexed by compact node id (0..k-1). build_nodes
+    # topo["nodes"]: arrays indexed by compact node id (0..k). build_nodes
     # pulls from prods_values / loads_values only where are_prods / are_loads.
+    # The trailing source node is neither prod nor load (a neutral anchor).
     are_prods, are_loads, prods_values, loads_values = [], [], [], []
     for sid in node_sub_ids:
         prod = prod_by_sub.get(sid, 0.0)
@@ -154,6 +187,8 @@ def build_antenna_overflow_graph(obs: Any, constraint_line_id: int,
             prods_values.append(prod)
         if load > 0:
             loads_values.append(load)
+    are_prods.append(False)
+    are_loads.append(False)
 
     topo = {
         "nodes": {
@@ -170,12 +205,20 @@ def build_antenna_overflow_graph(obs: Any, constraint_line_id: int,
     or_sub = int(obs.line_or_to_subid[constraint_line_id])
     ex_sub = int(obs.line_ex_to_subid[constraint_line_id])
     entry_sub = ex_sub if or_sub == root_sub_id else or_sub
+    constraint_flow = abs(float(p_or[constraint_line_id]))
     rows = [{
         "idx_or": sub_to_idx[root_sub_id],
         "idx_ex": sub_to_idx[entry_sub],
-        "delta_flows": -abs(float(p_or[constraint_line_id])),
+        "delta_flows": -constraint_flow,
         "gray_edges": False,
         "line_name": obs.name_line[constraint_line_id],
+    }, {
+        # Amont anchor: grid source → root (blue), mirroring the constraint flow.
+        "idx_or": sub_to_idx[source_id],
+        "idx_ex": sub_to_idx[root_sub_id],
+        "delta_flows": -constraint_flow,
+        "gray_edges": False,
+        "line_name": source_name,
     }]
 
     # Pocket branches: blue (negative delta = lost report), oriented root→leaf.
@@ -192,7 +235,7 @@ def build_antenna_overflow_graph(obs: Any, constraint_line_id: int,
 
     # The constraint line (row 0) is the only "cut" line → coloured black.
     g_overflow = OverFlowGraph(topo, [0], df, float_precision=float_precision)
-    g_overflow.g = nx.relabel_nodes(g_overflow.g, node_name_mapping, copy=True)
+    g_overflow.g = nx.relabel_nodes(g_overflow.g, compact_to_name, copy=True)
 
     g_distribution_graph = Structured_Overload_Distribution_Graph(g_overflow.g)
     real_hubs = g_distribution_graph.get_hubs()

--- a/expert_op4grid_recommender/graph_analysis/antenna_graph.py
+++ b/expert_op4grid_recommender/graph_analysis/antenna_graph.py
@@ -1,0 +1,219 @@
+# expert_op4grid_recommender/graph_analysis/antenna_graph.py
+#!/usr/bin/python3
+# Copyright (c) 2025-2026, RTE (https://www.rte-france.com)
+# See AUTHORS.txt
+# This Source Code Form is subject to the terms of the Mozilla Public License, version 2.0.
+# If a copy of the Mozilla Public License, version 2.0 was not distributed with this file,
+# you can obtain one at http://mozilla.org/MPL/2.0/.
+# SPDX-License-Identifier: MPL-2.0
+# This file is part of expert_op4grid_recommender, Expert system analyzer based on ExpertOp4Grid principles.
+"""Synthetic overflow graph for an islanded radial ("antenne") pocket.
+
+When a contingency islands a radial pocket of substations — disconnecting even
+the single most-loaded overloaded line breaks the grid apart — the regular
+``build_overflow_graph`` pipeline cannot run: ``alphaDeesp`` computes a flow
+*redistribution* that has no meaning on a pocket that simply blacks out.
+
+Instead we build a synthetic downstream ("aval") overflow graph by hand:
+
+* the constraint (overloaded) line becomes the **black** constrained edge,
+  oriented from its root substation (on the main grid) into the pocket;
+* every branch inside the pocket becomes a **blue** edge, oriented away from the
+  root (root → leaves) and carrying ``-|p_or|`` as its reported flow — the
+  *negative delta* of the flow it would lose if the constraint were cut.
+
+Because ``OverFlowGraph`` colours an edge blue when its reported flow is
+negative, every pocket branch lands on the constrained / downstream path, and
+``Structured_Overload_Distribution_Graph`` classifies the whole pocket as
+"aval". The recommender's injection-action discovery (load shedding, renewable
+curtailment, redispatch) then targets those downstream nodes directly.
+
+The function returns the same 6-tuple shape as
+:func:`expert_op4grid_recommender.graph_analysis.builder.build_overflow_graph`
+(with ``overflow_sim = None``, since no ``Grid2opSimulation`` is involved) plus
+an ``antenna_meta`` dict describing the pocket.
+"""
+
+from collections import deque
+from typing import Any, Dict, List, Tuple
+
+import networkx as nx
+import numpy as np
+import pandas as pd
+from alphaDeesp.core.graphsAndPaths import OverFlowGraph, Structured_Overload_Distribution_Graph
+
+
+def _sub_injections(obs: Any, sub_ids: List[int]) -> Tuple[Dict[int, float], Dict[int, float]]:
+    """Aggregate production and load (MW) per substation id."""
+    prod_by_sub: Dict[int, float] = {sid: 0.0 for sid in sub_ids}
+    load_by_sub: Dict[int, float] = {sid: 0.0 for sid in sub_ids}
+    sub_set = set(sub_ids)
+
+    gen_p = getattr(obs, "gen_p", None)
+    gen_to_subid = getattr(obs, "gen_to_subid", None)
+    if gen_p is not None and gen_to_subid is not None:
+        for p, sid in zip(gen_p, gen_to_subid):
+            sid = int(sid)
+            if sid in sub_set:
+                prod_by_sub[sid] += float(p)
+
+    load_p = getattr(obs, "load_p", None)
+    load_to_subid = getattr(obs, "load_to_subid", None)
+    if load_p is not None and load_to_subid is not None:
+        for p, sid in zip(load_p, load_to_subid):
+            sid = int(sid)
+            if sid in sub_set:
+                load_by_sub[sid] += float(p)
+
+    return prod_by_sub, load_by_sub
+
+
+def _orient_pocket(obs: Any, node_sub_ids: List[int], root_sub_id: int,
+                   constraint_line_id: int) -> List[Tuple[int, int, int]]:
+    """Return pocket branches as (from_sub, to_sub, line_id), oriented root→leaf.
+
+    Orientation is purely *topological* (breadth-first distance from the root),
+    so the pocket forms a clean DAG pointing away from the constraint regardless
+    of whether the pocket is a net consumer or producer. The constraint line
+    itself is excluded — it is added separately as the black edge.
+    """
+    sub_set = set(node_sub_ids)
+    # Build undirected adjacency over connected lines internal to the pocket.
+    adj: Dict[int, List[Tuple[int, int]]] = {sid: [] for sid in node_sub_ids}
+    line_status = obs.line_status
+    for lid in range(len(obs.name_line)):
+        if lid == constraint_line_id or not line_status[lid]:
+            continue
+        a = int(obs.line_or_to_subid[lid])
+        b = int(obs.line_ex_to_subid[lid])
+        if a in sub_set and b in sub_set and a != b:
+            adj[a].append((b, lid))
+            adj[b].append((a, lid))
+
+    # BFS depth from the root substation.
+    depth: Dict[int, int] = {root_sub_id: 0}
+    queue = deque([root_sub_id])
+    while queue:
+        cur = queue.popleft()
+        for nxt, _lid in adj.get(cur, []):
+            if nxt not in depth:
+                depth[nxt] = depth[cur] + 1
+                queue.append(nxt)
+
+    branches: List[Tuple[int, int, int]] = []
+    seen_lines = set()
+    for sid in node_sub_ids:
+        for nxt, lid in adj[sid]:
+            if lid in seen_lines:
+                continue
+            seen_lines.add(lid)
+            d_a = depth.get(sid, np.inf)
+            d_b = depth.get(nxt, np.inf)
+            # Orient from the endpoint closer to the root toward the leaf.
+            if d_a <= d_b:
+                branches.append((sid, nxt, lid))
+            else:
+                branches.append((nxt, sid, lid))
+    return branches
+
+
+def build_antenna_overflow_graph(obs: Any, constraint_line_id: int,
+                                 antenna_sub_ids: List[int], root_sub_id: int,
+                                 float_precision: str = "%.0f"):
+    """Build a synthetic downstream overflow graph for an islanded pocket.
+
+    Args:
+        obs: Grid2Op-compatible observation (post-contingency state, where the
+            constraint line is still connected and overloaded).
+        constraint_line_id (int): index of the overloaded line feeding the pocket.
+        antenna_sub_ids (list[int]): substation ids inside the pocket.
+        root_sub_id (int): the constraint endpoint on the main grid.
+        float_precision (str): edge-label precision passed to ``OverFlowGraph``.
+
+    Returns:
+        tuple: ``(df, overflow_sim, g_overflow, real_hubs, g_distribution_graph,
+        node_name_mapping, antenna_meta)`` — mirrors ``build_overflow_graph``'s
+        return (``overflow_sim is None``) with ``antenna_meta`` appended.
+    """
+    # Compact, contiguous node ids: root first, then the pocket substations.
+    node_sub_ids: List[int] = [root_sub_id] + [s for s in antenna_sub_ids if s != root_sub_id]
+    sub_to_idx: Dict[int, int] = {sid: i for i, sid in enumerate(node_sub_ids)}
+    node_name_mapping: Dict[int, str] = {i: obs.name_sub[sid] for i, sid in enumerate(node_sub_ids)}
+
+    prod_by_sub, load_by_sub = _sub_injections(obs, node_sub_ids)
+
+    # topo["nodes"]: arrays indexed by compact node id (0..k-1). build_nodes
+    # pulls from prods_values / loads_values only where are_prods / are_loads.
+    are_prods, are_loads, prods_values, loads_values = [], [], [], []
+    for sid in node_sub_ids:
+        prod = prod_by_sub.get(sid, 0.0)
+        load = load_by_sub.get(sid, 0.0)
+        are_prods.append(prod > 0)
+        are_loads.append(load > 0)
+        if prod > 0:
+            prods_values.append(prod)
+        if load > 0:
+            loads_values.append(load)
+
+    topo = {
+        "nodes": {
+            "are_prods": are_prods,
+            "are_loads": are_loads,
+            "prods_values": prods_values,
+            "loads_values": loads_values,
+        },
+        "edges": {"idx_or": [], "idx_ex": [], "init_flows": []},
+    }
+
+    p_or = obs.p_or
+    # Row 0 is the constraint (black) edge, root → pocket entry.
+    or_sub = int(obs.line_or_to_subid[constraint_line_id])
+    ex_sub = int(obs.line_ex_to_subid[constraint_line_id])
+    entry_sub = ex_sub if or_sub == root_sub_id else or_sub
+    rows = [{
+        "idx_or": sub_to_idx[root_sub_id],
+        "idx_ex": sub_to_idx[entry_sub],
+        "delta_flows": -abs(float(p_or[constraint_line_id])),
+        "gray_edges": False,
+        "line_name": obs.name_line[constraint_line_id],
+    }]
+
+    # Pocket branches: blue (negative delta = lost report), oriented root→leaf.
+    for from_sub, to_sub, lid in _orient_pocket(obs, node_sub_ids, root_sub_id, constraint_line_id):
+        rows.append({
+            "idx_or": sub_to_idx[from_sub],
+            "idx_ex": sub_to_idx[to_sub],
+            "delta_flows": -abs(float(p_or[lid])),
+            "gray_edges": False,
+            "line_name": obs.name_line[lid],
+        })
+
+    df = pd.DataFrame(rows, columns=["idx_or", "idx_ex", "delta_flows", "gray_edges", "line_name"])
+
+    # The constraint line (row 0) is the only "cut" line → coloured black.
+    g_overflow = OverFlowGraph(topo, [0], df, float_precision=float_precision)
+    g_overflow.g = nx.relabel_nodes(g_overflow.g, node_name_mapping, copy=True)
+
+    g_distribution_graph = Structured_Overload_Distribution_Graph(g_overflow.g)
+    real_hubs = g_distribution_graph.get_hubs()
+
+    total_prod = sum(prod_by_sub.get(s, 0.0) for s in antenna_sub_ids)
+    total_load = sum(load_by_sub.get(s, 0.0) for s in antenna_sub_ids)
+    net_mw = total_prod - total_load
+    antenna_meta = {
+        "constraint_line_id": int(constraint_line_id),
+        "constraint_line_name": obs.name_line[constraint_line_id],
+        "root_sub_id": int(root_sub_id),
+        "root_sub_name": obs.name_sub[root_sub_id],
+        "antenna_sub_ids": list(antenna_sub_ids),
+        "antenna_sub_names": [obs.name_sub[s] for s in antenna_sub_ids],
+        "n_subs": len(antenna_sub_ids),
+        "total_prod_mw": round(float(total_prod), 2),
+        "total_load_mw": round(float(total_load), 2),
+        "net_mw": round(float(net_mw), 2),
+        # Net exporter (prod > load) → curtailment / redispatch-down help;
+        # net importer (load > prod) → load shedding / redispatch-up help.
+        "direction": "producer" if net_mw > 0 else "consumer",
+    }
+
+    return df, None, g_overflow, real_hubs, g_distribution_graph, node_name_mapping, antenna_meta

--- a/expert_op4grid_recommender/graph_analysis/processor.py
+++ b/expert_op4grid_recommender/graph_analysis/processor.py
@@ -199,6 +199,86 @@ def identify_overload_lines_to_keep_overflow_graph_connected(obs_simu, lines_ove
     return lines_overloaded_ids_to_keep, prevent_islanded_subs
 
 
+def extract_antenna_context(obs_simu, lines_overloaded_ids):
+    """
+    Extract the radial ("antenne") pocket islanded by disconnecting the max overload.
+
+    This is the companion of
+    :func:`identify_overload_lines_to_keep_overflow_graph_connected` for the
+    case where disconnecting even the single most-loaded overloaded line breaks
+    the grid apart (``lines_overloaded_ids_to_keep is None``). Instead of giving
+    up, we describe the pocket of substations that gets disconnected so a
+    synthetic downstream overflow graph can be built on it (see
+    :func:`expert_op4grid_recommender.graph_analysis.antenna_graph.build_antenna_overflow_graph`).
+
+    The pocket is the set of substations that leave the main connected component
+    when the max overload edge is removed. The constraint line bridges the main
+    grid (its ``root`` substation) and the pocket (its entry substation).
+
+    Args:
+        obs_simu: Grid2Op-compatible observation (post-contingency state).
+        lines_overloaded_ids (list[int]): indices of the overloaded lines.
+
+    Returns:
+        dict | None: ``None`` when no pocket is islanded by the max overload
+        alone (i.e. this is not an antenna case). Otherwise a dict with keys:
+            - ``constraint_line_id`` (int): index of the max overload line.
+            - ``constraint_line_name`` (str)
+            - ``root_sub_id`` (int): the constraint endpoint on the main grid.
+            - ``antenna_sub_ids`` (list[int]): substation ids in the pocket.
+            - ``antenna_sub_names`` (list[str])
+    """
+    if not lines_overloaded_ids:
+        return None
+
+    max_rho = max(obs_simu.rho[i] for i in lines_overloaded_ids)
+    constraint_line_id = [i for i in lines_overloaded_ids if obs_simu.rho[i] == max_rho][0]
+    constraint_line_name = obs_simu.name_line[constraint_line_id]
+
+    comps_init, comps_wo_max_overload, _ = get_n_connected_components_graph_with_overloads(
+        obs_simu, lines_overloaded_ids)
+
+    # Nodes that leave the main component once the max overload is removed.
+    islanded_node_labels = set(comps_init[0]) - set(comps_wo_max_overload[0])
+    if not islanded_node_labels:
+        return None
+
+    def _label_to_subid(label):
+        # node labels are produced as "subid_<id>_bus_<b>" in
+        # get_n_connected_components_graph_with_overloads
+        if isinstance(label, int):
+            return label
+        return int(str(label).split('_')[1])
+
+    n_subs = len(obs_simu.name_sub)
+    antenna_sub_ids = sorted({sid for sid in (_label_to_subid(l) for l in islanded_node_labels)
+                              if sid < n_subs})
+    if not antenna_sub_ids:
+        return None
+
+    or_sub = int(obs_simu.line_or_to_subid[constraint_line_id])
+    ex_sub = int(obs_simu.line_ex_to_subid[constraint_line_id])
+    antenna_set = set(antenna_sub_ids)
+    # The constraint line bridges the pocket and the main grid: its endpoint
+    # inside the pocket is the entry, the other endpoint is the root.
+    if or_sub in antenna_set and ex_sub not in antenna_set:
+        root_sub_id = ex_sub
+    elif ex_sub in antenna_set and or_sub not in antenna_set:
+        root_sub_id = or_sub
+    else:
+        # Degenerate: both (or neither) endpoints in the pocket — not a clean
+        # single-feed antenna; bail out so the caller keeps the legacy path.
+        return None
+
+    return {
+        "constraint_line_id": constraint_line_id,
+        "constraint_line_name": constraint_line_name,
+        "root_sub_id": root_sub_id,
+        "antenna_sub_ids": antenna_sub_ids,
+        "antenna_sub_names": [obs_simu.name_sub[i] for i in antenna_sub_ids],
+    }
+
+
 def get_constrained_and_dispatch_paths(g_distribution_graph, obs, lines_overloaded_ids, lines_overloaded_ids_kept):
     """
     Extracts constrained (blue) and dispatch (red) paths from a structured overload distribution graph.

--- a/expert_op4grid_recommender/graph_analysis/processor.py
+++ b/expert_op4grid_recommender/graph_analysis/processor.py
@@ -331,6 +331,42 @@ def get_constrained_and_dispatch_paths(g_distribution_graph, obs, lines_overload
     return lines_blue_paths, nodes_blue_path, lines_dispatch, nodes_dispatch_path
 
 
+def pre_process_antenna_graph(g_overflow, node_name_mapping):
+    """``pre_process_graph_alphadeesp`` counterpart for the synthetic antenna graph.
+
+    The antenna overflow graph is built by hand (no ``Grid2opSimulation``), so
+    there is no ``overflow_sim`` to extract ``simulator_data`` from. Node
+    splitting — the only consumer of ``simulator_data`` — is disabled in antenna
+    mode, so an empty ``simulator_data`` is returned. The node-label reversion
+    (substation names → real substation indices) and edge-label cleanup are
+    identical to the regular pre-processing, so the injection-action discovery
+    indexes ``obs`` arrays with correct substation indices.
+
+    Args:
+        g_overflow (OverFlowGraph): antenna overflow graph (nodes are sub names).
+        node_name_mapping (dict): ``{real_substation_id: name}``.
+
+    Returns:
+        tuple: ``(g_overflow, g_distribution_graph, simulator_data)`` with
+        ``simulator_data == {}``.
+    """
+    reverse_node_name_mapping = {name: i for i, name in node_name_mapping.items()}
+    g_overflow.g = nx.relabel_nodes(g_overflow.g, reverse_node_name_mapping, copy=True)
+
+    all_edges_xlabel_attributes = nx.get_edge_attributes(g_overflow.g, "label")
+    for edge, label in all_edges_xlabel_attributes.items():
+        try:
+            float(label)
+        except (ValueError, TypeError):
+            match = re.search(r'[-+]?\d+', str(label))
+            if match:
+                all_edges_xlabel_attributes[edge] = match.group()
+    nx.set_edge_attributes(g_overflow.g, all_edges_xlabel_attributes, "label")
+
+    g_distribution_graph = Structured_Overload_Distribution_Graph(g_overflow.g)
+    return g_overflow, g_distribution_graph, {}
+
+
 def pre_process_graph_alphadeesp(g_overflow, overflow_sim, node_name_mapping):
     """
     Prepares the overflow graph and extracts simulation data for use with AlphaDeesp functions.

--- a/expert_op4grid_recommender/graph_analysis/processor.py
+++ b/expert_op4grid_recommender/graph_analysis/processor.py
@@ -251,7 +251,7 @@ def extract_antenna_context(obs_simu, lines_overloaded_ids):
         return int(str(label).split('_')[1])
 
     n_subs = len(obs_simu.name_sub)
-    antenna_sub_ids = sorted({sid for sid in (_label_to_subid(l) for l in islanded_node_labels)
+    antenna_sub_ids = sorted({sid for sid in (_label_to_subid(lbl) for lbl in islanded_node_labels)
                               if sid < n_subs})
     if not antenna_sub_ids:
         return None

--- a/expert_op4grid_recommender/graph_analysis/visualization.py
+++ b/expert_op4grid_recommender/graph_analysis/visualization.py
@@ -367,7 +367,7 @@ def make_overflow_graph_visualization(env, overflow_sim, g_overflow, hubs, obs_s
             # Default to False if we can't determine
             is_DC = False
     
-    if not is_DC:
+    if not is_DC and overflow_sim is not None:
         # Filter to keep only non-grey edges for highlighting
         non_grey_line_names = {
             data.get("name")

--- a/expert_op4grid_recommender/main.py
+++ b/expert_op4grid_recommender/main.py
@@ -8,6 +8,7 @@
 # This file is part of expert_op4grid_recommender, Expert system analyzer based on ExpertOp4Grid principles. ⚡️ This tool builds overflow graphs,
 # applies expert rules to filter potential actions, and identifies relevant corrective measures to alleviate line overloads.
 
+import copy
 import os
 import sys
 import argparse
@@ -29,7 +30,7 @@ from expert_op4grid_recommender.graph_analysis.processor import (
     pre_process_antenna_graph,
     extract_antenna_context,
 )
-from expert_op4grid_recommender.graph_analysis.antenna_graph import build_antenna_overflow_graph
+from expert_op4grid_recommender.graph_analysis.antenna_graph import build_antenna_overflow_graph, SOURCE_NODE_NAME
 from expert_op4grid_recommender.graph_analysis.visualization import make_overflow_graph_visualization, \
     get_graph_file_name
 from expert_op4grid_recommender.action_evaluation.classifier import ActionClassifier
@@ -460,12 +461,26 @@ def _make_antenna_visualization(context, df_of_g, g_overflow, hubs,
         try:
             cp_lines, cp_nodes, _ob_e, _ob_n = g_distribution_graph.get_constrained_edges_nodes()
             lines_constrained_path = list(cp_lines)
-            nodes_constrained_path = list(cp_nodes)
+            nodes_constrained_path = [n for n in cp_nodes if n != SOURCE_NODE_NAME]
         except Exception as exc:
             print("Could not pre-compute constrained path for antenna viewer: " + str(exc))
+        # Render a source-free copy of the graph. The synthetic ``__GRID_SOURCE__``
+        # node is required in the discovery graph (it anchors the amont so
+        # alphaDeesp's find_hubs doesn't drop the root as an isolate), but it is
+        # not a real substation: ``make_overflow_graph_visualization`` builds its
+        # voltage-level / electrical-node-number dicts from ``obs.name_sub`` only,
+        # and alphaDeesp's per-node setters index those dicts for EVERY node in
+        # the graph — so leaving the source in raises ``KeyError: __GRID_SOURCE__``.
+        # Stripping it from a copy keeps the discovery graph untouched while the
+        # rendered pocket shows only real substations.
+        g_overflow_for_viz = copy.copy(g_overflow)
+        g_overflow_for_viz.g = g_overflow.g.copy()
+        if g_overflow_for_viz.g.has_node(SOURCE_NODE_NAME):
+            g_overflow_for_viz.g.remove_node(SOURCE_NODE_NAME)
+        hubs_for_viz = [h for h in hubs if h != SOURCE_NODE_NAME]
         try:
             make_overflow_graph_visualization(
-                context["env"], None, g_overflow, hubs, obs_simu_defaut, save_folder,
+                context["env"], None, g_overflow_for_viz, hubs_for_viz, obs_simu_defaut, save_folder,
                 graph_file_name, lines_swapped=[], custom_layout=None,
                 lines_we_care_about=context.get("lines_we_care_about"),
                 monitoring_factor_thermal_limits=getattr(config, 'MONITORING_FACTOR_THERMAL_LIMITS', 1.0),

--- a/expert_op4grid_recommender/main.py
+++ b/expert_op4grid_recommender/main.py
@@ -8,7 +8,6 @@
 # This file is part of expert_op4grid_recommender, Expert system analyzer based on ExpertOp4Grid principles. ⚡️ This tool builds overflow graphs,
 # applies expert rules to filter potential actions, and identifies relevant corrective measures to alleviate line overloads.
 
-import copy
 import os
 import sys
 import argparse
@@ -30,7 +29,10 @@ from expert_op4grid_recommender.graph_analysis.processor import (
     pre_process_antenna_graph,
     extract_antenna_context,
 )
-from expert_op4grid_recommender.graph_analysis.antenna_graph import build_antenna_overflow_graph, SOURCE_NODE_NAME
+from expert_op4grid_recommender.graph_analysis.antenna_graph import (
+    build_antenna_overflow_graph,
+    focus_overflow_graph_on_pocket,
+)
 from expert_op4grid_recommender.graph_analysis.visualization import make_overflow_graph_visualization, \
     get_graph_file_name
 from expert_op4grid_recommender.action_evaluation.classifier import ActionClassifier
@@ -445,10 +447,12 @@ def _make_antenna_visualization(context, df_of_g, g_overflow, hubs,
                                 g_distribution_graph, obs_simu_defaut):
     """Render the antenna overflow graph (PDF/HTML), best-effort.
 
-    Mirrors the regular step-2 visualization but for the synthetic antenna graph:
-    no ``overflow_sim`` (so no before/after rho annotation), no swapped flows and
-    no red dispatch loops (a radial pocket is a pure constrained tree). Fully
-    guarded — a rendering failure must never abort the analysis.
+    Mirrors the regular step-2 visualization but for the antenna graph: no
+    ``overflow_sim`` (so no before/after rho annotation) and no red dispatch
+    loops (a radial pocket is a pure constrained tree). The analysis graph spans
+    the full grid (the gray healthy lines anchor the root); here we render a copy
+    focused on the pocket. Fully guarded — a rendering failure must never abort
+    the analysis.
     """
     with Timer("Antenna Visualization"):
         graph_file_name = get_graph_file_name(
@@ -461,26 +465,21 @@ def _make_antenna_visualization(context, df_of_g, g_overflow, hubs,
         try:
             cp_lines, cp_nodes, _ob_e, _ob_n = g_distribution_graph.get_constrained_edges_nodes()
             lines_constrained_path = list(cp_lines)
-            nodes_constrained_path = [n for n in cp_nodes if n != SOURCE_NODE_NAME]
+            nodes_constrained_path = list(cp_nodes)
         except Exception as exc:
             print("Could not pre-compute constrained path for antenna viewer: " + str(exc))
-        # Render a source-free copy of the graph. The synthetic ``__GRID_SOURCE__``
-        # node is required in the discovery graph (it anchors the amont so
-        # alphaDeesp's find_hubs doesn't drop the root as an isolate), but it is
-        # not a real substation: ``make_overflow_graph_visualization`` builds its
-        # voltage-level / electrical-node-number dicts from ``obs.name_sub`` only,
-        # and alphaDeesp's per-node setters index those dicts for EVERY node in
-        # the graph — so leaving the source in raises ``KeyError: __GRID_SOURCE__``.
-        # Stripping it from a copy keeps the discovery graph untouched while the
-        # rendered pocket shows only real substations.
-        g_overflow_for_viz = copy.copy(g_overflow)
-        g_overflow_for_viz.g = g_overflow.g.copy()
-        if g_overflow_for_viz.g.has_node(SOURCE_NODE_NAME):
-            g_overflow_for_viz.g.remove_node(SOURCE_NODE_NAME)
-        hubs_for_viz = [h for h in hubs if h != SOURCE_NODE_NAME]
+        # Render a pocket-focused copy: the analysis graph is built over the full
+        # grid (the gray healthy lines anchor the root for find_hubs), but the
+        # operator only wants to see the islanded pocket. The visualization never
+        # rebuilds the structured-overload graph, so trimming here is safe.
+        antenna_info = context["antenna_info"]
+        g_overflow_for_viz = focus_overflow_graph_on_pocket(
+            g_overflow, obs_simu_defaut,
+            antenna_info["root_sub_id"], antenna_info["antenna_sub_ids"],
+        )
         try:
             make_overflow_graph_visualization(
-                context["env"], None, g_overflow_for_viz, hubs_for_viz, obs_simu_defaut, save_folder,
+                context["env"], None, g_overflow_for_viz, hubs, obs_simu_defaut, save_folder,
                 graph_file_name, lines_swapped=[], custom_layout=None,
                 lines_we_care_about=context.get("lines_we_care_about"),
                 monitoring_factor_thermal_limits=getattr(config, 'MONITORING_FACTOR_THERMAL_LIMITS', 1.0),
@@ -498,12 +497,14 @@ def _make_antenna_visualization(context, df_of_g, g_overflow, hubs,
 def _run_antenna_step2_graph(context: Dict[str, Any]) -> Dict[str, Any]:
     """Step-2 graph build for the islanded-pocket (antenna) case.
 
-    The regular alphaDeesp pipeline cannot run on a grid that the contingency
-    breaks apart, so we build a synthetic downstream overflow graph of the
-    pocket instead (see ``graph_analysis.antenna_graph``). The result is shaped
-    exactly like the regular path so the downstream discovery / reassessment is
-    unchanged — except ``overflow_sim`` is ``None`` and the context carries
-    ``antenna_meta``.
+    The regular alphaDeesp pipeline cannot run a meaningful load-flow
+    redistribution on a grid that the contingency breaks apart, so we feed the
+    standard ``OverFlowGraph`` machinery the post-disconnection state implied by
+    the islanding (initial flows, zeroed on the pocket) and let it build the
+    graph (see ``graph_analysis.antenna_graph.build_antenna_overflow_graph``).
+    The result is shaped exactly like the regular path so the downstream
+    discovery / reassessment is unchanged — except ``overflow_sim`` is ``None``
+    and the context carries ``antenna_meta``.
     """
     obs_simu_defaut = context["obs_simu_defaut"]
     antenna_info = context["antenna_info"]

--- a/expert_op4grid_recommender/main.py
+++ b/expert_op4grid_recommender/main.py
@@ -440,6 +440,46 @@ def run_analysis_step1(analysis_date: Optional[datetime],
     return None, context
 
 
+def _make_antenna_visualization(context, df_of_g, g_overflow, hubs,
+                                g_distribution_graph, obs_simu_defaut):
+    """Render the antenna overflow graph (PDF/HTML), best-effort.
+
+    Mirrors the regular step-2 visualization but for the synthetic antenna graph:
+    no ``overflow_sim`` (so no before/after rho annotation), no swapped flows and
+    no red dispatch loops (a radial pocket is a pure constrained tree). Fully
+    guarded — a rendering failure must never abort the analysis.
+    """
+    with Timer("Antenna Visualization"):
+        graph_file_name = get_graph_file_name(
+            context["current_lines_defaut"], context["chronic_name"],
+            context["current_timestep"], False,
+        )
+        save_folder = config.SAVE_FOLDER_VISUALIZATION
+        lines_constrained_path = None
+        nodes_constrained_path = None
+        try:
+            cp_lines, cp_nodes, _ob_e, _ob_n = g_distribution_graph.get_constrained_edges_nodes()
+            lines_constrained_path = list(cp_lines)
+            nodes_constrained_path = list(cp_nodes)
+        except Exception as exc:
+            print("Could not pre-compute constrained path for antenna viewer: " + str(exc))
+        try:
+            make_overflow_graph_visualization(
+                context["env"], None, g_overflow, hubs, obs_simu_defaut, save_folder,
+                graph_file_name, lines_swapped=[], custom_layout=None,
+                lines_we_care_about=context.get("lines_we_care_about"),
+                monitoring_factor_thermal_limits=getattr(config, 'MONITORING_FACTOR_THERMAL_LIMITS', 1.0),
+                lines_constrained_path=lines_constrained_path,
+                nodes_constrained_path=nodes_constrained_path,
+                lines_red_loops=None, nodes_red_loops=None,
+            )
+        except Exception as exc:
+            print(
+                "Antenna overflow-graph visualization failed (continuing without it): "
+                f"{type(exc).__name__}: {exc}"
+            )
+
+
 def _run_antenna_step2_graph(context: Dict[str, Any]) -> Dict[str, Any]:
     """Step-2 graph build for the islanded-pocket (antenna) case.
 
@@ -461,6 +501,10 @@ def _run_antenna_step2_graph(context: Dict[str, Any]) -> Dict[str, Any]:
             antenna_info["antenna_sub_ids"],
             antenna_info["root_sub_id"],
         )
+
+    if config.DO_VISUALIZATION:
+        _make_antenna_visualization(context, df_of_g, g_overflow, hubs,
+                                    g_distribution_graph, obs_simu_defaut)
 
     context.update({
         "df_of_g": df_of_g,

--- a/expert_op4grid_recommender/main.py
+++ b/expert_op4grid_recommender/main.py
@@ -25,8 +25,11 @@ from expert_op4grid_recommender.config import DATE as DEFAULT_DATE, TIMESTEP as 
 from expert_op4grid_recommender.graph_analysis.processor import (
     identify_overload_lines_to_keep_overflow_graph_connected,
     get_constrained_and_dispatch_paths,
-    pre_process_graph_alphadeesp
+    pre_process_graph_alphadeesp,
+    pre_process_antenna_graph,
+    extract_antenna_context,
 )
+from expert_op4grid_recommender.graph_analysis.antenna_graph import build_antenna_overflow_graph
 from expert_op4grid_recommender.graph_analysis.visualization import make_overflow_graph_visualization, \
     get_graph_file_name
 from expert_op4grid_recommender.action_evaluation.classifier import ActionClassifier
@@ -373,19 +376,29 @@ def run_analysis_step1(analysis_date: Optional[datetime],
 
     lines_overloaded_names = [obs_simu_defaut.name_line[i] for i in lines_overloaded_ids]
 
+    antenna_info = None
     if not lines_overloaded_ids_kept:
-        print("Overload breaks the grid apart. No topological solution without load shedding.")
-        return {
-            "lines_overloaded_names": lines_overloaded_names,
-            "prioritized_actions": {},
-            "action_scores": {
-                "line_reconnection": {"scores": {}, "params": {}},
-                "line_disconnection": {"scores": {}, "params": {}},
-                "open_coupling": {"scores": {}, "params": {}},
-                "close_coupling": {"scores": {}, "params": {}},
-                "renewable_curtailment": {"scores": {}, "params": {}},
-            },
-        }, None
+        if config.ENABLE_ANTENNA_RECOMMENDATIONS:
+            antenna_info = extract_antenna_context(obs_simu_defaut, lines_overloaded_ids)
+        if antenna_info is None:
+            print("Overload breaks the grid apart. No topological solution without load shedding.")
+            return {
+                "lines_overloaded_names": lines_overloaded_names,
+                "prioritized_actions": {},
+                "action_scores": {
+                    "line_reconnection": {"scores": {}, "params": {}},
+                    "line_disconnection": {"scores": {}, "params": {}},
+                    "open_coupling": {"scores": {}, "params": {}},
+                    "close_coupling": {"scores": {}, "params": {}},
+                    "renewable_curtailment": {"scores": {}, "params": {}},
+                },
+            }, None
+        print(
+            "Overload islands a radial pocket — switching to antenna mode: building a "
+            "downstream overflow graph on the islanded substations "
+            f"{antenna_info['antenna_sub_names']} and restricting recommendations to "
+            "injection actions (load shedding / curtailment / redispatch)."
+        )
 
     context = {
         "backend": backend,
@@ -414,6 +427,8 @@ def run_analysis_step1(analysis_date: Optional[datetime],
         "actual_fast_mode": actual_fast_mode,
         "check_simu_overloads": check_simu_overloads,
         "switch_to_dc": switch_to_dc,
+        "antenna_mode": antenna_info is not None,
+        "antenna_info": antenna_info,
         "build_overflow_graph": build_overflow_graph,
         "get_env_first_obs": get_env_first_obs,
         "simulate_contingency": simulate_contingency,
@@ -425,8 +440,46 @@ def run_analysis_step1(analysis_date: Optional[datetime],
     return None, context
 
 
+def _run_antenna_step2_graph(context: Dict[str, Any]) -> Dict[str, Any]:
+    """Step-2 graph build for the islanded-pocket (antenna) case.
+
+    The regular alphaDeesp pipeline cannot run on a grid that the contingency
+    breaks apart, so we build a synthetic downstream overflow graph of the
+    pocket instead (see ``graph_analysis.antenna_graph``). The result is shaped
+    exactly like the regular path so the downstream discovery / reassessment is
+    unchanged — except ``overflow_sim`` is ``None`` and the context carries
+    ``antenna_meta``.
+    """
+    obs_simu_defaut = context["obs_simu_defaut"]
+    antenna_info = context["antenna_info"]
+
+    with Timer("Antenna Graph Building"):
+        (df_of_g, overflow_sim, g_overflow, hubs, g_distribution_graph,
+         node_name_mapping, antenna_meta) = build_antenna_overflow_graph(
+            obs_simu_defaut,
+            antenna_info["constraint_line_id"],
+            antenna_info["antenna_sub_ids"],
+            antenna_info["root_sub_id"],
+        )
+
+    context.update({
+        "df_of_g": df_of_g,
+        "overflow_sim": overflow_sim,  # None — no Grid2opSimulation in antenna mode
+        "g_overflow": g_overflow,
+        "hubs": hubs,
+        "g_distribution_graph": g_distribution_graph,
+        "node_name_mapping": node_name_mapping,
+        "antenna_meta": antenna_meta,
+        "use_dc": False,
+    })
+    return context
+
+
 def run_analysis_step2_graph(context: Dict[str, Any]) -> Dict[str, Any]:
     """Second part of the expert system analysis, focusing on graph generation and visualization."""
+    if context.get("antenna_mode"):
+        return _run_antenna_step2_graph(context)
+
     backend = context["backend"]
     env = context["env"]
     obs = context["obs"]
@@ -632,7 +685,11 @@ def _run_expert_discovery(context: Dict[str, Any], n_action_max: int = None
     Returns ``(prioritized_actions, action_scores)`` from the underlying
     :class:`ActionDiscoverer`.
     """
-    _run_expert_action_filter(context)
+    antenna_mode = bool(context.get("antenna_mode"))
+    if not antenna_mode:
+        # Topological candidate filtering is irrelevant in antenna mode (only
+        # injection actions are discovered, and those are created directly).
+        _run_expert_action_filter(context)
 
     env = context["env"]
     obs = context["obs"]
@@ -665,9 +722,14 @@ def _run_expert_discovery(context: Dict[str, Any], n_action_max: int = None
         n_action_max = config.N_PRIORITIZED_ACTIONS
 
     with Timer("Pre-process for AlphaDeesp"):
-        g_overflow_processed, g_distribution_graph_processed, simulator_data = pre_process_graph_alphadeesp(
-            g_overflow, overflow_sim, node_name_mapping
-        )
+        if antenna_mode:
+            g_overflow_processed, g_distribution_graph_processed, simulator_data = pre_process_antenna_graph(
+                g_overflow, node_name_mapping
+            )
+        else:
+            g_overflow_processed, g_distribution_graph_processed, simulator_data = pre_process_graph_alphadeesp(
+                g_overflow, overflow_sim, node_name_mapping
+            )
 
     if use_dc:
         print("Warning: you have used the DC load flow, so results are more approximate")
@@ -676,7 +738,7 @@ def _run_expert_discovery(context: Dict[str, Any], n_action_max: int = None
         context["env"] = env
         context["obs"] = obs
 
-    actions_unfiltered_keys = set(context["filtered_candidate_actions"])
+    actions_unfiltered_keys = set(context.get("filtered_candidate_actions") or [])
 
     with Timer("Action Discovery"):
         discoverer = ActionDiscoverer(
@@ -700,7 +762,9 @@ def _run_expert_discovery(context: Dict[str, Any], n_action_max: int = None
             lines_we_care_about=lines_we_care_about,
             check_rho_reduction_func=check_rho_reduction,
             create_default_action_func=create_default_action,
-            obs_linecut=getattr(overflow_sim, 'obs_linecut', None)
+            obs_linecut=getattr(overflow_sim, 'obs_linecut', None),
+            antenna_mode=antenna_mode,
+            antenna_meta=context.get("antenna_meta"),
         )
 
         if is_pypowsybl:
@@ -766,7 +830,7 @@ def run_analysis_step2_discovery(context: Dict[str, Any],
     # ``inputs.filtered_candidate_actions``, useful for models that
     # want to sample inside the expert-reduced action space. Idempotent
     # — free no-op when already populated (Expert path).
-    if context.get("g_distribution_graph") is not None:
+    if context.get("g_distribution_graph") is not None and not context.get("antenna_mode"):
         _run_expert_action_filter(context)
 
     inputs = build_recommender_inputs(context)
@@ -790,6 +854,10 @@ def run_analysis_step2_discovery(context: Dict[str, Any],
         "action_scores": action_scores,
         "pre_existing_overloads": pre_existing_info,
         "combined_actions": combined_actions,
+        # Present only for the islanded-pocket (antenna) case: describes the
+        # disconnected radial pocket and its net direction so callers can flag
+        # it to the operator. ``None`` for the regular path.
+        "antenna_meta": context.get("antenna_meta"),
         # Per-stage execution times (seconds). ``prediction_time`` is the
         # model's intrinsic recommend() call (includes internal candidate
         # simulation done by Expert-style models). ``assessment_time`` is

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "expert_op4grid_recommender"
-version = "0.2.4.post1"
+version = "0.2.5"
 authors = [
     { name="RTE", email="rte@rte-france.com" },
 ]

--- a/tests/test_antenna_graph.py
+++ b/tests/test_antenna_graph.py
@@ -8,6 +8,7 @@ These tests are self-contained: they build a tiny grid2op-compatible
 observation by hand, so they need neither pypowsybl nor a real environment.
 """
 
+import copy
 import types
 
 import networkx as nx
@@ -205,6 +206,43 @@ def test_pre_process_antenna_graph_reverts_and_returns_empty_simulator_data():
     # Nodes reverted to real substation indices; pocket stays downstream.
     assert set(sdg.get_constrained_path().n_aval()) == {1, 2, 3, 4}
     assert all(isinstance(n, (int, np.integer)) for n in g_proc.g.nodes())
+
+
+def test_viz_graph_strips_source_so_per_node_setters_dont_keyerror():
+    """Regression: the antenna overflow-graph visualization must render a copy
+    with the synthetic ``__GRID_SOURCE__`` node removed.
+
+    ``make_overflow_graph_visualization`` builds its voltage-level /
+    electrical-node-number dicts from ``obs.name_sub`` only, and alphaDeesp's
+    per-node setters index those dicts for EVERY node in the graph
+    (``dict[node] for node in self.g``). Leaving the synthetic source in raised
+    ``KeyError: __GRID_SOURCE__``. The discovery graph still needs the source
+    (it anchors the amont), so only the viz copy is stripped.
+    """
+    obs = _make_obs()
+    ctx = extract_antenna_context(obs, [list(obs.name_line).index("CONSTRAINT")])
+    _, _, g_overflow, hubs, _, _, _ = build_antenna_overflow_graph(
+        obs, ctx["constraint_line_id"], ctx["antenna_sub_ids"], ctx["root_sub_id"])
+
+    # The source node IS present in the discovery graph (still required there).
+    assert SOURCE_NODE_NAME in g_overflow.g.nodes()
+
+    # Mirror the viz copy built in main._make_antenna_visualization.
+    g_overflow_for_viz = copy.copy(g_overflow)
+    g_overflow_for_viz.g = g_overflow.g.copy()
+    g_overflow_for_viz.g.remove_node(SOURCE_NODE_NAME)
+
+    assert SOURCE_NODE_NAME not in g_overflow_for_viz.g.nodes()
+    assert set(g_overflow_for_viz.g.nodes()) <= set(obs.name_sub)
+    # The discovery graph must stay untouched by the copy.
+    assert SOURCE_NODE_NAME in g_overflow.g.nodes()
+
+    # Faithfully reproduce the exact alphaDeesp call that used to raise: a
+    # per-node dict keyed by obs.name_sub indexed for every node in the graph.
+    number_nodal_dict = {
+        sub_name: len({1}) for sub_name in obs.name_sub
+    }
+    g_overflow_for_viz.set_electrical_node_number(number_nodal_dict)  # must not raise
 
 
 def _make_injection_only_discoverer(obs, antenna_mode):

--- a/tests/test_antenna_graph.py
+++ b/tests/test_antenna_graph.py
@@ -1,0 +1,159 @@
+# Copyright (c) 2025-2026, RTE (https://www.rte-france.com)
+# See AUTHORS.txt
+# This Source Code Form is subject to the terms of the Mozilla Public License, version 2.0.
+# SPDX-License-Identifier: MPL-2.0
+"""Unit tests for the synthetic antenna (islanded-pocket) overflow graph.
+
+These tests are self-contained: they build a tiny grid2op-compatible
+observation by hand, so they need neither pypowsybl nor a real environment.
+"""
+
+import types
+
+import networkx as nx
+import numpy as np
+import pytest
+
+from expert_op4grid_recommender.graph_analysis.antenna_graph import build_antenna_overflow_graph
+from expert_op4grid_recommender.graph_analysis.processor import extract_antenna_context
+
+
+def _make_obs(antenna_prod=None):
+    """Build a fake observation with a radial pocket fed by one overloaded line.
+
+    Topology::
+
+        main grid:  0 - 5 - 6 - 7 - 8          (sub 0 is the antenna root)
+        constraint:    0 == 1                  (overloaded, rho = 1.5)
+        antenna:       1 - 2,  1 - 3,  3 - 4
+
+    The pocket {1, 2, 3, 4} is islanded as soon as the 0==1 line is cut.
+    Loads sit on subs 2/3/4 → net consumer, unless ``antenna_prod`` injects
+    generation to flip the pocket into a net producer.
+    """
+    name_sub = np.array([f"S{i}" for i in range(9)])
+    # lines: (or_sub, ex_sub, name)
+    lines = [
+        (0, 5, "L0_5"), (5, 6, "L5_6"), (6, 7, "L6_7"), (7, 8, "L7_8"),  # main grid
+        (0, 1, "CONSTRAINT"),                                            # feed
+        (1, 2, "L1_2"), (1, 3, "L1_3"), (3, 4, "L3_4"),                  # antenna
+    ]
+    n_lines = len(lines)
+    name_line = np.array([l[2] for l in lines])
+    line_or_to_subid = np.array([l[0] for l in lines])
+    line_ex_to_subid = np.array([l[1] for l in lines])
+    line_or_bus = np.ones(n_lines, dtype=int)
+    line_ex_bus = np.ones(n_lines, dtype=int)
+    line_status = np.ones(n_lines, dtype=bool)
+    a_or = np.full(n_lines, 100.0)
+    rho = np.full(n_lines, 0.5)
+    constraint_id = list(name_line).index("CONSTRAINT")
+    rho[constraint_id] = 1.5  # the overload
+    # active-power flows (MW), magnitudes only matter for the graph
+    p_or = np.full(n_lines, 10.0)
+    p_or[constraint_id] = 60.0
+    p_or[list(name_line).index("L1_2")] = 30.0
+    p_or[list(name_line).index("L1_3")] = 30.0
+    p_or[list(name_line).index("L3_4")] = 10.0
+
+    # loads on antenna subs 2/3/4
+    load_to_subid = np.array([2, 3, 4])
+    load_p = np.array([30.0, 20.0, 10.0])
+
+    if antenna_prod is None:
+        gen_to_subid = np.array([0])
+        gen_p = np.array([0.0])
+    else:
+        gen_to_subid = np.array([antenna_prod[0]])
+        gen_p = np.array([antenna_prod[1]])
+
+    return types.SimpleNamespace(
+        name_sub=name_sub, name_line=name_line,
+        line_or_to_subid=line_or_to_subid, line_ex_to_subid=line_ex_to_subid,
+        line_or_bus=line_or_bus, line_ex_bus=line_ex_bus,
+        line_status=line_status, a_or=a_or, rho=rho, p_or=p_or,
+        load_to_subid=load_to_subid, load_p=load_p,
+        gen_to_subid=gen_to_subid, gen_p=gen_p,
+    )
+
+
+def _edge_colors_by_name(g):
+    return {data["name"]: data["color"]
+            for _, _, data in g.edges(data=True)}
+
+
+def test_extract_antenna_context_identifies_pocket():
+    obs = _make_obs()
+    overloaded = [list(obs.name_line).index("CONSTRAINT")]
+    ctx = extract_antenna_context(obs, overloaded)
+
+    assert ctx is not None
+    assert ctx["constraint_line_name"] == "CONSTRAINT"
+    assert ctx["root_sub_id"] == 0
+    assert ctx["antenna_sub_ids"] == [1, 2, 3, 4]
+    assert set(ctx["antenna_sub_names"]) == {"S1", "S2", "S3", "S4"}
+
+
+def test_extract_antenna_context_none_when_no_overloads():
+    obs = _make_obs()
+    assert extract_antenna_context(obs, []) is None
+
+
+def test_antenna_graph_classifies_whole_pocket_as_aval():
+    obs = _make_obs()
+    ctx = extract_antenna_context(obs, [list(obs.name_line).index("CONSTRAINT")])
+
+    df, sim, g_overflow, hubs, sdg, mapping, meta = build_antenna_overflow_graph(
+        obs, ctx["constraint_line_id"], ctx["antenna_sub_ids"], ctx["root_sub_id"])
+
+    assert sim is None  # no Grid2opSimulation involved
+    cp = sdg.get_constrained_path()
+    # The whole pocket is downstream (aval); the root is upstream (amont).
+    assert set(cp.n_aval()) == {"S1", "S2", "S3", "S4"}
+    assert "S0" in cp.n_amont()
+
+    colors = _edge_colors_by_name(g_overflow.g)
+    assert colors["CONSTRAINT"] == "black"
+    for branch in ("L1_2", "L1_3", "L3_4"):
+        assert colors[branch] == "blue", f"{branch} should be a downstream blue edge"
+
+
+def test_antenna_meta_consumer_direction_and_net_mw():
+    obs = _make_obs()
+    ctx = extract_antenna_context(obs, [list(obs.name_line).index("CONSTRAINT")])
+    *_, meta = build_antenna_overflow_graph(
+        obs, ctx["constraint_line_id"], ctx["antenna_sub_ids"], ctx["root_sub_id"])
+
+    assert meta["direction"] == "consumer"
+    assert meta["n_subs"] == 4
+    assert meta["total_load_mw"] == pytest.approx(60.0)
+    assert meta["total_prod_mw"] == pytest.approx(0.0)
+    assert meta["net_mw"] == pytest.approx(-60.0)
+    assert set(meta["antenna_sub_names"]) == {"S1", "S2", "S3", "S4"}
+
+
+def test_antenna_meta_producer_direction():
+    # 200 MW of generation on antenna sub 2 outweighs the 60 MW of load.
+    obs = _make_obs(antenna_prod=(2, 200.0))
+    ctx = extract_antenna_context(obs, [list(obs.name_line).index("CONSTRAINT")])
+    *_, meta = build_antenna_overflow_graph(
+        obs, ctx["constraint_line_id"], ctx["antenna_sub_ids"], ctx["root_sub_id"])
+
+    assert meta["direction"] == "producer"
+    assert meta["total_prod_mw"] == pytest.approx(200.0)
+    assert meta["net_mw"] == pytest.approx(140.0)
+
+
+def test_antenna_graph_is_a_connected_dag_rooted_at_root():
+    obs = _make_obs()
+    ctx = extract_antenna_context(obs, [list(obs.name_line).index("CONSTRAINT")])
+    _, _, g_overflow, _, _, _, _ = build_antenna_overflow_graph(
+        obs, ctx["constraint_line_id"], ctx["antenna_sub_ids"], ctx["root_sub_id"])
+
+    g = g_overflow.g
+    assert set(g.nodes()) == {"S0", "S1", "S2", "S3", "S4"}
+    # 1 constraint edge + 3 antenna branches
+    assert g.number_of_edges() == 4
+    assert nx.is_weakly_connected(g)
+    # acyclic when collapsed to a simple digraph (radial, oriented away from root)
+    assert nx.is_directed_acyclic_graph(nx.DiGraph(g))

--- a/tests/test_antenna_graph.py
+++ b/tests/test_antenna_graph.py
@@ -52,9 +52,9 @@ def _make_obs(antenna_prod=None):
         (1, 2, "L1_2"), (1, 3, "L1_3"), (3, 4, "L3_4"),                  # antenna
     ]
     n_lines = len(lines)
-    name_line = np.array([l[2] for l in lines])
-    line_or_to_subid = np.array([l[0] for l in lines])
-    line_ex_to_subid = np.array([l[1] for l in lines])
+    name_line = np.array([ln[2] for ln in lines])
+    line_or_to_subid = np.array([ln[0] for ln in lines])
+    line_ex_to_subid = np.array([ln[1] for ln in lines])
     line_or_bus = np.ones(n_lines, dtype=int)
     line_ex_bus = np.ones(n_lines, dtype=int)
     line_status = np.ones(n_lines, dtype=bool)

--- a/tests/test_antenna_graph.py
+++ b/tests/test_antenna_graph.py
@@ -2,10 +2,12 @@
 # See AUTHORS.txt
 # This Source Code Form is subject to the terms of the Mozilla Public License, version 2.0.
 # SPDX-License-Identifier: MPL-2.0
-"""Unit tests for the synthetic antenna (islanded-pocket) overflow graph.
+"""Unit tests for the antenna (islanded-pocket) overflow graph.
 
 These tests are self-contained: they build a tiny grid2op-compatible
 observation by hand, so they need neither pypowsybl nor a real environment.
+
+See ``docs/antenna_overflow_graph.md`` for the design.
 """
 
 import types
@@ -17,7 +19,11 @@ from alphaDeesp.core.graphsAndPaths import Structured_Overload_Distribution_Grap
 
 from expert_op4grid_recommender.graph_analysis.antenna_graph import (
     SOURCE_NODE_NAME,
+    _build_topo,
+    _compute_delta_flow_frame,
+    _islanded_line_mask,
     build_antenna_overflow_graph,
+    focus_overflow_graph_on_pocket,
 )
 from expert_op4grid_recommender.graph_analysis.processor import (
     extract_antenna_context,
@@ -367,3 +373,152 @@ def test_orchestrator_targets_pocket_when_it_is_amont():
     assert 0 not in set(captured.get("ls", []))
     # Redispatch addresses the pocket on both raise/lower sides.
     assert pocket <= set(captured.get("rd_up", [])) | set(captured.get("rd_down", []))
+
+
+# ---------------------------------------------------------------------------
+# Helper-level unit tests (the pieces build_antenna_overflow_graph composes).
+# ---------------------------------------------------------------------------
+
+def test_islanded_line_mask_marks_pocket_incident_lines_only():
+    """Every line with an endpoint inside the pocket collapses (constraint +
+    internal branches); the healthy main-grid lines do not."""
+    obs = _make_obs()
+    nl = list(obs.name_line)
+    ctx = extract_antenna_context(obs, [nl.index("CONSTRAINT")])
+
+    mask = _islanded_line_mask(obs, ctx["antenna_sub_ids"])
+
+    islanded = {nl[i] for i, m in enumerate(mask) if m}
+    assert islanded == {"CONSTRAINT", "L1_2", "L1_3", "L3_4"}
+    # Healthy main-grid lines are untouched.
+    assert not (islanded & {"L0_5", "L5_6", "L6_7", "L7_8"})
+
+
+def test_build_topo_aggregates_prod_and_load_per_substation():
+    """topo['nodes'] carries per-substation prod/load over the full grid."""
+    obs = _make_obs(antenna_prod=(2, 200.0))  # 200 MW generation on sub 2
+    topo = _build_topo(obs)
+
+    assert len(topo["nodes"]["are_prods"]) == len(obs.name_sub)
+    assert len(topo["edges"]["idx_or"]) == len(obs.name_line)
+    # Sub 2 has both the 200 MW generator and a 30 MW load.
+    assert topo["nodes"]["are_prods"][2] is True
+    assert topo["nodes"]["prods_values"][2] == pytest.approx(200.0)
+    assert topo["nodes"]["are_loads"][2] is True
+    assert topo["nodes"]["loads_values"][2] == pytest.approx(30.0)
+    # Original (pre-swap) line orientation is preserved in the topo edges.
+    assert topo["edges"]["idx_or"] == [int(s) for s in obs.line_or_to_subid]
+    assert topo["edges"]["idx_ex"] == [int(s) for s in obs.line_ex_to_subid]
+
+
+def test_delta_flow_frame_collapse_yields_minus_initial_on_pocket():
+    """With new_flows = initial-with-pocket-zeroed, the pocket branches report
+    delta = -|p_or| (blue) and the healthy grid reports delta = 0 (gray)."""
+    obs = _make_obs()
+    nl = list(obs.name_line)
+    constraint = nl.index("CONSTRAINT")
+
+    new_flows = obs.p_or.copy()
+    new_flows[_islanded_line_mask(obs, [1, 2, 3, 4])] = 0.0
+    df = _compute_delta_flow_frame(obs, new_flows, constraint, threshold=0.05)
+
+    by_name = {r.line_name: r for r in df.itertuples()}
+    # Pocket branches: full negative report equal to the initial flow magnitude.
+    assert by_name["L1_2"].delta_flows == pytest.approx(-30.0)
+    assert by_name["L3_4"].delta_flows == pytest.approx(-10.0)
+    assert by_name["CONSTRAINT"].delta_flows == pytest.approx(-60.0)
+    # Healthy grid: untouched flow → zero delta.
+    assert by_name["L0_5"].delta_flows == pytest.approx(0.0)
+    # The frame has one row per line, in line order.
+    assert list(df["line_name"]) == nl
+
+
+def test_delta_flow_frame_gray_threshold_is_relative_to_constraint():
+    """A pocket branch whose report falls below ThresholdReportOfLine * the
+    constraint report is flagged gray (de-emphasised), like the real builder."""
+    obs = _make_obs()
+    nl = list(obs.name_line)
+    constraint = nl.index("CONSTRAINT")  # report 60
+    new_flows = obs.p_or.copy()
+    new_flows[_islanded_line_mask(obs, [1, 2, 3, 4])] = 0.0
+
+    # threshold 0.2 → max_overload = 0.2 * 60 = 12 MW. L3_4 (10) < 12 → gray.
+    df = _compute_delta_flow_frame(obs, new_flows, constraint, threshold=0.2)
+    by_name = {r.line_name: r for r in df.itertuples()}
+    assert by_name["L3_4"].gray_edges  # 10 < 12
+    assert not by_name["L1_2"].gray_edges  # 30 >= 12
+
+
+def test_build_returns_full_alphadeesp_frame_columns():
+    """df_of_g exposes the same columns the standard builders return."""
+    obs = _make_obs()
+    ctx = extract_antenna_context(obs, [list(obs.name_line).index("CONSTRAINT")])
+    df, sim, *_ = build_antenna_overflow_graph(
+        obs, ctx["constraint_line_id"], ctx["antenna_sub_ids"], ctx["root_sub_id"])
+
+    assert sim is None  # no Grid2opSimulation in antenna mode
+    assert {"idx_or", "idx_ex", "init_flows", "new_flows", "delta_flows",
+            "new_flows_swapped", "gray_edges", "line_name"} <= set(df.columns)
+    assert len(df) == len(obs.name_line)
+
+
+def test_producer_pocket_with_real_export_is_amont_and_producer():
+    """A pocket whose generation outweighs its load AND physically exports
+    (reversed flows) is classified amont with direction='producer'."""
+    obs = _make_exporting_obs()
+    # Flip the pocket into a net producer: 200 MW gen on sub 2 > 60 MW load.
+    obs.gen_to_subid = np.array([2])
+    obs.gen_p = np.array([200.0])
+    obs.name_gen = np.array(["G0"])
+
+    ctx = extract_antenna_context(obs, [list(obs.name_line).index("CONSTRAINT")])
+    _, _, g, _, sdg, _, meta = build_antenna_overflow_graph(
+        obs, ctx["constraint_line_id"], ctx["antenna_sub_ids"], ctx["root_sub_id"])
+
+    assert meta["direction"] == "producer"
+    assert meta["total_prod_mw"] == pytest.approx(200.0)
+    cp = sdg.get_constrained_path()
+    assert set(cp.n_amont()) == {"S1", "S2", "S3", "S4"}
+    assert "S0" in cp.n_aval()
+
+
+def test_focus_helper_preserves_edge_attributes_and_skips_missing_nodes():
+    """focus_overflow_graph_on_pocket keeps edge styling and never errors on a
+    pocket id that is not in the graph; the source graph stays untouched."""
+    obs = _make_obs()
+    ctx = extract_antenna_context(obs, [list(obs.name_line).index("CONSTRAINT")])
+    _, _, g_overflow, _, _, _, _ = build_antenna_overflow_graph(
+        obs, ctx["constraint_line_id"], ctx["antenna_sub_ids"], ctx["root_sub_id"])
+
+    # Include a bogus pocket id (99) — must be silently skipped.
+    focused = focus_overflow_graph_on_pocket(
+        g_overflow, obs, ctx["root_sub_id"], ctx["antenna_sub_ids"] + [99])
+
+    assert set(focused.g.nodes()) == {"S0", "S1", "S2", "S3", "S4"}
+    # Edge colours / names survive the subgraph copy.
+    colours = _edge_colors_by_name(focused.g)
+    assert colours["CONSTRAINT"] == "black"
+    assert colours["L1_2"] == "blue"
+    # The original analysis graph is not mutated.
+    assert "S8" in g_overflow.g.nodes()
+    assert focused.g is not g_overflow.g
+
+
+def test_antenna_graph_survives_negative_constraint_flow():
+    """The constraint line stored with a negative p_or (ex→or direction) is
+    handled by the branch-direction-swap and still ends up black + connecting
+    the pocket to the root."""
+    obs = _make_obs()
+    nl = list(obs.name_line)
+    # Force the constraint flow negative without changing topology.
+    obs.p_or = obs.p_or.copy()
+    obs.p_or[nl.index("CONSTRAINT")] = -60.0
+
+    ctx = extract_antenna_context(obs, [nl.index("CONSTRAINT")])
+    _, _, g_overflow, _, sdg, _, _ = build_antenna_overflow_graph(
+        obs, ctx["constraint_line_id"], ctx["antenna_sub_ids"], ctx["root_sub_id"])
+
+    colours = _edge_colors_by_name(g_overflow.g)
+    assert colours["CONSTRAINT"] == "black"
+    # Still a valid radial structure with a usable constrained path.
+    assert sdg.get_constrained_path() is not None

--- a/tests/test_antenna_graph.py
+++ b/tests/test_antenna_graph.py
@@ -13,8 +13,12 @@ import types
 import networkx as nx
 import numpy as np
 import pytest
+from alphaDeesp.core.graphsAndPaths import Structured_Overload_Distribution_Graph
 
-from expert_op4grid_recommender.graph_analysis.antenna_graph import build_antenna_overflow_graph
+from expert_op4grid_recommender.graph_analysis.antenna_graph import (
+    SOURCE_NODE_NAME,
+    build_antenna_overflow_graph,
+)
 from expert_op4grid_recommender.graph_analysis.processor import extract_antenna_context
 
 
@@ -144,6 +148,29 @@ def test_antenna_meta_producer_direction():
     assert meta["net_mw"] == pytest.approx(140.0)
 
 
+def test_node_name_mapping_reverts_to_real_substation_indices():
+    """The discovery pipeline reverts node names to *real* grid2op sub indices
+    (via pre_process_graph_alphadeesp) and uses them to index obs arrays, so the
+    mapping must be keyed by real substation ids — not compact 0..k-1 ids."""
+    obs = _make_obs()
+    ctx = extract_antenna_context(obs, [list(obs.name_line).index("CONSTRAINT")])
+    _, _, g_overflow, _, _, mapping, _ = build_antenna_overflow_graph(
+        obs, ctx["constraint_line_id"], ctx["antenna_sub_ids"], ctx["root_sub_id"])
+
+    # mapping is {real_sub_id: name} for the 5 real subs + the sentinel source
+    # (id == n_subs == 9), which the discovery's ``idx < n_subs`` guards drop.
+    assert mapping[0] == "S0" and mapping[4] == "S4"
+    assert mapping[9] == SOURCE_NODE_NAME
+
+    # Reverting names -> real indices (what pre_process_graph_alphadeesp does)
+    # must NOT crash in integer space and keeps the pocket downstream.
+    reverse = {name: sid for sid, name in mapping.items()}
+    g_idx = nx.relabel_nodes(g_overflow.g, reverse, copy=True)
+    sdg_idx = Structured_Overload_Distribution_Graph(g_idx)
+    # downstream nodes are the real substation indices of the pocket
+    assert set(sdg_idx.get_constrained_path().n_aval()) == {1, 2, 3, 4}
+
+
 def test_antenna_graph_is_a_connected_dag_rooted_at_root():
     obs = _make_obs()
     ctx = extract_antenna_context(obs, [list(obs.name_line).index("CONSTRAINT")])
@@ -151,9 +178,9 @@ def test_antenna_graph_is_a_connected_dag_rooted_at_root():
         obs, ctx["constraint_line_id"], ctx["antenna_sub_ids"], ctx["root_sub_id"])
 
     g = g_overflow.g
-    assert set(g.nodes()) == {"S0", "S1", "S2", "S3", "S4"}
-    # 1 constraint edge + 3 antenna branches
-    assert g.number_of_edges() == 4
+    assert set(g.nodes()) == {SOURCE_NODE_NAME, "S0", "S1", "S2", "S3", "S4"}
+    # grid-source anchor + constraint edge + 3 antenna branches
+    assert g.number_of_edges() == 5
     assert nx.is_weakly_connected(g)
     # acyclic when collapsed to a simple digraph (radial, oriented away from root)
     assert nx.is_directed_acyclic_graph(nx.DiGraph(g))

--- a/tests/test_antenna_graph.py
+++ b/tests/test_antenna_graph.py
@@ -19,7 +19,10 @@ from expert_op4grid_recommender.graph_analysis.antenna_graph import (
     SOURCE_NODE_NAME,
     build_antenna_overflow_graph,
 )
-from expert_op4grid_recommender.graph_analysis.processor import extract_antenna_context
+from expert_op4grid_recommender.graph_analysis.processor import (
+    extract_antenna_context,
+    pre_process_antenna_graph,
+)
 
 
 def _make_obs(antenna_prod=None):
@@ -67,12 +70,15 @@ def _make_obs(antenna_prod=None):
     if antenna_prod is None:
         gen_to_subid = np.array([0])
         gen_p = np.array([0.0])
+        name_gen = np.array(["G0"])
     else:
         gen_to_subid = np.array([antenna_prod[0]])
         gen_p = np.array([antenna_prod[1]])
+        name_gen = np.array(["G0"])
 
     return types.SimpleNamespace(
         name_sub=name_sub, name_line=name_line,
+        name_load=np.array(["LD2", "LD3", "LD4"]), name_gen=name_gen,
         line_or_to_subid=line_or_to_subid, line_ex_to_subid=line_ex_to_subid,
         line_or_bus=line_or_bus, line_ex_bus=line_ex_bus,
         line_status=line_status, a_or=a_or, rho=rho, p_or=p_or,
@@ -184,3 +190,71 @@ def test_antenna_graph_is_a_connected_dag_rooted_at_root():
     assert nx.is_weakly_connected(g)
     # acyclic when collapsed to a simple digraph (radial, oriented away from root)
     assert nx.is_directed_acyclic_graph(nx.DiGraph(g))
+
+
+def test_pre_process_antenna_graph_reverts_and_returns_empty_simulator_data():
+    obs = _make_obs()
+    ctx = extract_antenna_context(obs, [list(obs.name_line).index("CONSTRAINT")])
+    _, _, g_overflow, _, _, mapping, _ = build_antenna_overflow_graph(
+        obs, ctx["constraint_line_id"], ctx["antenna_sub_ids"], ctx["root_sub_id"])
+
+    g_proc, sdg, simulator_data = pre_process_antenna_graph(g_overflow, mapping)
+
+    # No Grid2opSimulation in antenna mode → no simulator data.
+    assert simulator_data == {}
+    # Nodes reverted to real substation indices; pocket stays downstream.
+    assert set(sdg.get_constrained_path().n_aval()) == {1, 2, 3, 4}
+    assert all(isinstance(n, (int, np.integer)) for n in g_proc.g.nodes())
+
+
+def _make_injection_only_discoverer(obs, antenna_mode):
+    """Build an ActionDiscoverer on the (integer-reverted) antenna graph."""
+    from expert_op4grid_recommender.action_evaluation.classifier import ActionClassifier
+    from expert_op4grid_recommender.action_evaluation.discovery import ActionDiscoverer
+
+    ctx = extract_antenna_context(obs, [list(obs.name_line).index("CONSTRAINT")])
+    _, _, g_overflow, _, _, mapping, meta = build_antenna_overflow_graph(
+        obs, ctx["constraint_line_id"], ctx["antenna_sub_ids"], ctx["root_sub_id"])
+    g_proc, sdg, _ = pre_process_antenna_graph(g_overflow, mapping)
+
+    fake_env = types.SimpleNamespace(action_space=lambda d: types.SimpleNamespace(spec=d))
+    return ActionDiscoverer(
+        env=fake_env, obs=obs, obs_defaut=obs,
+        classifier=ActionClassifier(fake_env.action_space),
+        timestep=0, lines_defaut=["CONSTRAINT"],
+        lines_overloaded_ids=[ctx["constraint_line_id"]],
+        act_reco_maintenance=None, non_connected_reconnectable_lines=[],
+        all_disconnected_lines=[], dict_action={}, actions_unfiltered=set(),
+        hubs=[], g_overflow=g_proc, g_distribution_graph=sdg, simulator_data={},
+        check_action_simulation=False, antenna_mode=antenna_mode, antenna_meta=meta,
+    )
+
+
+def test_orchestrator_antenna_mode_runs_injection_only():
+    obs = _make_obs()
+    discoverer = _make_injection_only_discoverer(obs, antenna_mode=True)
+
+    called = []
+    topological = {
+        "verify_relevant_reconnections": "reco",
+        "find_relevant_node_merging": "close",
+        "find_relevant_node_splitting": "open",
+        "find_relevant_disconnections": "disco",
+        "find_relevant_pst_actions": "pst",
+    }
+    injection = {
+        "find_relevant_load_shedding": "ls",
+        "find_relevant_renewable_curtailment": "rc",
+        "find_relevant_redispatch": "redispatch",
+    }
+    for meth, token in {**topological, **injection}.items():
+        setattr(discoverer, meth, (lambda t: (lambda *a, **k: called.append(t)))(token))
+
+    discoverer.discover_and_prioritize(n_action_max=5)
+
+    # Topological families are filtered out in antenna mode.
+    assert not (set(called) & set(topological.values()))
+    # Load shedding fires (the pocket is a net consumer with loads).
+    assert "ls" in called
+    # The redispatch gate is open too (pocket nodes available).
+    assert "redispatch" in called

--- a/tests/test_antenna_graph.py
+++ b/tests/test_antenna_graph.py
@@ -8,7 +8,6 @@ These tests are self-contained: they build a tiny grid2op-compatible
 observation by hand, so they need neither pypowsybl nor a real environment.
 """
 
-import copy
 import types
 
 import networkx as nx
@@ -155,42 +154,112 @@ def test_antenna_meta_producer_direction():
     assert meta["net_mw"] == pytest.approx(140.0)
 
 
-def test_node_name_mapping_reverts_to_real_substation_indices():
+def _make_exporting_obs():
+    """A pocket that EXPORTS power up to the main grid (amont-islanded case).
+
+    Same topology as ``_make_obs`` but the constraint and pocket-branch flows
+    are reversed (pocket → root), modelling generators inside the pocket feeding
+    the rest of the grid through the overloaded line — the case the RTE operator
+    flagged (flow rising from the pocket up to the constraint).
+    """
+    obs = _make_obs()
+    nl = list(obs.name_line)
+    p = obs.p_or.copy()
+    for ln in ("CONSTRAINT", "L1_2", "L1_3", "L3_4"):
+        p[nl.index(ln)] *= -1
+    obs.p_or = p
+    return obs
+
+
+def test_node_name_mapping_is_full_grid_identity_and_reverts_to_indices():
     """The discovery pipeline reverts node names to *real* grid2op sub indices
-    (via pre_process_graph_alphadeesp) and uses them to index obs arrays, so the
-    mapping must be keyed by real substation ids — not compact 0..k-1 ids."""
+    (via pre_process_antenna_graph) and uses them to index obs arrays. The graph
+    is now built over the full grid through the standard ExpertOp4Grid pipeline,
+    so the mapping is the plain ``{sub_id: name}`` identity (no synthetic node)."""
     obs = _make_obs()
     ctx = extract_antenna_context(obs, [list(obs.name_line).index("CONSTRAINT")])
     _, _, g_overflow, _, _, mapping, _ = build_antenna_overflow_graph(
         obs, ctx["constraint_line_id"], ctx["antenna_sub_ids"], ctx["root_sub_id"])
 
-    # mapping is {real_sub_id: name} for the 5 real subs + the sentinel source
-    # (id == n_subs == 9), which the discovery's ``idx < n_subs`` guards drop.
-    assert mapping[0] == "S0" and mapping[4] == "S4"
-    assert mapping[9] == SOURCE_NODE_NAME
+    assert mapping == {i: name for i, name in enumerate(obs.name_sub)}
+    assert SOURCE_NODE_NAME not in g_overflow.g.nodes()
 
-    # Reverting names -> real indices (what pre_process_graph_alphadeesp does)
-    # must NOT crash in integer space and keeps the pocket downstream.
+    # Reverting names -> real indices (what pre_process_antenna_graph does) must
+    # not crash in integer space and keeps the pocket downstream.
     reverse = {name: sid for sid, name in mapping.items()}
     g_idx = nx.relabel_nodes(g_overflow.g, reverse, copy=True)
     sdg_idx = Structured_Overload_Distribution_Graph(g_idx)
-    # downstream nodes are the real substation indices of the pocket
     assert set(sdg_idx.get_constrained_path().n_aval()) == {1, 2, 3, 4}
 
 
-def test_antenna_graph_is_a_connected_dag_rooted_at_root():
+def test_antenna_graph_uses_real_flow_colours_and_orientation():
+    """A consumer pocket: constraint is the black cut edge, pocket branches are
+    blue and oriented root → leaf. The analysis graph spans the full grid (the
+    healthy lines are gray and anchor the root); the pocket is what matters."""
     obs = _make_obs()
     ctx = extract_antenna_context(obs, [list(obs.name_line).index("CONSTRAINT")])
     _, _, g_overflow, _, _, _, _ = build_antenna_overflow_graph(
         obs, ctx["constraint_line_id"], ctx["antenna_sub_ids"], ctx["root_sub_id"])
 
     g = g_overflow.g
-    assert set(g.nodes()) == {SOURCE_NODE_NAME, "S0", "S1", "S2", "S3", "S4"}
-    # grid-source anchor + constraint edge + 3 antenna branches
-    assert g.number_of_edges() == 5
-    assert nx.is_weakly_connected(g)
-    # acyclic when collapsed to a simple digraph (radial, oriented away from root)
+    assert SOURCE_NODE_NAME not in g.nodes()
+    colours = _edge_colors_by_name(g)
+    assert colours["CONSTRAINT"] == "black"
+    for branch in ("L1_2", "L1_3", "L3_4"):
+        assert colours[branch] == "blue"
+    # Healthy main-grid lines carry zero delta → gray.
+    for healthy in ("L0_5", "L5_6", "L6_7", "L7_8"):
+        assert colours[healthy] == "gray"
+    # Constraint oriented from the main-grid root (S0) into the pocket (S1).
+    constraint_edges = [(u, v) for u, v, d in g.edges(data=True) if d.get("name") == "CONSTRAINT"]
+    assert constraint_edges == [("S0", "S1")]
+    # Radial: acyclic when collapsed to a simple digraph.
     assert nx.is_directed_acyclic_graph(nx.DiGraph(g))
+
+
+def test_focus_overflow_graph_on_pocket_trims_to_pocket():
+    """The visualization helper restricts a copy to root + pocket for a clean
+    render, leaving the analysis graph (full grid) untouched."""
+    from expert_op4grid_recommender.graph_analysis.antenna_graph import (
+        focus_overflow_graph_on_pocket,
+    )
+    obs = _make_obs()
+    ctx = extract_antenna_context(obs, [list(obs.name_line).index("CONSTRAINT")])
+    _, _, g_overflow, _, _, _, _ = build_antenna_overflow_graph(
+        obs, ctx["constraint_line_id"], ctx["antenna_sub_ids"], ctx["root_sub_id"])
+
+    focused = focus_overflow_graph_on_pocket(
+        g_overflow, obs, ctx["root_sub_id"], ctx["antenna_sub_ids"])
+
+    assert set(focused.g.nodes()) == {"S0", "S1", "S2", "S3", "S4"}
+    colours = _edge_colors_by_name(focused.g)
+    assert colours["CONSTRAINT"] == "black"
+    assert not ({"L0_5", "L5_6", "L6_7", "L7_8"} & set(colours))
+    # Analysis graph is untouched (still spans the full grid).
+    assert "S8" in g_overflow.g.nodes()
+
+
+def test_amont_islanded_pocket_orients_pocket_to_root():
+    """Regression for the amont-islanded case: when the pocket EXPORTS, the
+    edges must point pocket → root and alphaDeesp must classify the pocket as
+    amont (upstream), not aval. This is what was previously rendered inverted."""
+    obs = _make_exporting_obs()
+    ctx = extract_antenna_context(obs, [list(obs.name_line).index("CONSTRAINT")])
+    _, _, g_overflow, _, sdg, _, _ = build_antenna_overflow_graph(
+        obs, ctx["constraint_line_id"], ctx["antenna_sub_ids"], ctx["root_sub_id"])
+
+    g = g_overflow.g
+    # Constraint now points pocket entry (S1) → main-grid root (S0).
+    constraint_edges = [(u, v) for u, v, d in g.edges(data=True) if d.get("name") == "CONSTRAINT"]
+    assert constraint_edges == [("S1", "S0")]
+    # Pocket branches converge toward the entry (real flow direction), no loops.
+    branch_edges = {d["name"]: (u, v) for u, v, d in g.edges(data=True)
+                    if d.get("name") in {"L1_2", "L1_3", "L3_4"}}
+    assert branch_edges == {"L1_2": ("S2", "S1"), "L1_3": ("S3", "S1"), "L3_4": ("S4", "S3")}
+    # The exporting pocket is upstream (amont); the main grid is downstream (aval).
+    cp = sdg.get_constrained_path()
+    assert set(cp.n_amont()) == {"S1", "S2", "S3", "S4"}
+    assert "S0" in cp.n_aval()
 
 
 def test_pre_process_antenna_graph_reverts_and_returns_empty_simulator_data():
@@ -208,41 +277,20 @@ def test_pre_process_antenna_graph_reverts_and_returns_empty_simulator_data():
     assert all(isinstance(n, (int, np.integer)) for n in g_proc.g.nodes())
 
 
-def test_viz_graph_strips_source_so_per_node_setters_dont_keyerror():
-    """Regression: the antenna overflow-graph visualization must render a copy
-    with the synthetic ``__GRID_SOURCE__`` node removed.
-
-    ``make_overflow_graph_visualization`` builds its voltage-level /
-    electrical-node-number dicts from ``obs.name_sub`` only, and alphaDeesp's
-    per-node setters index those dicts for EVERY node in the graph
-    (``dict[node] for node in self.g``). Leaving the synthetic source in raised
-    ``KeyError: __GRID_SOURCE__``. The discovery graph still needs the source
-    (it anchors the amont), so only the viz copy is stripped.
-    """
+def test_no_synthetic_node_so_viz_per_node_setters_dont_keyerror():
+    """The graph is built over real substations only, so the viewer's per-node
+    setters (which index dicts keyed by obs.name_sub for every node) never hit a
+    synthetic-node KeyError."""
     obs = _make_obs()
     ctx = extract_antenna_context(obs, [list(obs.name_line).index("CONSTRAINT")])
-    _, _, g_overflow, hubs, _, _, _ = build_antenna_overflow_graph(
+    _, _, g_overflow, _, _, _, _ = build_antenna_overflow_graph(
         obs, ctx["constraint_line_id"], ctx["antenna_sub_ids"], ctx["root_sub_id"])
 
-    # The source node IS present in the discovery graph (still required there).
-    assert SOURCE_NODE_NAME in g_overflow.g.nodes()
+    assert set(g_overflow.g.nodes()) <= set(obs.name_sub)
+    # Exact alphaDeesp call performed by make_overflow_graph_visualization.
+    number_nodal_dict = {sub_name: 1 for sub_name in obs.name_sub}
+    g_overflow.set_electrical_node_number(number_nodal_dict)  # must not raise
 
-    # Mirror the viz copy built in main._make_antenna_visualization.
-    g_overflow_for_viz = copy.copy(g_overflow)
-    g_overflow_for_viz.g = g_overflow.g.copy()
-    g_overflow_for_viz.g.remove_node(SOURCE_NODE_NAME)
-
-    assert SOURCE_NODE_NAME not in g_overflow_for_viz.g.nodes()
-    assert set(g_overflow_for_viz.g.nodes()) <= set(obs.name_sub)
-    # The discovery graph must stay untouched by the copy.
-    assert SOURCE_NODE_NAME in g_overflow.g.nodes()
-
-    # Faithfully reproduce the exact alphaDeesp call that used to raise: a
-    # per-node dict keyed by obs.name_sub indexed for every node in the graph.
-    number_nodal_dict = {
-        sub_name: len({1}) for sub_name in obs.name_sub
-    }
-    g_overflow_for_viz.set_electrical_node_number(number_nodal_dict)  # must not raise
 
 
 def _make_injection_only_discoverer(obs, antenna_mode):
@@ -296,3 +344,26 @@ def test_orchestrator_antenna_mode_runs_injection_only():
     assert "ls" in called
     # The redispatch gate is open too (pocket nodes available).
     assert "redispatch" in called
+
+
+def test_orchestrator_targets_pocket_when_it_is_amont():
+    """Producer pocket (amont-islanded): the pocket is classified amont, yet the
+    injection methods must still receive the pocket substations (targeted via
+    antenna_meta), not the aval root."""
+    obs = _make_exporting_obs()
+    discoverer = _make_injection_only_discoverer(obs, antenna_mode=True)
+
+    captured = {}
+    discoverer.find_relevant_load_shedding = lambda nodes, *a, **k: captured.update(ls=list(nodes))
+    discoverer.find_relevant_renewable_curtailment = lambda *a, **k: captured.update(rc=True)
+    discoverer.find_relevant_redispatch = lambda up, down, *a, **k: captured.update(
+        rd_up=list(up), rd_down=list(down))
+
+    discoverer.discover_and_prioritize(n_action_max=5)
+
+    pocket = set(discoverer.antenna_meta["antenna_sub_ids"])
+    # Load shedding targets the pocket (not the aval root sub 0).
+    assert set(captured.get("ls", [])) == pocket
+    assert 0 not in set(captured.get("ls", []))
+    # Redispatch addresses the pocket on both raise/lower sides.
+    assert pocket <= set(captured.get("rd_up", [])) | set(captured.get("rd_down", []))


### PR DESCRIPTION
## Summary

Implements antenna mode for handling radial islanded pockets — when a contingency leaves a pocket of substations fed by a single overloaded line, disconnecting that line breaks the grid apart. Rather than giving up, antenna mode now builds the pocket graph through the **standard ExpertOp4Grid machinery** (alphaDeesp's `OverFlowGraph` + `Structured_Overload_Distribution_Graph`) by feeding it the post-disconnection state implied by the islanding.

## Key Changes

### New Modules
- **`graph_analysis/antenna_graph.py`** (295 lines): Core antenna graph builder
  - `build_antenna_overflow_graph()` — builds overflow graph for islanded pocket by computing delta flows from explicit "after" state (initial flows with pocket lines zeroed)
  - `_compute_delta_flow_frame()` — vectorised twin of alphaDeesp's `create_df`, replicating branch-direction swap, `new_flows_swapped` handling, and gray-edge threshold
  - `_islanded_line_mask()`, `_build_topo()` — helper functions for topology and line masking
  - `focus_overflow_graph_on_pocket()` — visualization helper to trim full-grid analysis graph to pocket + root for clean rendering

### Modified Modules
- **`graph_analysis/processor.py`**: Added `extract_antenna_context()` function
  - Detects radial pockets islanded by the max overload line
  - Returns pocket description (constraint line, root substation, pocket substations) or `None` if not an antenna case
  - Uses existing `get_n_connected_components_graph_with_overloads()` to identify islanded nodes

- **`main.py`**: Integrated antenna mode into analysis pipeline
  - Step 1 now calls `extract_antenna_context()` when no topological solution exists
  - Builds antenna graph via `build_antenna_overflow_graph()` when antenna mode is active
  - Added `_make_antenna_visualization()` helper for pocket-focused rendering
  - Passes antenna metadata through context to action discovery

- **`action_evaluation/discovery/_orchestrator.py`**: Antenna-mode action filtering
  - Restricts to injection families only (`ls`, `rc`, `redispatch`) — topological actions are filtered out
  - Skips red dispatch loop analysis (radial pocket is a pure tree)
  - Targets pocket substations directly via `antenna_meta["antenna_sub_ids"]` (not aval-only, to handle producer pockets correctly)

- **`action_evaluation/discovery/_base.py`**: Added `antenna_mode` and `antenna_meta` parameters to `ActionDiscoverer.__init__`

- **`config.py`**: Added `ENABLE_ANTENNA_RECOMMENDATIONS` flag (default: `True`)

- **`graph_analysis/visualization.py`**: Minor fix for DC mode detection

### Test Coverage
- **`tests/test_antenna_graph.py`** (524 lines): Comprehensive unit tests
  - 30+ tests covering pocket detection, graph construction, flow orientation, consumer/producer cases
  - Tests for both aval-islanded (consumer) and amont-islanded (producer) pockets
  - Validates edge colours, node classification, and action discovery targeting
  - Self-contained: builds fake observations without requiring pypowsybl or real environments

### Documentation
- **`docs/antenna_overflow_graph.md`** (198 lines): Design document
  - Problem statement and physical sub-cases (consumer vs. producer pockets)
  - Principle: reuse standard pipeline with synthetic "after" state
  - Implementation details and antenna_meta structure
  - Integration points in the analysis pipeline

### Changelog
- Updated `CHANGELOG.md` with antenna mode feature description

## Implementation Details

**Key insight**: Instead of hand-rolling a synthetic graph, feed alphaDeesp the post-disconnection state:
```
new_flows = initial post-contingency flows, with every line incident to the pocket set to 0
delta_flows = new_flows - init_flows
```

This gives:
- `delta_flows = 0` on healthy grid lines → gray edges (trimmed by `keep_

https://claude.ai/code/session_01G98jPDQCUoczpkHbeshENj