### PR TITLE
IHM manœuvre: dataset RTE 7000 source + HuggingFace Space deploy

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,25 @@
+# Trims the Docker build context (the IHM image only needs the package +
+# scripts; everything below is rebuilt, downloaded at runtime, or irrelevant).
+**/__pycache__
+**/*.pyc
+**/*.pyo
+*.egg-info
+
+# Local virtualenvs.
+venv
+.venv
+env
+
+# VCS / CI / editor.
+.git
+.github
+.circleci
+.idea
+.vscode
+
+# Not needed at runtime (the IHM downloads its data from HuggingFace on demand).
+docs
+tests
+data
+.cache
+Overflow_Graph

--- a/.github/workflows/deploy-huggingface.yml
+++ b/.github/workflows/deploy-huggingface.yml
@@ -1,0 +1,77 @@
+name: Deploy IHM Manœuvre to HuggingFace Space
+
+# Redeploys the HuggingFace Docker Space (the maneuver IHM, sourced live from
+# the RTE 7000 dataset) on every merge to main. Mirrors the manual flow in
+# deploy/huggingface/SETUP.md: push ONE squashed, history-free commit of the
+# current tree to the Space's main branch.
+#
+# Required repo configuration (Settings → Secrets and variables → Actions):
+#   - secret  HF_TOKEN     : a HuggingFace WRITE access token with access to the Space
+#   - variable HF_SPACE    : the Space path, e.g. "your-user/expert-op4grid-ihm"
+#   - variable HF_USERNAME : (optional) the token owner's HF username — only when
+#                            the Space lives under an ORG (differs from HF_SPACE owner).
+#
+# The job no-ops (does not fail) when HF_TOKEN / HF_SPACE are absent, so the
+# workflow is inert until you opt in by setting them.
+
+on:
+  push:
+    branches: [ main ]
+  workflow_dispatch: {}
+
+# Never run two deploys at once; the latest merge wins.
+concurrency:
+  group: huggingface-space-deploy
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    name: Push snapshot to HF Space
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check the deploy is configured
+        id: guard
+        env:
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+          HF_SPACE: ${{ vars.HF_SPACE }}
+        run: |
+          if [ -z "$HF_TOKEN" ] || [ -z "$HF_SPACE" ]; then
+            echo "::notice::HF_TOKEN secret and/or HF_SPACE variable not set — skipping deploy."
+            echo "configured=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "configured=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Checkout current tree
+        if: steps.guard.outputs.configured == 'true'
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1   # an orphan snapshot only needs the current tree
+
+      - name: Configure git
+        if: steps.guard.outputs.configured == 'true'
+        run: |
+          git config user.name  "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Build a history-free snapshot
+        if: steps.guard.outputs.configured == 'true'
+        run: |
+          cp deploy/huggingface/README.md README.md   # HF needs the frontmatter at repo root
+          git checkout --orphan hf-deploy
+          git add -A
+          git commit -q -m "Deploy ${GITHUB_SHA::7}"
+          test "$(git rev-list --count HEAD)" -eq 1   # sanity: exactly one commit
+
+      - name: Push to the HuggingFace Space
+        if: steps.guard.outputs.configured == 'true'
+        env:
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+          HF_SPACE: ${{ vars.HF_SPACE }}
+          HF_USERNAME: ${{ vars.HF_USERNAME }}
+        run: |
+          user="${HF_USERNAME:-${HF_SPACE%%/*}}"
+          # The token is a GitHub secret → masked in logs even inside the URL.
+          git remote add space "https://${user}:${HF_TOKEN}@huggingface.co/spaces/${HF_SPACE}"
+          git -c protocol.version=0 push -f space hf-deploy:main
+          echo "::notice::Pushed snapshot of ${GITHUB_SHA::7} to spaces/${HF_SPACE}; HF will rebuild."

--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,10 @@ venv/
 .coverage.*
 htmlcov/
 coverage.xml
+
+# environnements virtuels (noms personnalisés)
+venv*/
+
+# artefacts non versionnés sur le Space (profiling, slides)
+*.prof
+*.pptx

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,38 @@ situations réseau directement dans le dataset RTE 7000** par date/heure, et se
   téléchargement, frontière réseau mockée) et `tests/manoeuvre/test_ihm_dataset.py`
   (endpoints + garde-fous). Le mode local (`--grid`) est strictement préservé.
 
+### IHM de manœuvre : refonte UX du panneau + volet nodal
+
+Refonte ergonomique de l'IHM de manœuvre (`scripts/manoeuvre_ihm_assets/index.html`
++ `scripts/manoeuvre_ihm.py`). Doc : `docs/manoeuvre_ihm.md` ; figure annotée :
+`docs/manoeuvre/manoeuvre_ihm_overview.svg`.
+
+- **Situation réseau en deux onglets** *📁 Local* (chemin `.xiidm` + **sélecteur de
+  fichier natif**, `GET /api/pick_grid_file`) et *📅 RTE7000* (date/heure), avec un
+  **unique bouton Charger** ; RTE7000 mis en avant par défaut sur le Space.
+- **Dates d'accès rapide 2021-2023** (7 journées de la « Table de campagne »),
+  l'**année sélectionnant le dataset** (`dataset_source.repo_pour_date`,
+  `…-2021/-2022/-2023`) ; bulles d'information chiffrées.
+- **Champ poste unifié** : une recherche sur tous les postes NODE_BREAKER +
+  **liste browsable** sous le titre *« Pré-sélection de postes typiques »*
+  (exploration curée par typologie). **Plus d'auto-chargement de poste**.
+- **« 🗺 Scénario Topologique »** en 3 étapes (Poste → Topologie cible → Séquence).
+  **✓ Valider** (active le calcul) et **💾 Sauvegarder** séparés ; sur le Space
+  (`hosted`), les scénarios/séquences sauvegardés sont **aussi téléchargés en
+  local** (`/api/save` + `/api/save_sequence` renvoient `content`).
+- **En-têtes de schéma** : **↺ État d'origine** (départ) et **⇧ Nouvelle Topologie
+  Départ** (cible → promeut la cible courante en départ, `POST /api/promote_cible`).
+  **⟳ Recharger** (modale) remplace la section « Scénarios sauvegardés ».
+- **Volet nodal** : sections **Départ/Cible repliables**, **ouvrages isolés en tête
+  de cadre**, **↺ Réinitialiser** (reset complet détaillé + nodal), et **＋ Nœud**
+  crée un nœud vide **persistant** (cible de dépose ; nœuds vides ignorés au calcul).
+- **Tests** : garde-fou de **structure du front** (`test_ihm_frontend_asset.py` :
+  marqueurs requis présents / retirés absents, bloc script équilibré) ;
+  `test_ihm_cache_and_api.py` (sélecteur de fichier, `promote_cible`, `content` de
+  `/api/save` + `/api/save_sequence`, nœuds vides ignorés) ; `test_ihm_dataset.py`
+  (`repo_pour_date`, dérivation du repo par année sur timestamps **et** load,
+  drapeau `hosted`).
+
 ---
 
 ## [0.2.5] - 2026-06-19

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### IHM de manœuvre : source dataset RTE 7000 + déploiement HuggingFace Space
+
+L'IHM de manœuvre (`scripts/manoeuvre_ihm.py`) peut désormais **sourcer ses
+situations réseau directement dans le dataset RTE 7000** par date/heure, et se
+**déploie en HuggingFace Docker Space** (sur le modèle de Co-Study4Grid).
+
+- **Couche source par date** (`manoeuvre/dataset/source.py`, nouveau) :
+  `lister_instantanes(repo, date)` (liste les instantanés HH:MM d'une journée via
+  l'API tree HuggingFace), `choisir_instantane(insts, heure)` (le plus proche de
+  l'heure visée, **midi par défaut**), `telecharger_instantane` / `charger_situation`
+  (téléchargement **à la demande** + cache local + vérif md5, puis chargement
+  pypowsybl). Stdlib pur, jeton `HF_TOKEN` optionnel. Ré-exporté par
+  `manoeuvre.dataset`.
+- **Mode dataset de l'IHM** : `--grid` devient **optionnel** ; sans lui (ou avec
+  `--dataset`), l'IHM démarre sur le dataset. Nouveaux endpoints
+  `GET /api/dataset/config`, `GET /api/dataset/timestamps`,
+  `POST /api/dataset/load` ; garde-fous « aucune situation chargée »
+  (`/api/postes` renvoie `needs_date`). Options `--host` / `--port` (+ env `PORT`,
+  `DGITT_REPO`, `DGITT_CACHE_DIR`, `DGITT_DEFAULT_DATE`, `HF_TOKEN`).
+- **Frontend** : bandeau **📅 Dataset RTE7000** (date + heure midi-par-défaut +
+  dates échantillons) ; le poste courant est préservé lors d'un changement de
+  date. Le flux « relever les VL → choisir un poste → éditer/séquencer » est
+  inchangé.
+- **Déploiement** : `Dockerfile` (mono-conteneur Flask léger sur `:7860`, mode
+  dataset), `.dockerignore`, `deploy/huggingface/{README.md, SETUP.md}`,
+  `.github/workflows/deploy-huggingface.yml` (redéploiement auto, inerte sans
+  `HF_TOKEN`/`HF_SPACE`).
+- **Tests** : `tests/manoeuvre/test_dataset_source.py` (logique de résolution /
+  téléchargement, frontière réseau mockée) et `tests/manoeuvre/test_ihm_dataset.py`
+  (endpoints + garde-fous). Le mode local (`--grid`) est strictement préservé.
+
 ---
 
 ## [0.2.5] - 2026-06-19

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,55 @@
+# Expert Op4Grid — IHM Manœuvre : image mono-conteneur pour un HuggingFace
+# Docker Space.
+#
+# Un seul process Flask sert l'IHM de manœuvre (HTML statique + API) sur le port
+# 7860, en **mode dataset** : les situations réseau (instantanés XIIDM du dataset
+# RTE 7000) sont téléchargées **à la demande** depuis HuggingFace au moment où
+# l'utilisateur choisit une date/heure — rien n'est embarqué dans l'image.
+#
+# Build context = racine du dépôt :  docker build -t eo4g-ihm .
+# Test local              :  docker run --rm -p 7860:7860 eo4g-ihm
+#                            puis ouvrir http://localhost:7860
+
+FROM python:3.11-slim-bookworm
+
+# libgomp1 : runtime OpenMP lié par certaines wheels scientifiques (numpy).
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        libgomp1 \
+    && rm -rf /var/lib/apt/lists/*
+
+# Les Spaces HuggingFace exécutent le conteneur en uid 1000 ("user"). On garde
+# l'app sous son HOME pour que les écritures runtime (cache des instantanés
+# téléchargés) tombent sur un chemin inscriptible.
+RUN useradd -m -u 1000 user
+USER user
+ENV HOME=/home/user \
+    PATH=/home/user/.local/bin:$PATH \
+    PYTHONUNBUFFERED=1
+WORKDIR /home/user/app
+
+# Dépendances (couche propre pour le cache). L'IHM de manœuvre ne dépend que de
+# flask + pypowsybl + networkx + pandas : le module ``manoeuvre`` n'a aucune
+# autre dépendance externe. On évite ainsi tout le tas scientifique du
+# recommandeur (grid2op, expertop4grid, scipy, matplotlib…) — image légère.
+RUN pip install --no-cache-dir --upgrade pip \
+    && pip install --no-cache-dir \
+        flask \
+        "pypowsybl>=1.13.0" \
+        networkx \
+        pandas
+
+# Code applicatif : le package (importé via sys.path par le script) + l'IHM et
+# ses assets HTML. Pas de données embarquées : la source est le dataset distant.
+COPY --chown=user expert_op4grid_recommender/ ./expert_op4grid_recommender/
+COPY --chown=user scripts/ ./scripts/
+
+# Source des données = dataset RTE 7000, téléchargé à la demande dans ce cache
+# (éphémère sur un Space). HF_TOKEN (optionnel, secret du Space) desserre le
+# rate-limit anonyme du CDN HuggingFace.
+ENV DGITT_REPO=OpenSynth/D-GITT-RTE7000-2021 \
+    DGITT_CACHE_DIR=/home/user/app/.cache/dgitt \
+    DGITT_DEFAULT_DATE=2021-01-03 \
+    PORT=7860
+
+EXPOSE 7860
+CMD ["python", "scripts/manoeuvre_ihm.py", "--dataset", "--host", "0.0.0.0", "--port", "7860"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -49,6 +49,7 @@ COPY --chown=user scripts/ ./scripts/
 ENV DGITT_REPO=OpenSynth/D-GITT-RTE7000-2021 \
     DGITT_CACHE_DIR=/home/user/app/.cache/dgitt \
     DGITT_DEFAULT_DATE=2021-01-03 \
+    MANOEUVRE_IHM_HOSTED=1 \
     PORT=7860
 
 EXPOSE 7860

--- a/README.md
+++ b/README.md
@@ -27,6 +27,48 @@ system shipped as the default. See
 
 ---
 
+## Interactive Maneuver Interface (IHM)
+
+A lightweight web IHM (`scripts/manoeuvre_ihm.py`) drives the `manoeuvre`
+module interactively: pick a substation, edit a **target detailed topology**,
+compute and **animate the switching sequence**, and save scenarios/sequences.
+It also backs the hosted **TopologyManoeuver4Grid** HuggingFace Space (network
+situations sourced on demand from the RTE-7000 dataset by date/hour). Full
+guide: [`docs/manoeuvre_ihm.md`](docs/manoeuvre_ihm.md).
+
+![Annotated overview of the maneuver IHM on a node-split scenario at CARRIP3](docs/manoeuvre/manoeuvre_ihm_overview.svg)
+
+> **Fig. — Interactive maneuver environment on a node-split scenario at CARRIP3**
+> (departure: one electrical node; target: three nodes — busbar 1 kept, busbar 2
+> split into 2.1 and 2.2). Numbered affordances:
+> **(1)** the **Situation réseau** source in two tabs — *Local* (server-side
+> `.xiidm` path + native file picker) and *RTE7000* (dataset date/hour, with quick
+> "case-of-interest" chips) — loaded by a single **Charger** button (RTE7000
+> foregrounded on the Space);
+> **(2)** the unified **Poste** search (all NODE_BREAKER substations, pinned ★
+> first) + by-typology explorer;
+> **(3)** the read-only **departure** single-line diagram, header **↺ État
+> d'origine** (reset target to pristine);
+> **(4)** the **editable target** diagram (click a breaker/disconnector to
+> toggle), header **⇧ Nouvelle Topologie Départ** (promote the target to a new
+> departure);
+> **(5)** the nodal **bus view** (drag a feeder to re-route, drag one busbar onto
+> another to merge, *+ Nœud* to create a node);
+> **(6)** **2 · Topologie cible** — validate & save (locks "Calculer" until
+> validated);
+> **(7)** **3 · Séquence de manœuvres** — de-energization mode + compute /
+> **✋ manual**;
+> **(8)** **⚙ Calculer la topologie détaillée d'intérêt** (the nodal→detailed
+> bridge);
+> **(9)** the **step-by-step animated** sequence with a disconnector-operated-
+> under-load flagged in red (here **R18**) + **💾 save**;
+> **(10)** **⟳ Recharger** (next to the *Scénario Topologique* title) opens a modal
+> to replay a saved scenario.
+> Bus colors are the native `topological_coloring`; the three right-hand busbars
+> are the target nodes.
+
+---
+
 ## Installation
 
 1.  **Clone the repository:**

--- a/README.md
+++ b/README.md
@@ -45,8 +45,8 @@ guide: [`docs/manoeuvre_ihm.md`](docs/manoeuvre_ihm.md).
 > `.xiidm` path + native file picker) and *RTE7000* (dataset date/hour, with quick
 > "case-of-interest" chips) — loaded by a single **Charger** button (RTE7000
 > foregrounded on the Space);
-> **(2)** the unified **Poste** search (all NODE_BREAKER substations, pinned ★
-> first) + by-typology explorer;
+> **(2)** the unified **Poste** field — one search over all NODE_BREAKER
+> substations (pinned ★ marked in results) + a browsable by-typology list;
 > **(3)** the read-only **departure** single-line diagram, header **↺ État
 > d'origine** (reset target to pristine);
 > **(4)** the **editable target** diagram (click a breaker/disconnector to

--- a/README.md
+++ b/README.md
@@ -50,8 +50,8 @@ guide: [`docs/manoeuvre_ihm.md`](docs/manoeuvre_ihm.md).
 > **(3)** the read-only **departure** single-line diagram, header **↺ État
 > d'origine** (reset target to pristine);
 > **(4)** the **editable target** diagram (click a breaker/disconnector to
-> toggle), header **⇧ Nouvelle Topologie Départ** (promote the target to a new
-> departure);
+> toggle), header **⇧ Nouvelle Topologie Départ** (promote the *current edited*
+> target to a new departure — the departure pane above updates);
 > **(5)** the nodal **bus view** (drag a feeder to re-route, drag one busbar onto
 > another to merge, *+ Nœud* to create a node);
 > **(6)** **2 · Topologie cible** — validate & save (locks "Calculer" until

--- a/deploy/huggingface/README.md
+++ b/deploy/huggingface/README.md
@@ -1,0 +1,55 @@
+---
+title: Expert Op4Grid — IHM Manœuvre
+emoji: 🔌
+colorFrom: indigo
+colorTo: green
+sdk: docker
+app_port: 7860
+pinned: false
+license: mpl-2.0
+---
+
+# Expert Op4Grid — IHM Manœuvre (dataset RTE 7000)
+
+Interface web pour **identifier et séquencer les manœuvres** de reconfiguration
+d'un poste électrique (topologie NODE_BREAKER), bâtie sur le module `manoeuvre`
+d'[Expert Op4Grid Recommender](https://github.com/marota/Expert_op4grid_recommender).
+
+Ce Space est **branché directement sur le dataset RTE 7000**
+([`OpenSynth/D-GITT-RTE7000-2021`](https://huggingface.co/datasets/OpenSynth/D-GITT-RTE7000-2021)) :
+les situations réseau (instantanés XIIDM du réseau France, un toutes les 5 min)
+sont **téléchargées à la demande** au moment où vous choisissez une date/heure —
+rien n'est embarqué dans l'image.
+
+## Déroulé
+
+1. **📅 Dataset RTE7000** — choisissez une **date** (un accès rapide propose des
+   journées documentées) puis une **heure** (instantané, pas de 5 min ; **midi
+   présélectionné**) et cliquez **Charger la situation**. Le réseau France de
+   cette date/heure est téléchargé puis chargé.
+2. **Poste** — la liste de **tous les voltage levels** (postes NODE_BREAKER) de
+   la situation se peuple ; sélectionnez-en un (menu épinglé, exploration par
+   typologie, ou recherche). Sa **topologie détaillée** (SLD) s'affiche.
+3. **Éditer & séquencer** — modifiez la topologie cible (clic sur les organes ou
+   volet nodal), **validez la cible**, puis **calculez la séquence de manœuvres**
+   (modes smooth / agressif, algorithmes pluggables) et **animez-la** étape par
+   étape. Changez de date/heure à tout moment : le poste courant est rechargé à
+   la nouvelle situation.
+
+## Un utilisateur par instance
+
+L'IHM garde un **unique état réseau** en mémoire (singleton mono-utilisateur,
+requêtes sérialisées), donc un Space en cours sert **un utilisateur à la fois**.
+Pour plusieurs personnes, utilisez **Duplicate this Space** (chaque copie est
+isolée).
+
+## Ressources & notes
+
+- Pile scientifique légère (`pypowsybl` + `networkx` + `pandas` + `flask`). Le
+  réseau France complet (~7000 postes) se charge en quelques secondes au premier
+  choix d'une date ; les changements de poste à date constante sont instantanés.
+- **Internet sortant requis** : le Space récupère les instantanés depuis
+  `huggingface.co`. Un secret **`HF_TOKEN`** (jeton de lecture) est optionnel —
+  il desserre le rate-limit anonyme du CDN.
+- **Stockage éphémère** : le cache des instantanés et les scénarios/séquences
+  sauvegardés ne survivent pas à un redémarrage du Space.

--- a/deploy/huggingface/SETUP.md
+++ b/deploy/huggingface/SETUP.md
@@ -1,0 +1,97 @@
+# Déployer l'IHM de manœuvre sur un HuggingFace Docker Space
+
+Ce dossier scaffolde un déploiement **mono-conteneur** : un process Flask sert
+l'IHM de manœuvre (HTML statique + API) sur le port **7860**, en **mode
+dataset** — les situations réseau (instantanés XIIDM du dataset RTE 7000) sont
+**téléchargées à la demande** depuis HuggingFace. Rien de lourd n'est embarqué
+dans l'image.
+
+Dimensionné pour **un utilisateur par Space** (l'IHM garde un unique état réseau
+en mémoire). Pour plusieurs personnes, chacun clique **Duplicate this Space**.
+
+## Ce qui a été câblé
+
+| Fichier | Rôle |
+|---|---|
+| `Dockerfile` (racine) | Image mono-stage : Python + `flask`/`pypowsybl`/`networkx`/`pandas`, lance l'IHM sur `:7860` en mode dataset. |
+| `.dockerignore` (racine) | Réduit le contexte de build (`.git`, `tests`, `docs`, `data`, …). |
+| `deploy/huggingface/README.md` | Le **README du Space** (frontmatter `sdk: docker`, `app_port: 7860`) + page d'accueil. |
+| `scripts/manoeuvre_ihm.py` | `--grid` optionnel + `--dataset` / `--host` / `--port` (et env `PORT`, `DGITT_*`, `HF_TOKEN`) ; endpoints `/api/dataset/{config,timestamps,load}`. |
+| `expert_op4grid_recommender/manoeuvre/dataset/source.py` | Couche « instantané par date » : liste + télécharge un snapshot HF (stdlib pur, cache local, md5). |
+
+Le mode dataset est activé par `--dataset` (ou dès que `--grid` est absent). En
+local sans `--grid`, l'IHM démarre directement en mode dataset ; avec `--grid`,
+le comportement historique (réseau local) est strictement préservé et le bandeau
+dataset reste masqué.
+
+## Pas de Git LFS nécessaire
+
+Contrairement à Co-Study4Grid, **aucun binaire n'est embarqué** : le dataset est
+récupéré au runtime depuis HuggingFace. Il n'y a donc ni `.gitattributes` LFS ni
+gros fichier dans l'historique à gérer.
+
+## Variables d'environnement (configurables côté Space)
+
+| Variable | Défaut | Rôle |
+|---|---|---|
+| `DGITT_REPO` | `OpenSynth/D-GITT-RTE7000-2021` | Dataset HuggingFace source (2021 ; existe aussi en 2022 / 2023). |
+| `DGITT_DEFAULT_DATE` | `2021-01-03` | Date proposée par défaut dans l'IHM. |
+| `DGITT_CACHE_DIR` | `/home/user/app/.cache/dgitt` | Cache local des instantanés (éphémère sur un Space). |
+| `HF_TOKEN` | *(absent)* | **Optionnel** : jeton de lecture HF pour desserrer le rate-limit anonyme du CDN. Le mettre en **secret** du Space. |
+| `PORT` | `7860` | Port d'écoute (HF expose `:7860`). |
+
+## Étapes de déploiement
+
+1. **Créer le Space** — sur huggingface.co : *New → Space → Docker → Blank*.
+
+2. **Pousser un snapshot orphelin vers le Space** (un seul commit, sans
+   historique) :
+
+   ```bash
+   git remote add space https://huggingface.co/spaces/<user>/<space>   # une fois
+
+   git checkout --orphan hf-deploy
+   cp deploy/huggingface/README.md README.md   # HF attend le frontmatter à la racine
+   git add -A
+   git commit -m "Deploy Expert Op4Grid — IHM Manœuvre"
+   git log --oneline hf-deploy                  # DOIT être un commit unique
+   git -c protocol.version=0 push -f space hf-deploy:main
+   git checkout -f claude/zen-ptolemy-i7qdog
+   git branch -D hf-deploy
+   ```
+
+   (`protocol.version=0` contourne une erreur de négociation que certains
+   réseaux rencontrent contre HF.) HuggingFace lit le `Dockerfile` racine + le
+   frontmatter du README et construit l'image ; le premier build est long (wheel
+   `pypowsybl`), les suivants réutilisent les couches.
+
+3. **(Optionnel) Secret `HF_TOKEN`** — Space → *Settings → Variables and
+   secrets* → ajouter le secret `HF_TOKEN` (jeton de lecture) pour fiabiliser les
+   téléchargements.
+
+4. **Utiliser** — ouvrir le Space, choisir une date/heure → **Charger la
+   situation** → sélectionner un poste → éditer/séquencer.
+
+## Redéploiement automatique sur merge `main` (GitHub Action)
+
+`.github/workflows/deploy-huggingface.yml` rejoue le push orphelin
+automatiquement à chaque merge sur `main` (et sur `workflow_dispatch`). Il est
+**inerte** tant que les éléments suivants ne sont pas définis dans **Settings →
+Secrets and variables → Actions** du dépôt GitHub :
+
+| Type | Nom | Valeur |
+|---|---|---|
+| Secret | `HF_TOKEN` | jeton HuggingFace **write** ayant accès au Space |
+| Variable | `HF_SPACE` | chemin du Space, ex. `your-user/expert-op4grid-ihm` |
+| Variable | `HF_USERNAME` | *(optionnel)* le compte HF propriétaire du jeton, si le Space est sous une **org** |
+
+## Tester l'image localement (recommandé)
+
+```bash
+docker build -t eo4g-ihm .
+docker run --rm -p 7860:7860 eo4g-ihm
+# → ouvrir http://localhost:7860, choisir une date, charger, sélectionner un poste
+```
+
+Le conteneur a besoin d'un **accès internet sortant** vers `huggingface.co` pour
+lister et télécharger les instantanés.

--- a/deploy/huggingface/SETUP.md
+++ b/deploy/huggingface/SETUP.md
@@ -52,6 +52,9 @@ gros fichier dans l'historique à gérer.
 
    git checkout --orphan hf-deploy
    cp deploy/huggingface/README.md README.md   # HF attend le frontmatter à la racine
+   # Le endpoint git HF rejette les binaires non-LFS (>10 MiB ou .pptx/.prof…) :
+   # on les retire du commit de déploiement (restent sur le disque / dans le dépôt).
+   git rm -r --cached --ignore-unmatch 'venv*' '*.prof' '*.pptx'
    git add -A
    git commit -m "Deploy Expert Op4Grid — IHM Manœuvre"
    git log --oneline hf-deploy                  # DOIT être un commit unique

--- a/docs/manoeuvre/manoeuvre_ihm_overview.svg
+++ b/docs/manoeuvre/manoeuvre_ihm_overview.svg
@@ -25,7 +25,7 @@
   <!-- (2) unified Poste search + typology -->
   <text x="28" y="206" font-size="13" font-weight="bold" fill="#1e3a8a">1 · Poste</text>
   <rect x="28" y="214" width="248" height="26" rx="5" fill="#ffffff" stroke="#94a3b8"/>
-  <text x="40" y="231" font-size="12" fill="#64748b">🔎 rechercher un poste (★ épinglés en tête)</text>
+  <text x="40" y="231" font-size="12" fill="#64748b">🔎 rechercher un poste (tous) · ↓ liste par typologie</text>
   <rect x="28" y="246" width="248" height="24" rx="5" fill="#ffffff" stroke="#cbd5e1"/>
   <text x="40" y="262" font-size="11" fill="#64748b">📂 explorer par typologie…</text>
 

--- a/docs/manoeuvre/manoeuvre_ihm_overview.svg
+++ b/docs/manoeuvre/manoeuvre_ihm_overview.svg
@@ -1,0 +1,141 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1280 760" font-family="system-ui,'Segoe UI',Roboto,sans-serif">
+  <rect width="1280" height="760" fill="#ffffff"/>
+
+  <!-- ============================ SIDEBAR ============================ -->
+  <rect x="12" y="12" width="290" height="736" rx="6" fill="#f4f5f7" stroke="#cbd5e1"/>
+  <text x="28" y="40" font-size="16" font-weight="bold" fill="#111827">Situation réseau</text>
+
+  <!-- (1) two tabs + single Charger -->
+  <rect x="28" y="50" width="128" height="26" rx="4" fill="#e9eef5" stroke="#bfdbfe"/>
+  <text x="92" y="67" font-size="12" fill="#334155" text-anchor="middle">📁 Local</text>
+  <rect x="156" y="50" width="120" height="26" rx="4" fill="#2563eb"/>
+  <text x="216" y="67" font-size="12" fill="#ffffff" text-anchor="middle" font-weight="bold">📅 RTE7000</text>
+  <rect x="28" y="82" width="248" height="26" rx="5" fill="#eef6ff" stroke="#bfdbfe"/>
+  <text x="152" y="99" font-size="12" fill="#1e3a8a" text-anchor="middle">date · heure · ⚡ cas d'intérêt ⓘ</text>
+  <rect x="28" y="114" width="248" height="28" rx="5" fill="#2563eb"/>
+  <text x="152" y="133" font-size="13" fill="#ffffff" text-anchor="middle" font-weight="bold">⏬ Charger la situation</text>
+
+  <line x1="28" y1="156" x2="276" y2="156" stroke="#d1d5db"/>
+
+  <!-- (10) section title + Recharger -->
+  <text x="28" y="178" font-size="14" font-weight="bold" fill="#1e3a8a">🗺 Scénario Topologique</text>
+  <rect x="206" y="164" width="70" height="20" rx="4" fill="#ffffff" stroke="#94a3b8"/>
+  <text x="241" y="178" font-size="10" fill="#334155" text-anchor="middle">⟳ Recharger</text>
+
+  <!-- (2) unified Poste search + typology -->
+  <text x="28" y="206" font-size="13" font-weight="bold" fill="#1e3a8a">1 · Poste</text>
+  <rect x="28" y="214" width="248" height="26" rx="5" fill="#ffffff" stroke="#94a3b8"/>
+  <text x="40" y="231" font-size="12" fill="#64748b">🔎 rechercher un poste (★ épinglés en tête)</text>
+  <rect x="28" y="246" width="248" height="24" rx="5" fill="#ffffff" stroke="#cbd5e1"/>
+  <text x="40" y="262" font-size="11" fill="#64748b">📂 explorer par typologie…</text>
+
+  <!-- (6) validate target -->
+  <text x="28" y="296" font-size="13" font-weight="bold" fill="#1e3a8a">2 · Topologie cible</text>
+  <rect x="28" y="304" width="248" height="26" rx="5" fill="#ffffff" stroke="#94a3b8"/>
+  <text x="152" y="321" font-size="12" fill="#111827" text-anchor="middle">✓ Valider &amp; sauvegarder</text>
+
+  <!-- (7) sequence: mode + compute / manual -->
+  <text x="28" y="356" font-size="13" font-weight="bold" fill="#1e3a8a">3 · Séquence de manœuvres</text>
+  <rect x="28" y="364" width="120" height="22" rx="4" fill="#ffffff" stroke="#cbd5e1"/>
+  <text x="88" y="379" font-size="10" fill="#334155" text-anchor="middle">⦿ smooth</text>
+  <rect x="156" y="364" width="120" height="22" rx="4" fill="#ffffff" stroke="#cbd5e1"/>
+  <text x="216" y="379" font-size="10" fill="#334155" text-anchor="middle">○ agressif</text>
+  <rect x="28" y="392" width="248" height="26" rx="5" fill="#2563eb"/>
+  <text x="152" y="409" font-size="12" fill="#ffffff" text-anchor="middle" font-weight="bold">⚙ Calculer la séquence</text>
+  <rect x="28" y="424" width="248" height="26" rx="5" fill="#7c3aed"/>
+  <text x="152" y="441" font-size="12" fill="#ffffff" text-anchor="middle" font-weight="bold">✋ Séquence manuelle</text>
+
+  <!-- ============================ CENTRE ============================ -->
+  <!-- departure pane (3) -->
+  <rect x="312" y="12" width="660" height="350" rx="4" fill="#ffffff" stroke="#c7d2fe"/>
+  <rect x="312" y="12" width="660" height="28" fill="#eef2ff"/>
+  <text x="324" y="31" font-size="12" font-weight="bold" fill="#1e293b">Topologie de départ — 1 nœud (lecture seule)</text>
+  <rect x="846" y="16" width="118" height="20" rx="4" fill="#ffffff" stroke="#94a3b8"/>
+  <text x="905" y="30" font-size="10" fill="#334155" text-anchor="middle">↺ État d'origine</text>
+  <!-- SLD sketch: single purple node -->
+  <g stroke-width="5" stroke="#7c3aed"><line x1="360" y1="240" x2="924" y2="240"/></g>
+  <g stroke="#475569" stroke-width="1.4">
+    <line x1="430" y1="120" x2="430" y2="240"/><line x1="560" y1="120" x2="560" y2="240"/>
+    <line x1="700" y1="120" x2="700" y2="240"/><line x1="840" y1="120" x2="840" y2="240"/>
+    <line x1="500" y1="240" x2="500" y2="330"/><line x1="770" y1="240" x2="770" y2="330"/>
+  </g>
+  <text x="430" y="112" font-size="9" fill="#334155" text-anchor="middle">U.MON1</text>
+  <text x="560" y="112" font-size="9" fill="#334155" text-anchor="middle">VALES1</text>
+  <text x="700" y="112" font-size="9" fill="#334155" text-anchor="middle">V.PAU1</text>
+  <text x="840" y="112" font-size="9" fill="#334155" text-anchor="middle">RANTI1</text>
+
+  <!-- target pane (4) -->
+  <rect x="312" y="372" width="660" height="288" rx="4" fill="#ffffff" stroke="#fed7aa"/>
+  <rect x="312" y="372" width="660" height="28" fill="#fff7ed"/>
+  <text x="324" y="391" font-size="12" font-weight="bold" fill="#1e293b">Topologie cible (éditable — clic organe) — 3 nœuds</text>
+  <rect x="788" y="376" width="176" height="20" rx="4" fill="#ffffff" stroke="#94a3b8"/>
+  <text x="876" y="390" font-size="10" fill="#334155" text-anchor="middle">⇧ Nouvelle Topologie Départ</text>
+  <!-- SLD sketch: three coloured nodes -->
+  <g stroke-width="5"><line x1="360" y1="560" x2="640" y2="560" stroke="#7c3aed"/>
+    <line x1="652" y1="560" x2="800" y2="560" stroke="#9f1239"/>
+    <line x1="812" y1="560" x2="924" y2="560" stroke="#38bdf8"/></g>
+  <g stroke="#475569" stroke-width="1.4">
+    <line x1="430" y1="450" x2="430" y2="560"/><line x1="560" y1="450" x2="560" y2="560"/>
+    <line x1="700" y1="450" x2="700" y2="560"/><line x1="860" y1="450" x2="860" y2="560"/>
+    <line x1="500" y1="560" x2="500" y2="630"/><line x1="770" y1="560" x2="770" y2="630"/></g>
+  <text x="430" y="442" font-size="9" fill="#334155" text-anchor="middle">U.MON1</text>
+  <text x="560" y="442" font-size="9" fill="#334155" text-anchor="middle">VALES1</text>
+  <text x="700" y="442" font-size="9" fill="#334155" text-anchor="middle">V.PAU1</text>
+  <text x="860" y="442" font-size="9" fill="#334155" text-anchor="middle">RANTI1</text>
+
+  <!-- sequence + animation strip (9) -->
+  <rect x="312" y="672" width="660" height="76" rx="4" fill="#ffffff" stroke="#e5e7eb"/>
+  <text x="324" y="690" font-size="11" fill="#334155">◀ ▶ Lecture ▶|  ·  Étape 3/8  ·  ✎ Modifier la cible</text>
+  <rect x="838" y="678" width="126" height="20" rx="4" fill="#ffffff" stroke="#94a3b8"/>
+  <text x="901" y="692" font-size="10" fill="#334155" text-anchor="middle">💾 Sauvegarder la séquence</text>
+  <text x="324" y="712" font-size="10" font-family="monospace" fill="#111827">1 OPEN CARRI3COUPL.1 DJ_OC  ouverture du couplage</text>
+  <rect x="320" y="717" width="640" height="13" fill="#fde68a" opacity="0.5"/>
+  <text x="324" y="727" font-size="10" font-family="monospace" fill="#111827">3 OPEN PERSAL31CARRI SA.1  boucle courte  ← étape courante</text>
+  <text x="324" y="742" font-size="10" font-family="monospace" fill="#b91c1c">⚠ R18 — un sectionneur ne se manœuvre que hors charge</text>
+
+  <!-- ============================ NODAL (RIGHT) ============================ -->
+  <rect x="982" y="12" width="286" height="736" rx="6" fill="#f4f5f7" stroke="#cbd5e1"/>
+  <text x="998" y="32" font-size="13" font-weight="bold" fill="#065f46">Topologie nodale</text>
+
+  <!-- departure node (5) -->
+  <rect x="996" y="44" width="258" height="96" rx="5" fill="#ffffff" stroke="#d1fae5"/>
+  <text x="1008" y="62" font-size="11" font-weight="bold" fill="#065f46">Départ — 1 nœud (lecture seule)</text>
+  <line x1="1018" y1="110" x2="1238" y2="110" stroke="#7c3aed" stroke-width="6"/>
+  <text x="1024" y="100" font-size="8" fill="#334155">U.MON1</text>
+  <text x="1110" y="100" font-size="8" fill="#334155">VALES1</text>
+  <text x="1196" y="100" font-size="8" fill="#334155">RANTI1</text>
+
+  <!-- target nodes (3) -->
+  <rect x="996" y="156" width="258" height="356" rx="5" fill="#ffffff" stroke="#d1fae5"/>
+  <text x="1008" y="174" font-size="11" font-weight="bold" fill="#065f46">Cible — 3 nœuds (éditable, glisser-déposer)</text>
+  <rect x="1008" y="182" width="56" height="18" rx="3" fill="#ffffff" stroke="#94a3b8"/>
+  <text x="1036" y="195" font-size="9" fill="#334155" text-anchor="middle">+ Nœud</text>
+  <rect x="1070" y="182" width="60" height="18" rx="3" fill="#ffffff" stroke="#94a3b8"/>
+  <text x="1100" y="195" font-size="9" fill="#334155" text-anchor="middle">= départ</text>
+  <rect x="1136" y="182" width="58" height="18" rx="3" fill="#ffffff" stroke="#94a3b8"/>
+  <text x="1165" y="195" font-size="9" fill="#334155" text-anchor="middle">∅ Désél.</text>
+  <text x="1008" y="236" font-size="9" fill="#334155">N0 (barre 1)</text>
+  <line x1="1018" y1="246" x2="1238" y2="246" stroke="#7c3aed" stroke-width="6"/>
+  <text x="1008" y="312" font-size="9" fill="#334155">N1 (barre 2.1)</text>
+  <line x1="1018" y1="322" x2="1180" y2="322" stroke="#9f1239" stroke-width="6"/>
+  <text x="1008" y="392" font-size="9" fill="#334155">N2 (barre 2.2)</text>
+  <line x1="1060" y1="402" x2="1238" y2="402" stroke="#38bdf8" stroke-width="6"/>
+
+  <!-- compute detailed target (8) -->
+  <rect x="996" y="528" width="258" height="30" rx="5" fill="#ecfdf5" stroke="#6ee7b7"/>
+  <text x="1125" y="547" font-size="10" fill="#065f46" text-anchor="middle" font-weight="bold">⚙ Calculer la topologie détaillée d'intérêt</text>
+
+  <!-- ============================ CALLOUTS (red numbered circles) ============================ -->
+  <g font-size="13" font-weight="bold" text-anchor="middle">
+    <circle cx="284" cy="63" r="12" fill="#dc2626"/><text x="284" y="68" fill="#fff">1</text>
+    <circle cx="262" cy="227" r="12" fill="#dc2626"/><text x="262" y="232" fill="#fff">2</text>
+    <circle cx="332" cy="26" r="12" fill="#dc2626"/><text x="332" y="31" fill="#fff">3</text>
+    <circle cx="332" cy="386" r="12" fill="#dc2626"/><text x="332" y="391" fill="#fff">4</text>
+    <circle cx="1244" cy="110" r="12" fill="#dc2626"/><text x="1244" y="115" fill="#fff">5</text>
+    <circle cx="262" cy="317" r="12" fill="#dc2626"/><text x="262" y="322" fill="#fff">6</text>
+    <circle cx="262" cy="405" r="12" fill="#dc2626"/><text x="262" y="410" fill="#fff">7</text>
+    <circle cx="1010" cy="543" r="12" fill="#dc2626"/><text x="1010" y="548" fill="#fff">8</text>
+    <circle cx="332" cy="724" r="12" fill="#dc2626"/><text x="332" y="729" fill="#fff">9</text>
+    <circle cx="258" cy="174" r="12" fill="#dc2626"/><text x="258" y="179" fill="#fff">10</text>
+  </g>
+</svg>

--- a/docs/manoeuvre/manoeuvre_ihm_overview.svg
+++ b/docs/manoeuvre/manoeuvre_ihm_overview.svg
@@ -25,14 +25,16 @@
   <!-- (2) unified Poste search + typology -->
   <text x="28" y="206" font-size="13" font-weight="bold" fill="#1e3a8a">1 · Poste</text>
   <rect x="28" y="214" width="248" height="26" rx="5" fill="#ffffff" stroke="#94a3b8"/>
-  <text x="40" y="231" font-size="12" fill="#64748b">🔎 rechercher un poste (tous) · ↓ liste par typologie</text>
+  <text x="40" y="231" font-size="11" fill="#64748b">🔎 rechercher · ↓ Pré-sélection de postes typiques</text>
   <rect x="28" y="246" width="248" height="24" rx="5" fill="#ffffff" stroke="#cbd5e1"/>
   <text x="40" y="262" font-size="11" fill="#64748b">📂 explorer par typologie…</text>
 
   <!-- (6) validate target -->
   <text x="28" y="296" font-size="13" font-weight="bold" fill="#1e3a8a">2 · Topologie cible</text>
-  <rect x="28" y="304" width="248" height="26" rx="5" fill="#ffffff" stroke="#94a3b8"/>
-  <text x="152" y="321" font-size="12" fill="#111827" text-anchor="middle">✓ Valider &amp; sauvegarder</text>
+  <rect x="28" y="304" width="108" height="26" rx="5" fill="#ffffff" stroke="#94a3b8"/>
+  <text x="82" y="321" font-size="12" fill="#111827" text-anchor="middle">✓ Valider</text>
+  <rect x="142" y="304" width="134" height="26" rx="5" fill="#ffffff" stroke="#94a3b8"/>
+  <text x="209" y="321" font-size="11" fill="#111827" text-anchor="middle">[nom] 💾 Sauvegarder</text>
 
   <!-- (7) sequence: mode + compute / manual -->
   <text x="28" y="356" font-size="13" font-weight="bold" fill="#1e3a8a">3 · Séquence de manœuvres</text>
@@ -111,7 +113,7 @@
   <rect x="1008" y="182" width="56" height="18" rx="3" fill="#ffffff" stroke="#94a3b8"/>
   <text x="1036" y="195" font-size="9" fill="#334155" text-anchor="middle">+ Nœud</text>
   <rect x="1070" y="182" width="60" height="18" rx="3" fill="#ffffff" stroke="#94a3b8"/>
-  <text x="1100" y="195" font-size="9" fill="#334155" text-anchor="middle">= départ</text>
+  <text x="1100" y="195" font-size="9" fill="#334155" text-anchor="middle">↺ Réinit.</text>
   <rect x="1136" y="182" width="58" height="18" rx="3" fill="#ffffff" stroke="#94a3b8"/>
   <text x="1165" y="195" font-size="9" fill="#334155" text-anchor="middle">∅ Désél.</text>
   <text x="1008" y="236" font-size="9" fill="#334155">N0 (barre 1)</text>

--- a/docs/manoeuvre_ihm.md
+++ b/docs/manoeuvre_ihm.md
@@ -33,7 +33,7 @@ python scripts/manoeuvre_ihm.py --grid /chemin/vers/grid.xiidm
 | `--scenarios-dir` | `tests/manoeuvre/scenarios` | Dossier de sauvegarde des **scénarios** (cibles) |
 | `--sequences-dir` | `tests/manoeuvre/sequences` | Dossier de sauvegarde des **séquences** générées |
 | `--dataset` | — | Activer la **source dataset RTE 7000** (défaut si `--grid` absent) |
-| `--dataset-repo` | `OpenSynth/D-GITT-RTE7000-2021` (env `DGITT_REPO`) | Dataset HuggingFace source |
+| `--dataset-repo` | `OpenSynth/D-GITT-RTE7000-2021` (env `DGITT_REPO`) | Dataset HuggingFace source (repo **base** ; l'année d'une date d'accès rapide sélectionne `…-2021/-2022/-2023`) |
 | `--cache-dir` | `.cache/dgitt` (env `DGITT_CACHE_DIR`) | Cache local des instantanés téléchargés |
 | `--default-date` | `2021-01-03` (env `DGITT_DEFAULT_DATE`) | Date proposée par défaut dans l'IHM |
 
@@ -51,9 +51,13 @@ CORNIP3, GUARBP6, MORBRP6.
 
 Sans `--grid`, l'IHM démarre en **mode dataset** : au lieu d'un réseau local
 figé, elle source les situations dans le dataset HuggingFace
-[`OpenSynth/D-GITT-RTE7000-2021`](https://huggingface.co/datasets/OpenSynth/D-GITT-RTE7000-2021)
+[`OpenSynth/D-GITT-RTE7000-{2021,2022,2023}`](https://huggingface.co/datasets/OpenSynth/D-GITT-RTE7000-2021)
 (réseau France, **un instantané XIIDM toutes les 5 min**), **téléchargés à la
 demande** (rien n'est embarqué). C'est le mode utilisé par le HuggingFace Space.
+Le dataset existe **par année** ; l'**année** d'une date sélectionne
+automatiquement le repo (`…-2021` / `…-2022` / `…-2023`, cf.
+`dataset_source.repo_pour_date`), de sorte que les 7 journées d'accès rapide
+(2021-2023, « Table de campagne ») fonctionnent toutes.
 
 ```bash
 pip install flask pypowsybl networkx pandas      # dépendances de l'IHM dataset
@@ -97,7 +101,8 @@ merge `main`, inerte tant que `HF_TOKEN`/`HF_SPACE` ne sont pas définis). Voir
 > d'information) — chargée par un **unique bouton Charger** (RTE7000 mis en avant
 > par défaut sur le Space hébergé) ;
 > **(2)** le champ **Poste unifié** — une **seule recherche** sur tous les postes
-> NODE_BREAKER (épinglés ★ en tête) plus l'**explorateur curé par typologie** ;
+> NODE_BREAKER (postes épinglés ★ repérés dans les résultats) et, en dessous,
+> l'**exploration curée par typologie** ;
 > **(3)** le schéma unifilaire **de départ** (lecture seule, état de référence),
 > dont l'en-tête porte **↺ État d'origine** (réinitialise la cible à l'état
 > d'origine) ;
@@ -151,9 +156,9 @@ merge `main`, inerte tant que `HF_TOKEN`/`HF_SPACE` ne sont pas définis). Voir
   L'onglet **RTE7000 est mis en avant par défaut** sur le HuggingFace Space (mode
   dataset) ; **Local** par défaut en usage local.
 - **Scénario Topologique** : la suite de travail en **trois étapes** —
-  **1 · Poste** (champ de recherche **unique** sur tous les postes, postes
-  épinglés ★ en tête, + explorateur **par typologie** curé), **2 · Topologie
-  cible** (éditer + valider), **3 · Séquence de manœuvres**.
+  **1 · Poste** (champ de recherche **unique** sur tous les postes + liste
+  browsable curée **par typologie** en dessous), **2 · Topologie cible** (éditer
+  + valider), **3 · Séquence de manœuvres**.
 - **Schéma de départ** (centre haut, bandeau bleu) : topologie détaillée
   initiale, **non modifiable** ; sert de référence. Son en-tête porte le bouton
   **↺ État d'origine** (réinitialise la cible à l'état d'origine du poste).
@@ -188,12 +193,12 @@ des variables CSS).
    NODE_BREAKER de la situation et, **en dessous**, une **liste browsable**.
    Champ **vide** → exploration **curée par typologie** (sections : *≥5 jeux de
    barres*, *sectionnement extrême*, *faisceau de couplage partagé*, *organes
-   internes*, *omnibus*, *départs déconnectés*, *gros postes*, …), **postes
-   épinglés ★ en tête** (jeu de test + 7 postes 3 JdB). En **saisissant**, la
-   liste filtre en **recherche plein-texte** sur tous les postes (bornée à 300
-   résultats affichés). Un poste **grisé** (⚠ absent) n'est pas présent dans la
-   situation chargée → charger la grille France (`grid.xiidm`) pour y accéder
-   (le rendu détaillé SLD requiert le réseau).
+   internes*, *omnibus*, *départs déconnectés*, *gros postes*, …). En
+   **saisissant**, la liste filtre en **recherche plein-texte** sur tous les
+   postes (bornée à 300 résultats affichés ; les postes épinglés ★ — jeu de test
+   + 7 postes 3 JdB — y sont marqués). Un poste **grisé** (⚠ absent) n'est pas
+   présent dans la situation chargée → charger la grille France (`grid.xiidm`)
+   pour y accéder (le rendu détaillé SLD requiert le réseau).
 2. **Éditer la cible** : cliquer un disjoncteur/sectionneur dans le schéma du
    bas pour basculer son état (ouvert/fermé). Le nombre de nœuds cible évolue en
    direct.
@@ -489,7 +494,7 @@ assert res.ecarts == []
 | **Recharger** une cible sauvegardée pour recalculer | « ▷ Rejouer » |
 | Promouvoir la **cible courante** en nouvel état de départ | « ⇧ Nouvelle Topologie Départ » (en-tête du schéma cible) → `/api/promote_cible` (le schéma de départ est mis à jour) |
 | **Recharger** un scénario (départ + cible) | Bouton « ⟳ Recharger » (titre *Scénario Topologique*) → modale (sélecteur + Valider / Annuler) → `/api/load_scenario` (mode `both`) |
-| **Rechercher / explorer un poste** (champ unique) | `#posteSearch` + liste `#posteList` browsable : vide = exploration curée **par typologie** (épinglés ★ en tête) ; saisie = recherche plein-texte sur **tous** les VL NODE_BREAKER |
+| **Rechercher / explorer un poste** (champ unique) | `#posteSearch` + liste `#posteList` browsable : vide = exploration curée **par typologie** ; saisie = recherche plein-texte sur **tous** les VL NODE_BREAKER (épinglés ★ marqués dans les résultats) |
 | **Sauvegarder la séquence** avec lien vers ses topologies | `/api/save_sequence` (JSON autonome + champ `scenario`) |
 | Atteindre la **topologie détaillée** imposée (barre exacte) + vérification | façade `sequencer` (« libtopo » = `determiner_manoeuvres_cible_detaillee`) ; statut « DÉTAILLÉE VÉRIFIÉE » / « NODALE OK · N écart(s) » |
 | **Avertissement d'écrasement** d'un fichier de sauvegarde existant | Confirmation / renommage (réponse `{exists:true}`) |

--- a/docs/manoeuvre_ihm.md
+++ b/docs/manoeuvre_ihm.md
@@ -266,7 +266,8 @@ L'édition se fait par **glisser-déposer** :
   comme cible de dépose — glisser-y ensuite des départs. Un nœud resté **vide**
   est **ignoré** au calcul de la topologie détaillée (et retiré de l'affichage à
   ce moment-là).
-- **Réinitialiser** : **= départ** ramène la cible à la partition de départ ;
+- **Réinitialiser** : **↺ Réinitialiser** ramène la cible à la topologie
+  d'origine du poste (**détaillée + nodale** = départ, via `/api/reset`) ;
   **∅ Désélectionner** vide la sélection.
 
 Les **ouvrages déconnectés** (organe ouvert → non raccordés à une barre) ne sont
@@ -296,7 +297,7 @@ de scénario** (modale **⟳ Recharger**) **resynchronise** la cible nodale (par
 ouvrages isolés) — par ex. ouvrir le DJ d'un départ le fait passer en *ouvrage
 isolé* dans le volet nodal, et recharger un scénario à N nœuds affiche bien ces N
 nœuds côté nodal. Le
-glisser-déposer nodal et `= départ` sont des **propositions** de partition
+glisser-déposer nodal (et **＋ Nœud**) sont des **propositions** de partition
 (le détail n'est pas encore modifié) ; **⚙ Calculer…** les réalise, charge la
 cible détaillée et resynchronise le volet nodal sur la topologie **obtenue**
 (d'où, en cas de réalisation partielle, un volet nodal qui correspond bien au

--- a/docs/manoeuvre_ihm.md
+++ b/docs/manoeuvre_ihm.md
@@ -172,7 +172,9 @@ merge `main`, inerte tant que `HF_TOKEN`/`HF_SPACE` ne sont pas définis). Voir
   **nœud** = barre horizontale colorée ; chaque **branche** = départ vertical
   portant son **libellé** détaillé et sa **valeur de flux** en MW) de la topologie
   nodale de départ et d'une **cible nodale éditable par glisser-déposer**. Voir §3
-  *Éditer une topologie nodale cible*. Repliable via ◂.
+  *Éditer une topologie nodale cible*. Le volet entier est repliable via ◂, et
+  ses sections **Départ** et **Cible** sont **repliables indépendamment** (bouton
+  **▾ / ▸** dans leur en-tête — replier l'une donne tout l'espace à l'autre).
 - Le **nombre de nœuds électriques** est affiché par schéma et se met à jour à
   chaque modification.
 - Chaque en-tête porte un bouton **▾ / ▸** pour **replier** son schéma : l'autre
@@ -271,10 +273,12 @@ L'édition se fait par **glisser-déposer** :
   **∅ Désélectionner** vide la sélection.
 
 Les **ouvrages déconnectés** (organe ouvert → non raccordés à une barre) ne sont
-**pas** des nœuds électriques : ils sont listés à part (chips **⚠ Ouvrages
-isolés**, sous chaque schéma) et n'occupent pas d'espace en barre. Pour en
-**reconnecter** un, le **glisser sur une barre** (il rejoint ce nœud) ; côté
-serveur, les isolés restants sont **laissés déconnectés** (hors partition cible).
+**pas** des nœuds électriques : ils sont listés à part, en **tête de chaque
+cadre** (chips **⚠ Ouvrages isolés**, première ligne sous le titre de section),
+**individuellement sélectionnables** (clic) et **glissables**, et n'occupent pas
+d'espace en barre. Pour en **reconnecter** un, le **glisser sur une barre** (il
+rejoint ce nœud) ; côté serveur, les isolés restants sont **laissés déconnectés**
+(hors partition cible).
 Le compteur de nœuds exclut les isolés.
 - **⚙ Calculer la topologie détaillée d'intérêt** : envoie la partition nodale
   (`/api/nodale_to_detaillee`) ; l'IHM **charge l'état détaillé réalisant** cette
@@ -500,7 +504,7 @@ assert res.ecarts == []
 | **Topologie nodale qui suit l'étape** d'animation | Volet nodal « cible » rendu en lecture seule depuis `nodale` de `/api/step` (titre « Étape k/n (vue) ») ; restauré à « Cible (éditable) » à la sortie |
 | Voir **départ en haut** et **cible éditable en bas** | Deux schémas empilés |
 | Couleurs **natives** par niveau de tension (63 kV violet) | `topological_coloring`, rendu navigateur |
-| **Explorer les postes par typologie** (sections) | Sélecteur 📂 `#posteCat` : un `<optgroup>` par typologie (≥5 JdB, sectionnement extrême, faisceau partagé, organes internes, omnibus, départs déconnectés, gros postes…) ; entrées grisées = absentes de la situation (`catalog` de `/api/postes`) |
+| **Explorer les postes par typologie** (sections) | Liste `#posteList` (champ vide) : une section par typologie (≥5 JdB, sectionnement extrême, faisceau partagé, organes internes, omnibus, départs déconnectés, gros postes…) ; entrées grisées = absentes de la situation (`catalog` de `/api/postes`) |
 | **Recharger** une cible sauvegardée pour recalculer | « ▷ Rejouer » |
 | Promouvoir la **cible courante** en nouvel état de départ | « ⇧ Nouvelle Topologie Départ » (en-tête du schéma cible) → `/api/promote_cible` (le schéma de départ est mis à jour) |
 | **Recharger** un scénario (départ + cible) | Bouton « ⟳ Recharger » (titre *Scénario Topologique*) → modale (sélecteur + Valider / Annuler) → `/api/load_scenario` (mode `both`) |
@@ -517,7 +521,8 @@ assert res.ecarts == []
 | **Signaler visuellement** l'atteinte de la topologie cible | Halo jaune sur la vue du poste + « ✓ topologie cible atteinte » (champ `reached` de `/api/step`) |
 | **Éditer une topologie nodale cible** (réaiguillage / fusion / nouveau nœud) | Volet nodal SVG « vue bus » (barre + départs verticaux, libellés SLD + flux MW) ; **glisser-déposer** (départ→barre = réaiguillage, barre→barre = fusion) côté client |
 | **Élargir** le volet nodal pour afficher tous les nœuds | Séparateur déplaçable entre colonnes 2 et 3 (`#ndresize`) |
-| **Ouvrages déconnectés** présentés en liste (pas en nœud), reconnectables | Liste « ⚠ Ouvrages isolés » (chips) ; glisser sur une barre = reconnexion ; `isolated` dans `/api/nodale*` |
+| **Ouvrages déconnectés** présentés en liste (pas en nœud), reconnectables | Chips « ⚠ Ouvrages isolés » **en tête de cadre** (sous le titre de section), individuellement sélectionnables ; glisser sur une barre = reconnexion ; `isolated` dans `/api/nodale*` |
+| **Replier** indépendamment les sections nodales **Départ** / **Cible** | Bouton **▾ / ▸** dans le `.stitle` → `toggleNsec()` (replie tout sauf le titre ; l'autre section prend l'espace) |
 | **Re-éditer la cible détaillée** après calcul de séquence + signaler l'obsolescence | Bouton **✎ Modifier la cible** (`/api/cible`) ; bandeau « la séquence n'atteint plus cet état cible » |
 | Demander un **calcul de topologie détaillée d'intérêt** depuis la cible nodale | `/api/nodale_to_detaillee` → façade `identifier_topologie_detaillee` (phase A, algo sélectionné), cible détaillée chargée |
 

--- a/docs/manoeuvre_ihm.md
+++ b/docs/manoeuvre_ihm.md
@@ -103,7 +103,7 @@ merge `main`, inerte tant que `HF_TOKEN`/`HF_SPACE` ne sont pas définis). Voir
 > d'origine) ;
 > **(4)** le schéma **cible éditable** — clic sur un disjoncteur/sectionneur pour
 > le basculer — dont l'en-tête porte **⇧ Nouvelle Topologie Départ** (promeut la
-> cible sélectionnée en nouveau départ, pour chaîner les scénarios) ;
+> **cible courante (éditée)** en nouveau départ, pour chaîner les scénarios) ;
 > **(5)** la « **vue bus** » nodale — glisser un départ sur une barre =
 > ré-aiguillage, glisser une barre sur une autre = fusion, *+ Nœud* = créer un
 > nœud — en partition de départ (un nœud, lecture seule) et cible (trois nœuds,
@@ -159,8 +159,9 @@ merge `main`, inerte tant que `HF_TOKEN`/`HF_SPACE` ne sont pas définis). Voir
   **↺ État d'origine** (réinitialise la cible à l'état d'origine du poste).
 - **Schéma cible** (centre bas, bandeau orange) : topologie détaillée
   **éditable** ; c'est aussi là que se déroule l'animation de la séquence. Son
-  en-tête porte le bouton **⇧ Nouvelle Topologie Départ** (la cible sélectionnée
-  dans *Scénarios sauvegardés* devient le nouvel état de départ).
+  en-tête porte le bouton **⇧ Nouvelle Topologie Départ** (la **cible courante
+  éditée** devient le nouvel état de départ — `/api/promote_cible` ; le schéma de
+  départ ci-dessus est mis à jour).
 - **Volet nodal** (droite) : représentation **schématique en « vue bus »** (un
   **nœud** = barre horizontale colorée ; chaque **branche** = départ vertical
   portant son **libellé** détaillé et sa **valeur de flux** en MW) de la topologie
@@ -182,15 +183,17 @@ des variables CSS).
 ## 3. Flux de travail
 
 1. **Choisir un poste** (étape *1 · Poste* du Scénario Topologique) → les deux
-   schémas affichent l'état de départ (pristine). Deux entrées **fusionnées** :
-   le **champ de recherche unique** (tout VL NODE_BREAKER de la situation ; les
-   postes **épinglés ★** — jeu de test + 7 postes 3 JdB — sont listés en tête de
-   liste pour rester d'accès rapide) et l'**explorateur par typologie** 📂
-   (sections : *≥5 jeux de barres*, *sectionnement extrême*, *faisceau de couplage
-   partagé*, *organes internes*, *omnibus*, *départs déconnectés*, *gros postes*,
-   …). Dans l'explorateur par typologie, un poste **grisé** (⚠) n'est pas présent
-   dans la situation chargée → charger la grille France (`grid.xiidm`) pour y
-   accéder (le rendu détaillé SLD requiert le réseau).
+   schémas affichent l'état de départ (pristine). Un **unique champ** réunit deux
+   modes dans une même interaction : une **recherche** sur **tous** les postes
+   NODE_BREAKER de la situation et, **en dessous**, une **liste browsable**.
+   Champ **vide** → exploration **curée par typologie** (sections : *≥5 jeux de
+   barres*, *sectionnement extrême*, *faisceau de couplage partagé*, *organes
+   internes*, *omnibus*, *départs déconnectés*, *gros postes*, …), **postes
+   épinglés ★ en tête** (jeu de test + 7 postes 3 JdB). En **saisissant**, la
+   liste filtre en **recherche plein-texte** sur tous les postes (bornée à 300
+   résultats affichés). Un poste **grisé** (⚠ absent) n'est pas présent dans la
+   situation chargée → charger la grille France (`grid.xiidm`) pour y accéder
+   (le rendu détaillé SLD requiert le réseau).
 2. **Éditer la cible** : cliquer un disjoncteur/sectionneur dans le schéma du
    bas pour basculer son état (ouvert/fermé). Le nombre de nœuds cible évolue en
    direct.
@@ -342,10 +345,11 @@ qu'il s'allume exactement lorsque la cible est atteinte et s'éteint sinon.
   **petite modale** (sélecteur de scénario + **Valider** / **Annuler**) qui
   **rejoue** le scénario choisi (départ **et** cible sauvegardés). Remplace
   l'ancienne section « Scénarios sauvegardés ».
-- **⇧ Nouvelle Topologie Départ** (en-tête du schéma cible) : la cible
-  sélectionnée devient le **nouvel état de départ** — permet de **chaîner** les
-  scénarios (repartir d'une topologie validée plutôt que de l'état de base du
-  réseau), puis d'éditer une nouvelle cible par-dessus.
+- **⇧ Nouvelle Topologie Départ** (en-tête du schéma cible) : la **cible courante
+  (éditée)** devient le **nouvel état de départ** (`/api/promote_cible`, **sans**
+  passer par un scénario sauvegardé) — le schéma de départ ci-dessus est mis à
+  jour. Permet de **chaîner** (repartir d'une topologie validée plutôt que de
+  l'état de base du réseau), puis d'éditer une nouvelle cible par-dessus.
 
 ---
 
@@ -366,6 +370,7 @@ navigateur).
 | `POST /api/load` | `{vl}` | `{initial_svg, nb_initial, svg, switches, nb_noeuds, nodale_depart, nodale_cible}` | Charge un poste (départ pristine) — **n'importe quel** VL NODE_BREAKER ; inclut les partitions nodales |
 | `POST /api/toggle` | `{id}` | `{svg, switches, nb_noeuds, nodale}` | Bascule un OC (cible) ; `nodale` = vue nodale resynchronisée |
 | `POST /api/reset` | — | `{svg, switches, nb_noeuds, nodale}` | Réinitialise la cible = départ |
+| `POST /api/promote_cible` | — | `{initial_svg, nb_initial, svg, switches, nb_noeuds, vl, nodale_depart, nodale_cible}` | **Promeut la cible courante en nouvel état de départ** (chaînage sans scénario sauvegardé) ; met à jour les deux schémas + vues nodales |
 | `POST /api/cible` | — | `{svg, switches, nb_noeuds, nodale}` | Vue de la cible détaillée **courante** (sans la modifier) — pour revenir l'éditer alors qu'une séquence est calculée |
 | `POST /api/nodale` | — | `{nodale_depart, nodale_cible}` | Partitions nodales (cible initialisée = départ) ; `nodale_*` = `{groups[[…]], labels{id:nom}, types{id:type}, flows{id:MW}, dirs{id:TOP\|BOTTOM}, order{id:x}, colors{id:#hex}, isolated[…]}`. `labels`/`dirs`/`order`/`colors` sont **extraits du SLD** (libellés, côté, ordre horizontal et **couleur du nœud `topological_coloring`** identiques à la vue détaillée) ; `flows` provient d'une charge de réseau ; `isolated` liste les départs **déconnectés** (composante sans barre) |
 | `POST /api/nodale_to_detaillee` | `{groups, isolated?}` | `{svg, switches, nb_noeuds, is_verified, message, ecarts[], noeuds_non_realisables[[…]], nb_obtenu, nb_vise, nodale}` | Calcule la **topologie détaillée d'intérêt** réalisant la cible nodale `groups` (les `isolated` sont laissés hors partition) et la charge comme cible détaillée ; `nodale` = `{groups, colors, isolated}` de la topologie **réalisée** (resynchronise le volet nodal) |
@@ -482,9 +487,9 @@ assert res.ecarts == []
 | Couleurs **natives** par niveau de tension (63 kV violet) | `topological_coloring`, rendu navigateur |
 | **Explorer les postes par typologie** (sections) | Sélecteur 📂 `#posteCat` : un `<optgroup>` par typologie (≥5 JdB, sectionnement extrême, faisceau partagé, organes internes, omnibus, départs déconnectés, gros postes…) ; entrées grisées = absentes de la situation (`catalog` de `/api/postes`) |
 | **Recharger** une cible sauvegardée pour recalculer | « ▷ Rejouer » |
-| Choisir l'**état de départ** depuis une topologie sauvegardée | « ⇧ Nouvelle Topologie Départ » (en-tête du schéma cible) |
+| Promouvoir la **cible courante** en nouvel état de départ | « ⇧ Nouvelle Topologie Départ » (en-tête du schéma cible) → `/api/promote_cible` (le schéma de départ est mis à jour) |
 | **Recharger** un scénario (départ + cible) | Bouton « ⟳ Recharger » (titre *Scénario Topologique*) → modale (sélecteur + Valider / Annuler) → `/api/load_scenario` (mode `both`) |
-| **Rechercher / choisir un poste** (champ unique) | `#posteSearch` (datalist de **tous** les VL NODE_BREAKER, postes épinglés ★ en tête) ; charge au choix / Entrée |
+| **Rechercher / explorer un poste** (champ unique) | `#posteSearch` + liste `#posteList` browsable : vide = exploration curée **par typologie** (épinglés ★ en tête) ; saisie = recherche plein-texte sur **tous** les VL NODE_BREAKER |
 | **Sauvegarder la séquence** avec lien vers ses topologies | `/api/save_sequence` (JSON autonome + champ `scenario`) |
 | Atteindre la **topologie détaillée** imposée (barre exacte) + vérification | façade `sequencer` (« libtopo » = `determiner_manoeuvres_cible_detaillee`) ; statut « DÉTAILLÉE VÉRIFIÉE » / « NODALE OK · N écart(s) » |
 | **Avertissement d'écrasement** d'un fichier de sauvegarde existant | Confirmation / renommage (réponse `{exists:true}`) |

--- a/docs/manoeuvre_ihm.md
+++ b/docs/manoeuvre_ihm.md
@@ -89,21 +89,35 @@ merge `main`, inerte tant que `HF_TOKEN`/`HF_SPACE` ne sont pas définis). Voir
 ```
 ┌──────────────────────┬─────────────────────────────────┬────────────────────┐
 │ PANNEAU LATÉRAL      │ SCHÉMA — TOPOLOGIE DE DÉPART     │ VOLET NODAL        │
-│                      │ (SLD pypowsybl, couleurs nœud)  │                    │
-│ • Poste (sélecteur)  ├─────────────────────────────────┤ Topo nodale DÉPART │
-│ • ↺ État de départ   │ SCHÉMA — TOPOLOGIE CIBLE        │ (lecture seule)    │
-│ 1 · Valider la cible │ clic organe = bascule ; anim.   ├────────────────────┤
-│ 2 · Calculer séq.    ├─────────────────────────────────┤ Topo nodale CIBLE  │
-│ • Scénarios          │ Contrôles ◀ ▶ Lecture ▶|        │ (éditable : chips) │
-│ • Nœuds électriques  │ Séquence (texte) + 💾           │ ⚙ Calculer la      │
-│                      │                                 │ topo détaillée     │
+│ Situation réseau     │ (SLD pypowsybl)  [↺ État d'orig.]│                    │
+│  [📁 Local|📅 RTE7000]├─────────────────────────────────┤ Topo nodale DÉPART │
+│  ⏬ Charger (unique)  │ SCHÉMA — TOPOLOGIE CIBLE        │ (lecture seule)    │
+│ 🗺 Scénario Topo.     │ [⇧ Nouvelle Topologie Départ]   ├────────────────────┤
+│  1 · Poste (recherche)│ clic organe = bascule ; anim.  │ Topo nodale CIBLE  │
+│  2 · Topologie cible  ├─────────────────────────────────┤ (éditable : chips) │
+│  3 · Séquence         │ Contrôles ◀ ▶ Lecture ▶|        │ ⚙ Calculer la      │
+│ • Scénarios · Nœuds   │ Séquence (texte) + 💾           │ topo détaillée     │
 └──────────────────────┴─────────────────────────────────┴────────────────────┘
 ```
 
+- **Situation réseau** (haut du panneau) : **deux onglets** — **📁 Local**
+  (chemin `.xiidm` côté serveur + bouton **📂** de sélection native, usage local)
+  et **📅 RTE7000** (date / heure du dataset, avec **puces d'accès rapide** vers
+  les journées « cas d'intérêt » documentées, chacune avec sa **bulle**
+  d'explication) — et un **unique bouton ⏬ Charger** qui agit sur l'onglet actif.
+  L'onglet **RTE7000 est mis en avant par défaut** sur le HuggingFace Space (mode
+  dataset) ; **Local** par défaut en usage local.
+- **Scénario Topologique** : la suite de travail en **trois étapes** —
+  **1 · Poste** (champ de recherche **unique** sur tous les postes, postes
+  épinglés ★ en tête, + explorateur **par typologie** curé), **2 · Topologie
+  cible** (éditer + valider), **3 · Séquence de manœuvres**.
 - **Schéma de départ** (centre haut, bandeau bleu) : topologie détaillée
-  initiale, **non modifiable** ; sert de référence.
+  initiale, **non modifiable** ; sert de référence. Son en-tête porte le bouton
+  **↺ État d'origine** (réinitialise la cible à l'état d'origine du poste).
 - **Schéma cible** (centre bas, bandeau orange) : topologie détaillée
-  **éditable** ; c'est aussi là que se déroule l'animation de la séquence.
+  **éditable** ; c'est aussi là que se déroule l'animation de la séquence. Son
+  en-tête porte le bouton **⇧ Nouvelle Topologie Départ** (la cible sélectionnée
+  dans *Scénarios sauvegardés* devient le nouvel état de départ).
 - **Volet nodal** (droite) : représentation **schématique en « vue bus »** (un
   **nœud** = barre horizontale colorée ; chaque **branche** = départ vertical
   portant son **libellé** détaillé et sa **valeur de flux** en MW) de la topologie
@@ -124,14 +138,16 @@ des variables CSS).
 
 ## 3. Flux de travail
 
-1. **Choisir un poste** → les deux schémas affichent l'état de départ (pristine).
-   Trois entrées : le **menu épinglé** (jeu de test + 7 postes 3 JdB), le
-   **sélecteur par typologie** 📂 (sections : *≥5 jeux de barres*, *sectionnement
-   extrême*, *faisceau de couplage partagé*, *organes internes*, *omnibus*,
-   *départs déconnectés*, *gros postes*, …) et le **champ de recherche** (tout VL
-   NODE_BREAKER de la situation). Dans le sélecteur par typologie, un poste
-   **grisé** (⚠) n'est pas présent dans la situation chargée → charger la grille
-   France (`grid.xiidm`) pour y accéder (le rendu détaillé SLD requiert le réseau).
+1. **Choisir un poste** (étape *1 · Poste* du Scénario Topologique) → les deux
+   schémas affichent l'état de départ (pristine). Deux entrées **fusionnées** :
+   le **champ de recherche unique** (tout VL NODE_BREAKER de la situation ; les
+   postes **épinglés ★** — jeu de test + 7 postes 3 JdB — sont listés en tête de
+   liste pour rester d'accès rapide) et l'**explorateur par typologie** 📂
+   (sections : *≥5 jeux de barres*, *sectionnement extrême*, *faisceau de couplage
+   partagé*, *organes internes*, *omnibus*, *départs déconnectés*, *gros postes*,
+   …). Dans l'explorateur par typologie, un poste **grisé** (⚠) n'est pas présent
+   dans la situation chargée → charger la grille France (`grid.xiidm`) pour y
+   accéder (le rendu détaillé SLD requiert le réseau).
 2. **Éditer la cible** : cliquer un disjoncteur/sectionneur dans le schéma du
    bas pour basculer son état (ouvert/fermé). Le nombre de nœuds cible évolue en
    direct.
@@ -216,8 +232,8 @@ Le compteur de nœuds exclut les isolés.
 
 **Synchronisation détaillé ↔ nodal.** La topologie **détaillée** fait foi : le
 volet nodal cible **reflète** la partition de l'état détaillé courant. Toute
-**édition du détail** (bascule d'un organe, `↺ État de départ`) **ou rechargement
-de scénario** (`▷ Rejouer`) **resynchronise** la cible nodale (partition, couleurs,
+**édition du détail** (bascule d'un organe, `↺ État d'origine`) **ou rechargement
+de scénario** (modale **⟳ Recharger**) **resynchronise** la cible nodale (partition, couleurs,
 ouvrages isolés) — par ex. ouvrir le DJ d'un départ le fait passer en *ouvrage
 isolé* dans le volet nodal, et recharger un scénario à N nœuds affiche bien ces N
 nœuds côté nodal. Le
@@ -279,11 +295,14 @@ atteinte ». L'indicateur est recalculé **à chaque étape** côté serveur
 qu'il s'allume exactement lorsque la cible est atteinte et s'éteint sinon.
 
 ### Réutiliser des scénarios
-- **▷ Rejouer** : recharge un scénario (départ **et** cible sauvegardés).
-- **⇧ Comme départ** : la cible sauvegardée devient le **nouvel état de
-  départ** — permet de **chaîner** les scénarios (repartir d'une topologie
-  validée plutôt que de l'état de base du réseau), puis d'éditer une nouvelle
-  cible par-dessus.
+- **⟳ Recharger** (bouton à droite du titre *🗺 Scénario Topologique*) : ouvre une
+  **petite modale** (sélecteur de scénario + **Valider** / **Annuler**) qui
+  **rejoue** le scénario choisi (départ **et** cible sauvegardés). Remplace
+  l'ancienne section « Scénarios sauvegardés ».
+- **⇧ Nouvelle Topologie Départ** (en-tête du schéma cible) : la cible
+  sélectionnée devient le **nouvel état de départ** — permet de **chaîner** les
+  scénarios (repartir d'une topologie validée plutôt que de l'état de base du
+  réseau), puis d'éditer une nouvelle cible par-dessus.
 
 ---
 
@@ -296,10 +315,11 @@ navigateur).
 |-----------------|-------|---------|------|
 | `GET /` | — | HTML | Page de l'IHM |
 | `GET /api/postes` | — | `{postes:[…], all:[…], catalog:[…]}` | `postes` = liste **épinglée** (jeu de test + 7 postes 400 kV à **3 jeux de barres** identifiés) ; `all` = **tous** les postes NODE_BREAKER de la situation (champ de recherche) ; `catalog` = **sections par typologie** (cf. ci-dessous). En mode dataset avant tout chargement : `{postes:[], all:[], catalog:[], needs_date:true}` |
-| `GET /api/dataset/config` | — | `{enabled, repo, default_date, default_time, sample_dates[]}` | Config de la source dataset ; `enabled=false` en mode `--grid` (le bandeau dataset reste masqué) |
+| `GET /api/dataset/config` | — | `{enabled, repo, default_date, default_time, sample_dates[]}` | Config de la source dataset (onglet **RTE7000**) ; `enabled` décide de l'**onglet actif par défaut** (RTE7000 sur le Space, Local en mode `--grid`) — l'onglet RTE7000 reste présent dans les deux cas |
 | `GET /api/dataset/timestamps?date=YYYY-MM-DD` | — | `{ok, date, timestamps:[{ts,path}], default}` / `400` (date invalide) / `502` (HF) | Instantanés disponibles pour la journée (HH:MM), avec l'horodatage présélectionné (le plus proche de **midi**) |
 | `POST /api/dataset/load` | `{date, time}` | `{ok, date, time, iso, postes:[…], all:[…], catalog:[…]}` / `400` (absent) / `502` (HF) | **Télécharge à la demande** l'instantané `(date, time)` du dataset, reconstruit la session et liste les postes (même forme que `/api/load_grid`) |
 | `POST /api/load_grid` | `{path}` | `{ok, postes:[…], all:[…], catalog:[…]}` / `400 {ok:false, error}` | Charge **dynamiquement** une autre situation réseau `.xiidm` (chemin **côté serveur**) et réinitialise la session ; 400 propre si fichier introuvable/illisible (session inchangée) |
+| `GET /api/pick_grid_file` | — | `{path, error?}` | Ouvre un **sélecteur de fichier natif** (onglet *Local*, usage local) pour choisir une situation `.xiidm` ; `path` vide si annulé ; `error` si headless / tkinter absent (l'IHM invite à coller le chemin) |
 | `POST /api/load` | `{vl}` | `{initial_svg, nb_initial, svg, switches, nb_noeuds, nodale_depart, nodale_cible}` | Charge un poste (départ pristine) — **n'importe quel** VL NODE_BREAKER ; inclut les partitions nodales |
 | `POST /api/toggle` | `{id}` | `{svg, switches, nb_noeuds, nodale}` | Bascule un OC (cible) ; `nodale` = vue nodale resynchronisée |
 | `POST /api/reset` | — | `{svg, switches, nb_noeuds, nodale}` | Réinitialise la cible = départ |
@@ -407,7 +427,7 @@ assert res.ecarts == []
 | Spécification | Couverture |
 |---------------|-----------|
 | Modifier **manuellement et interactivement** l'état des DJ/SA depuis une topologie de départ | Clic sur l'organe du schéma cible → `/api/toggle` |
-| **Valider** la topologie cible avant de calculer | Étape 1 « Valider & sauvegarder » ; le bouton « Calculer » reste verrouillé tant que la cible n'est pas validée |
+| **Valider** la topologie cible avant de calculer | Étape **2 · Topologie cible** « Valider & sauvegarder » ; le bouton « Calculer » reste verrouillé tant que la cible n'est pas validée |
 | **Sauvegarder** la cible pour des tests par ailleurs | Scénario JSON (`/api/save`) avec topologies détaillées + nodales |
 | Demander la **séquence de manœuvres** départ → cible | `/api/sequence` → façade pluggable (`PlanificateurTopologie.sequencer`, phase B ; « libtopo » = `determiner_manoeuvres_cible_detaillee`) |
 | **Choisir l'algorithme** de chaque phase de calcul (natif « libtopo » + plugins enregistrés) | Sélecteurs « Algo » (panneau Séquence = phase B ; volet nodal = phase A) ; `GET/POST /api/algos` (disponibles par phase + sélection de session) ; badge `algo <nom>` dans le statut de séquence. Les plugins tiers (registre / entry points `expert_op4grid_recommender.manoeuvre`) apparaissent automatiquement — cf. `docs/manoeuvre_plugins.md` |
@@ -419,7 +439,9 @@ assert res.ecarts == []
 | Couleurs **natives** par niveau de tension (63 kV violet) | `topological_coloring`, rendu navigateur |
 | **Explorer les postes par typologie** (sections) | Sélecteur 📂 `#posteCat` : un `<optgroup>` par typologie (≥5 JdB, sectionnement extrême, faisceau partagé, organes internes, omnibus, départs déconnectés, gros postes…) ; entrées grisées = absentes de la situation (`catalog` de `/api/postes`) |
 | **Recharger** une cible sauvegardée pour recalculer | « ▷ Rejouer » |
-| Choisir l'**état de départ** depuis une topologie sauvegardée | « ⇧ Comme départ » |
+| Choisir l'**état de départ** depuis une topologie sauvegardée | « ⇧ Nouvelle Topologie Départ » (en-tête du schéma cible) |
+| **Recharger** un scénario (départ + cible) | Bouton « ⟳ Recharger » (titre *Scénario Topologique*) → modale (sélecteur + Valider / Annuler) → `/api/load_scenario` (mode `both`) |
+| **Rechercher / choisir un poste** (champ unique) | `#posteSearch` (datalist de **tous** les VL NODE_BREAKER, postes épinglés ★ en tête) ; charge au choix / Entrée |
 | **Sauvegarder la séquence** avec lien vers ses topologies | `/api/save_sequence` (JSON autonome + champ `scenario`) |
 | Atteindre la **topologie détaillée** imposée (barre exacte) + vérification | façade `sequencer` (« libtopo » = `determiner_manoeuvres_cible_detaillee`) ; statut « DÉTAILLÉE VÉRIFIÉE » / « NODALE OK · N écart(s) » |
 | **Avertissement d'écrasement** d'un fichier de sauvegarde existant | Confirmation / renommage (réponse `{exists:true}`) |

--- a/docs/manoeuvre_ihm.md
+++ b/docs/manoeuvre_ihm.md
@@ -86,6 +86,49 @@ merge `main`, inerte tant que `HF_TOKEN`/`HF_SPACE` ne sont pas définis). Voir
 
 ## 2. Disposition de l'interface
 
+![Vue d'ensemble annotée de l'IHM de manœuvre sur un scénario de scission de nœud à CARRIP3](manoeuvre/manoeuvre_ihm_overview.svg)
+
+> **Fig. — L'environnement interactif de manœuvre sur un scénario de scission de
+> nœud à CARRIP3** (départ : un nœud électrique ; cible : trois nœuds — barre 1
+> conservée, barre 2 scindée en sections 2.1 et 2.2). Repères :
+> **(1)** la source **Situation réseau**, en **deux onglets** — *📁 Local*
+> (chemin `.xiidm` côté serveur + **sélecteur de fichier natif**) et *📅 RTE7000*
+> (date/heure du dataset RTE-7000, avec **puces « cas d'intérêt »** et bulles
+> d'information) — chargée par un **unique bouton Charger** (RTE7000 mis en avant
+> par défaut sur le Space hébergé) ;
+> **(2)** le champ **Poste unifié** — une **seule recherche** sur tous les postes
+> NODE_BREAKER (épinglés ★ en tête) plus l'**explorateur curé par typologie** ;
+> **(3)** le schéma unifilaire **de départ** (lecture seule, état de référence),
+> dont l'en-tête porte **↺ État d'origine** (réinitialise la cible à l'état
+> d'origine) ;
+> **(4)** le schéma **cible éditable** — clic sur un disjoncteur/sectionneur pour
+> le basculer — dont l'en-tête porte **⇧ Nouvelle Topologie Départ** (promeut la
+> cible sélectionnée en nouveau départ, pour chaîner les scénarios) ;
+> **(5)** la « **vue bus** » nodale — glisser un départ sur une barre =
+> ré-aiguillage, glisser une barre sur une autre = fusion, *+ Nœud* = créer un
+> nœud — en partition de départ (un nœud, lecture seule) et cible (trois nœuds,
+> éditable) ;
+> **(6)** *2 · Topologie cible* : **✓ Valider & sauvegarder** la cible (« Calculer »
+> reste verrouillé tant que la cible n'est pas validée) ;
+> **(7)** *3 · Séquence de manœuvres* : choisir un mode de dé-énergisation
+> (smooth/agressif) et un algorithme, puis **⚙ Calculer** ou construire à la main
+> (**✋ Séquence manuelle**) la séquence ;
+> **(8)** **⚙ Calculer la topologie détaillée d'intérêt** réalise la cible nodale
+> éditée en cible détaillée (le **pont nodal → détaillé**) ;
+> **(9)** la séquence, **animée pas à pas** avec l'étape courante surlignée et les
+> opérations auditées — un sectionneur manœuvré **sous charge** est signalé en
+> **rouge** avec la règle enfreinte (ici **R18**, invariant hors-charge) — plus
+> l'export **💾 Sauvegarder la séquence** ;
+> **(10)** **⟳ Recharger** (à droite du titre *🗺 Scénario Topologique*) ouvre une
+> petite **modale** (sélecteur de scénario + Valider/Annuler) pour **rejouer** un
+> scénario sauvegardé.
+> Les couleurs des barres sont le `topological_coloring` natif des schémas
+> NODE_BREAKER ; à droite, les barres **violette**, **bordeaux** et **bleu clair**
+> sont les trois nœuds cibles (barre 1, et barre 2 scindée en 2.1 et 2.2).
+
+> La figure ci-dessus est un **schéma annoté** (SVG versionné) de la disposition ;
+> structure équivalente en ASCII :
+
 ```
 ┌──────────────────────┬─────────────────────────────────┬────────────────────┐
 │ PANNEAU LATÉRAL      │ SCHÉMA — TOPOLOGIE DE DÉPART     │ VOLET NODAL        │

--- a/docs/manoeuvre_ihm.md
+++ b/docs/manoeuvre_ihm.md
@@ -537,6 +537,22 @@ assert res.ecarts == []
   `scripts/manoeuvre_ihm_assets/index.html` (≈ 600 lignes), chargé au démarrage
   du module et servi tel quel par la route `GET /` (`PAGE`). Le `.py` ne contient
   plus de bloc HTML embarqué — édition du front sans toucher au serveur Python.
+- **Couverture de test** (`tests/manoeuvre/`) :
+  - `test_ihm_frontend_asset.py` — asset servi verbatim **+ garde-fou de
+    structure** : liste de **marqueurs requis** (onglets, `posteList`,
+    `promoteCible`, `validateCible`, `toggleNsec`, `Réinitialiser`, dates
+    2022/2023…) **présents** et de **marqueurs retirés** (`dsBox`, `posteCat`,
+    `datalist`, `= départ`, « Scénarios sauvegardés », auto-chargement…)
+    **absents** ; bloc `<script>` unique et accolades équilibrées.
+  - `test_ihm_dataset.py` — `/api/dataset/{config,timestamps,load}`,
+    `repo_pour_date` + **dérivation du repo par année** (timestamps **et** load),
+    drapeau `hosted`.
+  - `test_ihm_cache_and_api.py` — `/api/pick_grid_file` (succès / headless /
+    timeout), `/api/promote_cible` (+ `Session.promote_cible`), `content` renvoyé
+    par `/api/save` **et** `/api/save_sequence` (téléchargement local),
+    `_normalize_groups` ignore les nœuds vides.
+  - `test_ihm_nodale_*` / `test_ihm_sequence_edit.py` / `test_ihm_algo_selection.py`
+    — édition nodale, séquence, sélecteurs d'algo (inchangés).
 - **Couleurs** : pypowsybl encode les couleurs via des variables CSS
   (`var(--sld-vl-color)`). Le navigateur les résout nativement ; aucune palette
   maison n'est appliquée. (Pour un export PNG hors navigateur, voir

--- a/docs/manoeuvre_ihm.md
+++ b/docs/manoeuvre_ihm.md
@@ -27,10 +27,15 @@ python scripts/manoeuvre_ihm.py --grid /chemin/vers/grid.xiidm
 
 | Argument | Défaut | Rôle |
 |----------|--------|------|
-| `--grid` | *(requis)* | Réseau `.xiidm` contenant les postes de test |
-| `--port` | `8000` | Port HTTP |
+| `--grid` | *(optionnel)* | Réseau `.xiidm` local. **Omis ⇒ mode dataset** (cf. § 1bis) |
+| `--host` | `127.0.0.1` (env `HOST`) | Interface d'écoute (`0.0.0.0` en conteneur / Space) |
+| `--port` | `8000` (env `PORT`) | Port HTTP |
 | `--scenarios-dir` | `tests/manoeuvre/scenarios` | Dossier de sauvegarde des **scénarios** (cibles) |
 | `--sequences-dir` | `tests/manoeuvre/sequences` | Dossier de sauvegarde des **séquences** générées |
+| `--dataset` | — | Activer la **source dataset RTE 7000** (défaut si `--grid` absent) |
+| `--dataset-repo` | `OpenSynth/D-GITT-RTE7000-2021` (env `DGITT_REPO`) | Dataset HuggingFace source |
+| `--cache-dir` | `.cache/dgitt` (env `DGITT_CACHE_DIR`) | Cache local des instantanés téléchargés |
+| `--default-date` | `2021-01-03` (env `DGITT_DEFAULT_DATE`) | Date proposée par défaut dans l'IHM |
 
 > Le serveur charge le réseau une fois (≈ 15 s pour un grand `.xiidm`) puis
 > affiche les postes de test disponibles. Il est **mono-utilisateur** et
@@ -39,6 +44,43 @@ python scripts/manoeuvre_ihm.py --grid /chemin/vers/grid.xiidm
 **Postes de test** (intersection des fixtures et du réseau) : CARRIP3, CARRIP6,
 CZTRYP6, COMPIP3, BXTO5P3, BXTO5P6, CZBEVP3, PALUNP3, NOVIOP3, SSAVOP3, VIELMP6,
 CORNIP3, GUARBP6, MORBRP6.
+
+---
+
+## 1bis. Mode dataset RTE 7000 + déploiement HuggingFace
+
+Sans `--grid`, l'IHM démarre en **mode dataset** : au lieu d'un réseau local
+figé, elle source les situations dans le dataset HuggingFace
+[`OpenSynth/D-GITT-RTE7000-2021`](https://huggingface.co/datasets/OpenSynth/D-GITT-RTE7000-2021)
+(réseau France, **un instantané XIIDM toutes les 5 min**), **téléchargés à la
+demande** (rien n'est embarqué). C'est le mode utilisé par le HuggingFace Space.
+
+```bash
+pip install flask pypowsybl networkx pandas      # dépendances de l'IHM dataset
+python scripts/manoeuvre_ihm.py --dataset        # http://localhost:8000
+```
+
+Déroulé dans l'IHM (bandeau **📅 Dataset RTE7000** en tête de barre latérale) :
+
+1. choisir une **date** (accès rapides vers des journées documentées) puis une
+   **heure** — menu des instantanés disponibles, **midi présélectionné** ;
+2. **Charger la situation** → le réseau France de cette date/heure est téléchargé
+   puis chargé ; **tous les voltage levels** (postes NODE_BREAKER) se peuplent ;
+3. sélectionner un poste → sa **topologie détaillée** s'affiche (suite du flux
+   habituel : éditer la cible, séquencer, animer). Changer de date/heure recharge
+   la situation **en préservant le poste courant** s'il existe encore.
+
+La couche de sourcing est `manoeuvre/dataset/source.py` (`lister_instantanes`,
+`choisir_instantane`, `charger_situation` — stdlib pur, cache + md5, jeton
+`HF_TOKEN` optionnel). Le **réseau France complet** (~5 900 postes NODE_BREAKER)
+se charge en quelques secondes au premier choix d'une date ; les changements de
+poste à date constante sont quasi instantanés.
+
+**Déploiement HuggingFace Docker Space** : `Dockerfile` (mono-conteneur Flask sur
+`:7860`, mode dataset) + `deploy/huggingface/` (README du Space + `SETUP.md`
+détaillé) + `.github/workflows/deploy-huggingface.yml` (redéploiement auto sur
+merge `main`, inerte tant que `HF_TOKEN`/`HF_SPACE` ne sont pas définis). Voir
+`deploy/huggingface/SETUP.md`.
 
 ---
 
@@ -253,7 +295,10 @@ navigateur).
 | Méthode & route | Corps | Réponse | Rôle |
 |-----------------|-------|---------|------|
 | `GET /` | — | HTML | Page de l'IHM |
-| `GET /api/postes` | — | `{postes:[…], all:[…], catalog:[…]}` | `postes` = liste **épinglée** (jeu de test + 7 postes 400 kV à **3 jeux de barres** identifiés) ; `all` = **tous** les postes NODE_BREAKER de la situation (champ de recherche) ; `catalog` = **sections par typologie** (cf. ci-dessous) |
+| `GET /api/postes` | — | `{postes:[…], all:[…], catalog:[…]}` | `postes` = liste **épinglée** (jeu de test + 7 postes 400 kV à **3 jeux de barres** identifiés) ; `all` = **tous** les postes NODE_BREAKER de la situation (champ de recherche) ; `catalog` = **sections par typologie** (cf. ci-dessous). En mode dataset avant tout chargement : `{postes:[], all:[], catalog:[], needs_date:true}` |
+| `GET /api/dataset/config` | — | `{enabled, repo, default_date, default_time, sample_dates[]}` | Config de la source dataset ; `enabled=false` en mode `--grid` (le bandeau dataset reste masqué) |
+| `GET /api/dataset/timestamps?date=YYYY-MM-DD` | — | `{ok, date, timestamps:[{ts,path}], default}` / `400` (date invalide) / `502` (HF) | Instantanés disponibles pour la journée (HH:MM), avec l'horodatage présélectionné (le plus proche de **midi**) |
+| `POST /api/dataset/load` | `{date, time}` | `{ok, date, time, iso, postes:[…], all:[…], catalog:[…]}` / `400` (absent) / `502` (HF) | **Télécharge à la demande** l'instantané `(date, time)` du dataset, reconstruit la session et liste les postes (même forme que `/api/load_grid`) |
 | `POST /api/load_grid` | `{path}` | `{ok, postes:[…], all:[…], catalog:[…]}` / `400 {ok:false, error}` | Charge **dynamiquement** une autre situation réseau `.xiidm` (chemin **côté serveur**) et réinitialise la session ; 400 propre si fichier introuvable/illisible (session inchangée) |
 | `POST /api/load` | `{vl}` | `{initial_svg, nb_initial, svg, switches, nb_noeuds, nodale_depart, nodale_cible}` | Charge un poste (départ pristine) — **n'importe quel** VL NODE_BREAKER ; inclut les partitions nodales |
 | `POST /api/toggle` | `{id}` | `{svg, switches, nb_noeuds, nodale}` | Bascule un OC (cible) ; `nodale` = vue nodale resynchronisée |

--- a/docs/manoeuvre_ihm.md
+++ b/docs/manoeuvre_ihm.md
@@ -190,13 +190,16 @@ des variables CSS).
 
 ## 3. Flux de travail
 
-1. **Choisir un poste** (étape *1 · Poste* du Scénario Topologique) → les deux
-   schémas affichent l'état de départ (pristine). Un **unique champ** réunit deux
-   modes dans une même interaction : une **recherche** sur **tous** les postes
-   NODE_BREAKER de la situation et, **en dessous**, une **liste browsable**.
-   Champ **vide** → exploration **curée par typologie** (sections : *≥5 jeux de
-   barres*, *sectionnement extrême*, *faisceau de couplage partagé*, *organes
-   internes*, *omnibus*, *départs déconnectés*, *gros postes*, …). En
+1. **Choisir un poste** (étape *1 · Poste* du Scénario Topologique). **Aucun poste
+   n'est chargé automatiquement** (au lancement ni au chargement d'une situation) :
+   les schémas restent sur « Choisissez un poste… » tant qu'on n'en a pas
+   sélectionné un — alors les deux schémas affichent son état de départ (pristine).
+   Un **unique champ** réunit deux modes dans une même interaction : une
+   **recherche** sur **tous** les postes NODE_BREAKER de la situation et, **en
+   dessous** (sous le titre **« Pré-sélection de postes typiques »**), une **liste
+   browsable**. Champ **vide** → exploration **curée par typologie** (sections :
+   *≥5 jeux de barres*, *sectionnement extrême*, *faisceau de couplage partagé*,
+   *organes internes*, *omnibus*, *départs déconnectés*, *gros postes*, …). En
    **saisissant**, la liste filtre en **recherche plein-texte** sur tous les
    postes (bornée à 300 résultats affichés ; les postes épinglés ★ — jeu de test
    + 7 postes 3 JdB — y sont marqués). Un poste **grisé** (⚠ absent) n'est pas

--- a/docs/manoeuvre_ihm.md
+++ b/docs/manoeuvre_ihm.md
@@ -113,8 +113,9 @@ merge `main`, inerte tant que `HF_TOKEN`/`HF_SPACE` ne sont pas définis). Voir
 > ré-aiguillage, glisser une barre sur une autre = fusion, *+ Nœud* = créer un
 > nœud — en partition de départ (un nœud, lecture seule) et cible (trois nœuds,
 > éditable) ;
-> **(6)** *2 · Topologie cible* : **✓ Valider & sauvegarder** la cible (« Calculer »
-> reste verrouillé tant que la cible n'est pas validée) ;
+> **(6)** *2 · Topologie cible* : **✓ Valider** la cible (active « Calculer », sans
+> écrire de fichier) puis, sur la ligne en dessous, le **nom** + **💾 Sauvegarder**
+> (sur le Space, le fichier est aussi **téléchargé en local**) ;
 > **(7)** *3 · Séquence de manœuvres* : choisir un mode de dé-énergisation
 > (smooth/agressif) et un algorithme, puis **⚙ Calculer** ou construire à la main
 > (**✋ Séquence manuelle**) la séquence ;
@@ -202,8 +203,12 @@ des variables CSS).
 2. **Éditer la cible** : cliquer un disjoncteur/sectionneur dans le schéma du
    bas pour basculer son état (ouvert/fermé). Le nombre de nœuds cible évolue en
    direct.
-3. **Valider & sauvegarder la cible** (étape 1) : nomme et persiste le scénario
-   (départ + cible). **Obligatoire** avant le calcul.
+3. **Valider la cible** (étape *2 · Topologie cible*) : le bouton **✓ Valider**
+   débloque le calcul de séquence **sans écrire de fichier**. Pour la conserver,
+   **💾 Sauvegarder** (champ nom à gauche, bouton à droite) persiste le scénario
+   (départ + cible) ; **sur une IHM déportée (Space)** le JSON est aussi
+   **téléchargé en local** (le FS du Space est éphémère). Sauvegarder valide
+   aussi la cible.
 4. **Calculer la séquence** (étape 2, débloqué après validation) : choisir le
    **mode** (Smooth, défaut, ou Agressif) puis lancer le calcul départ → cible ;
    statut **VÉRIFIÉE / NON VÉRIFIÉE** (+ badge `mode`).
@@ -256,8 +261,11 @@ L'édition se fait par **glisser-déposer** :
   déplace. Pour en déplacer plusieurs d'un coup, **cliquer** d'abord les branches
   voulues (sélection surlignée, inter-nœuds) puis glisser l'une d'elles.
 - **Fusionner des nœuds** : glisser une **barre** sur une autre barre (fusion).
-- **Créer un nœud** : bouton **＋ Nœud** (nœud vide, ou contenant la sélection
-  courante) — puis y glisser des départs.
+- **Créer un nœud** : bouton **＋ Nœud**. Avec une sélection, il y déplace les
+  départs sélectionnés ; **sans sélection, il crée un nœud vide qui persiste**
+  comme cible de dépose — glisser-y ensuite des départs. Un nœud resté **vide**
+  est **ignoré** au calcul de la topologie détaillée (et retiré de l'affichage à
+  ce moment-là).
 - **Réinitialiser** : **= départ** ramène la cible à la partition de départ ;
   **∅ Désélectionner** vide la sélection.
 
@@ -367,7 +375,7 @@ navigateur).
 |-----------------|-------|---------|------|
 | `GET /` | — | HTML | Page de l'IHM |
 | `GET /api/postes` | — | `{postes:[…], all:[…], catalog:[…]}` | `postes` = liste **épinglée** (jeu de test + 7 postes 400 kV à **3 jeux de barres** identifiés) ; `all` = **tous** les postes NODE_BREAKER de la situation (champ de recherche) ; `catalog` = **sections par typologie** (cf. ci-dessous). En mode dataset avant tout chargement : `{postes:[], all:[], catalog:[], needs_date:true}` |
-| `GET /api/dataset/config` | — | `{enabled, repo, default_date, default_time, sample_dates[]}` | Config de la source dataset (onglet **RTE7000**) ; `enabled` décide de l'**onglet actif par défaut** (RTE7000 sur le Space, Local en mode `--grid`) — l'onglet RTE7000 reste présent dans les deux cas |
+| `GET /api/dataset/config` | — | `{enabled, repo, default_date, default_time, sample_dates[], hosted}` | Config de la source dataset (onglet **RTE7000**) ; `enabled` décide de l'**onglet actif par défaut** (RTE7000 sur le Space, Local en mode `--grid`) ; `hosted` = IHM déportée → le front **télécharge en local** les fichiers sauvegardés |
 | `GET /api/dataset/timestamps?date=YYYY-MM-DD` | — | `{ok, date, timestamps:[{ts,path}], default}` / `400` (date invalide) / `502` (HF) | Instantanés disponibles pour la journée (HH:MM), avec l'horodatage présélectionné (le plus proche de **midi**) |
 | `POST /api/dataset/load` | `{date, time}` | `{ok, date, time, iso, postes:[…], all:[…], catalog:[…]}` / `400` (absent) / `502` (HF) | **Télécharge à la demande** l'instantané `(date, time)` du dataset, reconstruit la session et liste les postes (même forme que `/api/load_grid`) |
 | `POST /api/load_grid` | `{path}` | `{ok, postes:[…], all:[…], catalog:[…]}` / `400 {ok:false, error}` | Charge **dynamiquement** une autre situation réseau `.xiidm` (chemin **côté serveur**) et réinitialise la session ; 400 propre si fichier introuvable/illisible (session inchangée) |
@@ -386,9 +394,9 @@ navigateur).
 | `POST /api/seq_delete_many` | `{indices:[…]}` | idem `seq_insert` | Supprime en une fois plusieurs manœuvres (sélection / bloc) |
 | `POST /api/manual_start` | — | `{cible_svg, cible_nb, goto, manoeuvres[], n_steps, labels[], …}` | Démarre une séquence **manuelle vierge** (départ → cible affichée en référence) |
 | `GET /api/scenarios` | — | `{scenarios:[…]}` | Liste des scénarios sauvegardés |
-| `POST /api/save` | `{name, overwrite?}` | `{path, scenarios[]}` ou `{exists:true, name, path}` | Sauvegarde le scénario cible |
+| `POST /api/save` | `{name, overwrite?}` | `{path, name, content, scenarios[]}` ou `{exists:true, name, path}` | Sauvegarde le scénario cible ; `content` = JSON écrit (téléchargement local côté front si IHM déportée) |
 | `POST /api/load_scenario` | `{name, mode}` | `{initial_svg, nb_initial, svg, switches, nb_noeuds, vl, nodale_depart, nodale_cible}` | Recharge (`mode="both"` ou `"as_depart"`) ; `nodale_cible` = vue nodale de la cible chargée |
-| `POST /api/save_sequence` | `{name, overwrite?}` | `{path}` ou `{exists:true, name, path}` | Sauvegarde la séquence **courante** (éditée telle quelle) |
+| `POST /api/save_sequence` | `{name, overwrite?}` | `{path, name, content}` ou `{exists:true, name, path}` | Sauvegarde la séquence **courante** (éditée telle quelle) ; `content` = JSON écrit (téléchargement local côté front si IHM déportée) |
 
 > **Avertissement d'écrasement** : sans `overwrite:true`, si le fichier existe
 > déjà, `/api/save` et `/api/save_sequence` renvoient `{exists:true}` (sans
@@ -480,7 +488,8 @@ assert res.ecarts == []
 | Spécification | Couverture |
 |---------------|-----------|
 | Modifier **manuellement et interactivement** l'état des DJ/SA depuis une topologie de départ | Clic sur l'organe du schéma cible → `/api/toggle` |
-| **Valider** la topologie cible avant de calculer | Étape **2 · Topologie cible** « Valider & sauvegarder » ; le bouton « Calculer » reste verrouillé tant que la cible n'est pas validée |
+| **Valider** la topologie cible avant de calculer | Étape **2 · Topologie cible** : bouton **✓ Valider** (sans fichier) ; le bouton « Calculer » reste verrouillé tant que la cible n'est pas validée |
+| **Télécharger** les fichiers sauvegardés quand l'IHM est déportée (Space) | `hosted` (`/api/dataset/config`) → `save()` / `saveSeq()` déclenchent un download du `content` renvoyé par `/api/save` / `/api/save_sequence` |
 | **Sauvegarder** la cible pour des tests par ailleurs | Scénario JSON (`/api/save`) avec topologies détaillées + nodales |
 | Demander la **séquence de manœuvres** départ → cible | `/api/sequence` → façade pluggable (`PlanificateurTopologie.sequencer`, phase B ; « libtopo » = `determiner_manoeuvres_cible_detaillee`) |
 | **Choisir l'algorithme** de chaque phase de calcul (natif « libtopo » + plugins enregistrés) | Sélecteurs « Algo » (panneau Séquence = phase B ; volet nodal = phase A) ; `GET/POST /api/algos` (disponibles par phase + sélection de session) ; badge `algo <nom>` dans le statut de séquence. Les plugins tiers (registre / entry points `expert_op4grid_recommender.manoeuvre`) apparaissent automatiquement — cf. `docs/manoeuvre_plugins.md` |

--- a/expert_op4grid_recommender/manoeuvre/CLAUDE.md
+++ b/expert_op4grid_recommender/manoeuvre/CLAUDE.md
@@ -77,6 +77,12 @@ python scripts/render_carrip3_sld.py --grid path/to/grid.xiidm
 #   docs/manoeuvre_ihm.md
 pip install -e ".[ihm]"   # guillemets requis sous zsh (sinon: pip install flask)
 python scripts/manoeuvre_ihm.py --grid path/to/grid.xiidm   # http://localhost:8000
+
+# Mode dataset RTE 7000 (sans --grid) : source les situations par date/heure
+# dans le dataset HF OpenSynth/D-GITT-RTE7000-* (telechargement a la demande).
+# Couche dans manoeuvre/dataset/source.py ; deploiement HF Space dans
+# Dockerfile + deploy/huggingface/. Doc : docs/manoeuvre_ihm.md (S 1bis).
+python scripts/manoeuvre_ihm.py --dataset                   # http://localhost:8000
 ```
 
 ## Conventions critiques

--- a/expert_op4grid_recommender/manoeuvre/dataset/__init__.py
+++ b/expert_op4grid_recommender/manoeuvre/dataset/__init__.py
@@ -50,6 +50,16 @@ from .structure import (
     poste_from_fixture_json,
     postes_depuis_xiidm,
 )
+from .source import (
+    DATES_ECHANTILLON,
+    REPO_DEFAUT,
+    charger_situation,
+    choisir_instantane,
+    lister_instantanes,
+    prefixe_jour,
+    resoudre_et_telecharger,
+    telecharger_instantane,
+)
 
 __all__ = [
     "Snapshot", "BlocTransition", "Oscillation", "TimelinePoste",
@@ -59,4 +69,7 @@ __all__ = [
     "generer_combinaisons", "stats_blocs",
     "couverture_structure", "graph_from_fixture_json",
     "poste_from_fixture_json", "postes_depuis_xiidm",
+    "DATES_ECHANTILLON", "REPO_DEFAUT", "charger_situation",
+    "choisir_instantane", "lister_instantanes", "prefixe_jour",
+    "resoudre_et_telecharger", "telecharger_instantane",
 ]

--- a/expert_op4grid_recommender/manoeuvre/dataset/source.py
+++ b/expert_op4grid_recommender/manoeuvre/dataset/source.py
@@ -40,11 +40,28 @@ from .dgitt import _charger_reseau, horodatage_depuis_nom
 #: dataset par défaut (année 2021 ; voir docs/dataset_rte7000/)
 REPO_DEFAUT = "OpenSynth/D-GITT-RTE7000-2021"
 
-#: dates « connues bonnes » (journées traitées dans docs/dataset_rte7000/) —
-#: proposées comme accès rapide dans l'IHM. Toute autre date reste saisissable.
+#: dates **identifiées intéressantes** (journées traitées dans
+#: docs/dataset_rte7000/ — « Table de campagne », 3 ans 2021-2023) — proposées
+#: comme accès rapide dans l'IHM. Toute autre date reste saisissable. L'année
+#: d'une date détermine le repo HuggingFace (cf. ``repo_pour_date``).
 DATES_ECHANTILLON: tuple[str, ...] = (
     "2021-01-03", "2021-01-05", "2021-04-14", "2021-07-15", "2021-10-12",
+    "2022-06-15", "2023-02-08",
 )
+
+
+def repo_pour_date(repo_base: str, date_iso: str) -> str:
+    """Repo HuggingFace à interroger pour la date ``date_iso``.
+
+    Le dataset D-GITT-RTE7000 existe par année (``…-2021`` / ``…-2022`` /
+    ``…-2023``). Si ``repo_base`` se termine par une année (``…-YYYY``), on la
+    remplace par l'année de ``date_iso`` ; sinon ``repo_base`` est renvoyé tel
+    quel (configuration mono-repo / repo personnalisé). Fonction pure."""
+    m = re.match(r"^(.*-)(\d{4})$", repo_base or "")
+    y = re.match(r"^\s*(\d{4})-", date_iso or "")
+    if m and y:
+        return f"{m.group(1)}{y.group(1)}"
+    return repo_base
 
 API = "https://huggingface.co/api/datasets/{repo}/tree/main/{prefix}"
 RESOLVE = "https://huggingface.co/datasets/{repo}/resolve/main/{path}"

--- a/expert_op4grid_recommender/manoeuvre/dataset/source.py
+++ b/expert_op4grid_recommender/manoeuvre/dataset/source.py
@@ -1,0 +1,236 @@
+"""
+manoeuvre/dataset/source.py — Source « instantané par date » du dataset
+=======================================================================
+
+Liste et télécharge **à la demande** un instantané XIIDM du dataset Hugging Face
+``OpenSynth/D-GITT-RTE7000-*`` (réseau France, 1 instantané toutes les 5 min ;
+arborescence ``YYYY/MM/JJ/recollement-auto-YYYYMMDD-HHMM-enrichi.xiidm.bz2``)
+pour une **date** et une **heure** données, **sans dépendre du client ``hf``** :
+listing par l'API ``/tree``, téléchargement HTTP via les URLs ``/resolve``,
+vérification md5 contre les fichiers jumeaux ``*.md5``. Stdlib pur.
+
+C'est la brique qui branche l'IHM de manœuvre (``scripts/manoeuvre_ihm.py``) sur
+le dataset : choisir une date → relever les voltage levels de l'instantané →
+charger la topologie d'un poste à cette date/heure. Conçu pour un Space
+HuggingFace (accès internet sortant vers ``huggingface.co``), avec cache local
+``cache_dir`` (reprise : un instantané déjà vérifié n'est pas retéléchargé).
+
+Les helpers HTTP dupliquent volontairement ceux de
+``scripts/download_dgitt_subset.py`` (qui reste **autonome**, sans dépendre du
+package) ; ils convergent sur le même schéma d'URL et la même vérification md5.
+
+Un ``HF_TOKEN`` (jeton de lecture) est optionnel : utile pour desserrer le
+rate-limit anonyme du CDN HF.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import random
+import re
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from pathlib import Path
+from typing import Optional
+
+from .dgitt import _charger_reseau, horodatage_depuis_nom
+
+#: dataset par défaut (année 2021 ; voir docs/dataset_rte7000/)
+REPO_DEFAUT = "OpenSynth/D-GITT-RTE7000-2021"
+
+#: dates « connues bonnes » (journées traitées dans docs/dataset_rte7000/) —
+#: proposées comme accès rapide dans l'IHM. Toute autre date reste saisissable.
+DATES_ECHANTILLON: tuple[str, ...] = (
+    "2021-01-03", "2021-01-05", "2021-04-14", "2021-07-15", "2021-10-12",
+)
+
+API = "https://huggingface.co/api/datasets/{repo}/tree/main/{prefix}"
+RESOLVE = "https://huggingface.co/datasets/{repo}/resolve/main/{path}"
+
+#: codes HTTP transitoires (le CDN/rate-limiter HF rend des 403 épisodiques sur
+#: les rafales anonymes — ils passent au retry)
+_RETRIABLE = {403, 429, 500, 502, 503, 504}
+
+
+# ===========================================================================
+# Couche HTTP (isolée pour le mock en test)
+# ===========================================================================
+
+def _entetes(token: Optional[str] = None) -> dict:
+    """En-têtes HTTP (User-Agent + Authorization si un jeton est fourni)."""
+    en = {"User-Agent": "dgitt-subset/1.0"}
+    if token:
+        en["Authorization"] = f"Bearer {token}"
+    return en
+
+
+def _http_get(url: str, timeout: int = 120, essais: int = 5,
+              token: Optional[str] = None) -> bytes:
+    """GET avec retries exponentiels sur les codes transitoires."""
+    req = urllib.request.Request(url, headers=_entetes(token))
+    for essai in range(essais):
+        try:
+            with urllib.request.urlopen(req, timeout=timeout) as resp:
+                return resp.read()
+        except urllib.error.HTTPError as exc:
+            if exc.code not in _RETRIABLE or essai == essais - 1:
+                raise
+            time.sleep(2 ** essai + random.uniform(0, 1))
+        except (urllib.error.URLError, TimeoutError):
+            if essai == essais - 1:
+                raise
+            time.sleep(2 ** essai + random.uniform(0, 1))
+    raise AssertionError("unreachable")
+
+
+def lister_fichiers(repo: str, prefix: str,
+                    token: Optional[str] = None) -> list[str]:
+    """Chemins des ``*.xiidm.bz2`` sous ``prefix`` (API tree, paginée), triés."""
+    fichiers: list[str] = []
+    url = API.format(repo=repo, prefix=urllib.parse.quote(prefix))
+    while url:
+        req = urllib.request.Request(url, headers=_entetes(token))
+        with urllib.request.urlopen(req, timeout=60) as resp:
+            items = json.load(resp)
+            link = resp.headers.get("Link", "")
+        fichiers += [it["path"] for it in items
+                     if it.get("type") == "file"
+                     and it["path"].endswith(".xiidm.bz2")]
+        m = re.search(r'<([^>]+)>;\s*rel="next"', link)
+        url = m.group(1) if m else None
+    return sorted(fichiers)
+
+
+def _md5_attendu(repo: str, path: str,
+                 token: Optional[str] = None) -> Optional[str]:
+    """Digest md5 publié dans le fichier jumeau ``<path>.md5`` (None si absent)."""
+    try:
+        contenu = _http_get(
+            RESOLVE.format(repo=repo, path=urllib.parse.quote(path + ".md5")),
+            timeout=30, token=token).decode("ascii", "replace")
+    except urllib.error.HTTPError as exc:
+        if exc.code == 404:
+            return None
+        raise
+    m = re.search(r"\b([0-9a-fA-F]{32})\b", contenu)
+    return m.group(1).lower() if m else None
+
+
+def _md5_fichier(p: Path) -> str:
+    """Digest md5 d'un fichier local (lecture par blocs)."""
+    h = hashlib.md5()
+    with p.open("rb") as fh:
+        for chunk in iter(lambda: fh.read(1 << 20), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def telecharger_un(repo: str, path: str, racine: Path,
+                   token: Optional[str] = None) -> Path:
+    """Télécharge ``path`` sous ``racine`` (arborescence préservée) et le vérifie
+    (md5). Reprise : si le fichier local existe et concorde, pas de re-téléchargement.
+    Retourne le chemin local."""
+    dest = Path(racine) / path
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    attendu = _md5_attendu(repo, path, token=token)
+    if dest.exists() and attendu and _md5_fichier(dest) == attendu:
+        return dest
+    octets = _http_get(RESOLVE.format(repo=repo, path=urllib.parse.quote(path)),
+                       token=token)
+    if attendu:
+        obtenu = hashlib.md5(octets).hexdigest()
+        if obtenu != attendu:
+            raise IOError(f"md5 invalide pour {path} : {obtenu} ≠ {attendu}")
+    dest.write_bytes(octets)
+    return dest
+
+
+# ===========================================================================
+# Résolution par date / heure
+# ===========================================================================
+
+def prefixe_jour(date_iso: str) -> str:
+    """``'2021-01-03'`` → ``'2021/01/03'`` (préfixe d'arborescence du dataset).
+
+    Lève ``ValueError`` si la date n'est pas au format ``YYYY-MM-DD``."""
+    m = re.match(r"^\s*(\d{4})-(\d{2})-(\d{2})\s*$", date_iso or "")
+    if not m:
+        raise ValueError(f"Date attendue au format YYYY-MM-DD : {date_iso!r}")
+    return "/".join(m.groups())
+
+
+def _minutes(hhmm: str) -> int:
+    """``'HH:MM'`` → minutes depuis minuit (tolère ``'HHhMM'`` / ``'HHMM'``)."""
+    m = re.match(r"^\s*(\d{1,2})[h:]?(\d{2})\s*$", hhmm or "")
+    if not m:
+        return 12 * 60
+    return int(m.group(1)) * 60 + int(m.group(2))
+
+
+def lister_instantanes(repo: str, date_iso: str,
+                       token: Optional[str] = None) -> list[dict]:
+    """Instantanés disponibles pour ``date_iso`` :
+    ``[{'ts': 'HH:MM', 'iso': 'YYYY-MM-DDTHH:MM', 'path': <hf_path>}, …]`` trié
+    par horodatage croissant. Liste vide si la journée est absente du dataset."""
+    out: list[dict] = []
+    for path in lister_fichiers(repo, prefixe_jour(date_iso), token=token):
+        try:
+            iso = horodatage_depuis_nom(Path(path).name)
+        except ValueError:
+            continue
+        out.append({"ts": iso[11:16], "iso": iso, "path": path})
+    out.sort(key=lambda d: d["iso"])
+    return out
+
+
+def choisir_instantane(instantanes: list[dict],
+                       heure: str = "12:00") -> Optional[dict]:
+    """Instantané le plus proche de ``heure`` (HH:MM). ``None`` si liste vide.
+
+    Par défaut **midi** : sur un poste calme, l'instantané de mi-journée est
+    représentatif ; l'utilisateur peut viser n'importe quel horodatage."""
+    if not instantanes:
+        return None
+    cible = _minutes(heure)
+    return min(instantanes, key=lambda d: abs(_minutes(d["ts"]) - cible))
+
+
+def telecharger_instantane(repo: str, hf_path: str, cache_dir,
+                           token: Optional[str] = None) -> Path:
+    """Télécharge l'instantané ``hf_path`` dans ``cache_dir`` (repris si déjà
+    présent et vérifié). Retourne le chemin local."""
+    return telecharger_un(repo, hf_path, Path(cache_dir), token=token)
+
+
+def resoudre_et_telecharger(repo: str, date_iso: str, cache_dir,
+                            heure: str = "12:00",
+                            token: Optional[str] = None) -> tuple[Path, dict]:
+    """Liste la journée → choisit l'instantané le plus proche de ``heure`` →
+    le télécharge dans ``cache_dir``. Retourne ``(chemin_local, meta)`` où
+    ``meta = {'date', 'ts', 'iso', 'path'}``.
+
+    Lève ``FileNotFoundError`` si aucun instantané n'existe pour cette date."""
+    insts = lister_instantanes(repo, date_iso, token=token)
+    choisi = choisir_instantane(insts, heure)
+    if choisi is None:
+        raise FileNotFoundError(
+            f"Aucun instantané pour {date_iso} dans {repo}.")
+    local = telecharger_instantane(repo, choisi["path"], cache_dir, token=token)
+    return local, {"date": date_iso, **choisi}
+
+
+def charger_situation(repo: str, date_iso: str, cache_dir,
+                      heure: str = "12:00",
+                      token: Optional[str] = None):
+    """Bout-en-bout : résout + télécharge l'instantané (date/heure) puis le
+    **charge en réseau pypowsybl**. Retourne ``(net, meta)`` avec
+    ``meta = {'date', 'ts', 'iso', 'path', 'local'}``.
+
+    pypowsybl n'est importé que par ``_charger_reseau`` (paresseux)."""
+    local, meta = resoudre_et_telecharger(repo, date_iso, cache_dir,
+                                          heure=heure, token=token)
+    net = _charger_reseau(local)
+    meta["local"] = str(local)
+    return net, meta

--- a/scripts/manoeuvre_ihm.py
+++ b/scripts/manoeuvre_ihm.py
@@ -1072,9 +1072,10 @@ def api_dataset_timestamps():
     """Instantanés disponibles (HH:MM) pour la date ``?date=YYYY-MM-DD``, avec
     l'horodatage présélectionné par défaut (le plus proche de midi)."""
     date = (request.args.get("date") or "").strip()
+    repo = dataset_source.repo_pour_date(DATASET["repo"], date)
     try:
         insts = dataset_source.lister_instantanes(
-            DATASET["repo"], date, token=DATASET["token"])
+            repo, date, token=DATASET["token"])
     except ValueError as exc:
         return jsonify(ok=False, error=str(exc)), 400
     except Exception as exc:  # pragma: no cover - dépend du réseau HF
@@ -1094,9 +1095,10 @@ def api_dataset_load():
     body = request.json or {}
     date = (body.get("date") or "").strip()
     heure = (body.get("time") or DATASET["default_time"]).strip()
+    repo = dataset_source.repo_pour_date(DATASET["repo"], date)
     try:
         net, meta = dataset_source.charger_situation(
-            DATASET["repo"], date, DATASET["cache_dir"],
+            repo, date, DATASET["cache_dir"],
             heure=heure, token=DATASET["token"])
     except (ValueError, FileNotFoundError) as exc:
         return jsonify(ok=False, error=str(exc)), 400

--- a/scripts/manoeuvre_ihm.py
+++ b/scripts/manoeuvre_ihm.py
@@ -52,6 +52,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import pathlib
 import re
 import sys
@@ -87,6 +88,7 @@ from expert_op4grid_recommender.manoeuvre.plugins import (
     PlanificateurTopologie,
     disponibles as algos_disponibles,
 )
+from expert_op4grid_recommender.manoeuvre.dataset import source as dataset_source
 
 # Postes de test retenus (intersectés avec les VL réellement présents)
 POSTES_TEST = [
@@ -995,6 +997,30 @@ def _prefix_svg_ids(svg: str, pfx: str) -> str:
 app = Flask(__name__)
 SESSION: Session = None  # type: ignore
 
+# Configuration de la **source dataset par date** (mode déploiement Space
+# HuggingFace : on charge à la demande un instantané XIIDM du dataset RTE 7000).
+# Renseignée par ``main()`` / variables d'environnement. ``enabled=False`` =>
+# mode local (``--grid``) : le bandeau « Dataset » de l'IHM reste masqué et le
+# comportement historique est strictement préservé.
+DATASET = {
+    "enabled": False,
+    "repo": dataset_source.REPO_DEFAUT,
+    "cache_dir": ".cache/dgitt",
+    "token": None,
+    "default_date": dataset_source.DATES_ECHANTILLON[0],
+    "default_time": "12:00",
+    "sample_dates": list(dataset_source.DATES_ECHANTILLON),
+}
+
+
+def _algos_courants() -> dict[str, str]:
+    """Sélection d'algos courante, ou défauts « libtopo » si aucune session n'est
+    encore chargée (mode dataset avant le choix d'une date)."""
+    if SESSION is not None:
+        return SESSION.algos
+    return {p: "libtopo" for p in ("identificateur", "sequenceur",
+                                   "planificateur")}
+
 
 @app.get("/")
 def index():
@@ -1006,7 +1032,64 @@ def api_postes():
     # ``postes`` : liste épinglée (jeu de test + 3 JdB). ``all`` : tous les postes
     # NODE_BREAKER de la situation chargée (recherche dans l'IHM). ``catalog`` :
     # sections par typologie (cf. POSTES_CATALOG) avec disponibilité par poste.
+    # Mode dataset avant tout chargement : aucune situation => le front affiche
+    # le bandeau de choix de date (``needs_date``).
+    if SESSION is None:
+        return jsonify(postes=[], all=[], catalog=[], needs_date=True)
     return jsonify(postes=SESSION.postes, all=SESSION.all_postes,
+                   catalog=SESSION.catalog())
+
+
+# ── Source dataset RTE 7000 (chargement d'une situation par date / heure) ────
+
+@app.get("/api/dataset/config")
+def api_dataset_config():
+    """Configuration de la source dataset pour le front : si ``enabled``, l'IHM
+    affiche le bandeau date/heure ; sinon (mode ``--grid`` local) il reste masqué."""
+    return jsonify(enabled=DATASET["enabled"], repo=DATASET["repo"],
+                   default_date=DATASET["default_date"],
+                   default_time=DATASET["default_time"],
+                   sample_dates=DATASET["sample_dates"])
+
+
+@app.get("/api/dataset/timestamps")
+def api_dataset_timestamps():
+    """Instantanés disponibles (HH:MM) pour la date ``?date=YYYY-MM-DD``, avec
+    l'horodatage présélectionné par défaut (le plus proche de midi)."""
+    date = (request.args.get("date") or "").strip()
+    try:
+        insts = dataset_source.lister_instantanes(
+            DATASET["repo"], date, token=DATASET["token"])
+    except ValueError as exc:
+        return jsonify(ok=False, error=str(exc)), 400
+    except Exception as exc:  # pragma: no cover - dépend du réseau HF
+        return jsonify(ok=False, error=f"Listing HuggingFace impossible : {exc}"), 502
+    choisi = dataset_source.choisir_instantane(insts, DATASET["default_time"])
+    return jsonify(ok=True, date=date,
+                   timestamps=[{"ts": d["ts"], "path": d["path"]} for d in insts],
+                   default=(choisi["ts"] if choisi else None))
+
+
+@app.post("/api/dataset/load")
+def api_dataset_load():
+    """Charge la **situation réseau** du dataset à ``{date, time}`` (téléchargement
+    à la demande depuis HuggingFace + cache local), reconstruit la session et
+    renvoie la liste des postes (même forme que ``/api/load_grid``)."""
+    global SESSION
+    body = request.json or {}
+    date = (body.get("date") or "").strip()
+    heure = (body.get("time") or DATASET["default_time"]).strip()
+    try:
+        net, meta = dataset_source.charger_situation(
+            DATASET["repo"], date, DATASET["cache_dir"],
+            heure=heure, token=DATASET["token"])
+    except (ValueError, FileNotFoundError) as exc:
+        return jsonify(ok=False, error=str(exc)), 400
+    except Exception as exc:  # pragma: no cover - dépend du réseau HF / fichier
+        return jsonify(ok=False, error=f"Chargement impossible : {exc}"), 502
+    SESSION = Session(net)
+    return jsonify(ok=True, date=meta["date"], time=meta["ts"], iso=meta["iso"],
+                   postes=SESSION.postes, all=SESSION.all_postes,
                    catalog=SESSION.catalog())
 
 
@@ -1076,7 +1159,7 @@ def api_algos():
     """Algorithmes pluggables **disponibles** (registre ``manoeuvre.plugins``,
     natifs « libtopo » + plugins tiers enregistrés / entry points), par phase,
     et **sélection courante** de la session."""
-    return jsonify(disponibles=algos_disponibles(), selection=SESSION.algos)
+    return jsonify(disponibles=algos_disponibles(), selection=_algos_courants())
 
 
 @app.post("/api/algos")
@@ -1098,6 +1181,8 @@ def api_nodale_to_detaillee():
 
 @app.get("/api/scenarios")
 def api_scenarios():
+    if SESSION is None:
+        return jsonify(scenarios=[])
     return jsonify(scenarios=SESSION.list_scenarios())
 
 
@@ -1187,24 +1272,51 @@ PAGE = (_ASSETS_DIR / "index.html").read_text(encoding="utf-8")
 def main():
     global SESSION
     ap = argparse.ArgumentParser(description=__doc__)
-    ap.add_argument("--grid", required=True, help="Chemin du réseau .xiidm")
-    ap.add_argument("--port", type=int, default=8000)
+    # ``--grid`` optionnel : s'il est omis, l'IHM démarre en **mode dataset**
+    # (source RTE 7000 par date) ; sinon comportement local historique.
+    ap.add_argument("--grid", default=None,
+                    help="Chemin du réseau .xiidm (mode local). Omis => mode dataset.")
+    ap.add_argument("--host", default=os.environ.get("HOST", "127.0.0.1"),
+                    help="Interface d'écoute (0.0.0.0 pour un conteneur / Space).")
+    ap.add_argument("--port", type=int, default=int(os.environ.get("PORT", "8000")))
     ap.add_argument("--scenarios-dir", default="tests/manoeuvre/scenarios",
                     help="Dossier de sauvegarde des scénarios cible")
     ap.add_argument("--sequences-dir", default="tests/manoeuvre/sequences",
                     help="Dossier de sauvegarde des séquences générées")
+    # Mode dataset (source par date depuis HuggingFace).
+    ap.add_argument("--dataset", action="store_true",
+                    help="Activer la source dataset RTE 7000 (défaut si --grid absent).")
+    ap.add_argument("--dataset-repo",
+                    default=os.environ.get("DGITT_REPO", dataset_source.REPO_DEFAUT),
+                    help="Dataset HuggingFace (défaut : %(default)s)")
+    ap.add_argument("--cache-dir",
+                    default=os.environ.get("DGITT_CACHE_DIR", ".cache/dgitt"),
+                    help="Cache local des instantanés téléchargés")
+    ap.add_argument("--default-date",
+                    default=os.environ.get("DGITT_DEFAULT_DATE",
+                                           dataset_source.DATES_ECHANTILLON[0]),
+                    help="Date proposée par défaut dans l'IHM (YYYY-MM-DD)")
     args = ap.parse_args()
 
     global SCEN_DIR, SEQ_DIR
     SCEN_DIR = pathlib.Path(args.scenarios_dir)
     SEQ_DIR = pathlib.Path(args.sequences_dir)
 
-    print(f"Chargement du réseau {args.grid} …")
-    SESSION = Session(pp.network.load(args.grid))
-    print(f"Postes de test disponibles : {SESSION.postes}")
-    print(f"IHM Manœuvre : http://localhost:{args.port}  (Ctrl-C pour arrêter)")
+    use_dataset = args.dataset or not args.grid
+    DATASET.update(enabled=use_dataset, repo=args.dataset_repo,
+                   cache_dir=args.cache_dir, token=os.environ.get("HF_TOKEN"),
+                   default_date=args.default_date)
+
+    if args.grid:
+        print(f"Chargement du réseau {args.grid} …")
+        SESSION = Session(pp.network.load(args.grid))
+        print(f"Postes de test disponibles : {SESSION.postes}")
+    if use_dataset:
+        print(f"Mode dataset : {DATASET['repo']} (cache {DATASET['cache_dir']}). "
+              "Choisir une date/heure dans l'IHM.")
+    print(f"IHM Manœuvre : http://{args.host}:{args.port}  (Ctrl-C pour arrêter)")
     # threaded=False : sérialise les requêtes (l'état réseau pypowsybl est partagé).
-    app.run(host="127.0.0.1", port=args.port, threaded=False)
+    app.run(host=args.host, port=args.port, threaded=False)
 
 
 if __name__ == "__main__":

--- a/scripts/manoeuvre_ihm.py
+++ b/scripts/manoeuvre_ihm.py
@@ -1025,6 +1025,11 @@ DATASET = {
     "default_date": dataset_source.DATES_ECHANTILLON[0],
     "default_time": "12:00",
     "sample_dates": list(dataset_source.DATES_ECHANTILLON),
+    # IHM déportée (Space HuggingFace) : le système de fichiers est éphémère →
+    # le front télécharge aussi en local les scénarios/séquences sauvegardés.
+    # Auto-détecté (HF pose ``SPACE_ID``) ou forcé via env / ``--hosted``.
+    "hosted": bool(os.environ.get("SPACE_ID")
+                   or os.environ.get("MANOEUVRE_IHM_HOSTED")),
 }
 
 
@@ -1064,7 +1069,8 @@ def api_dataset_config():
     return jsonify(enabled=DATASET["enabled"], repo=DATASET["repo"],
                    default_date=DATASET["default_date"],
                    default_time=DATASET["default_time"],
-                   sample_dates=DATASET["sample_dates"])
+                   sample_dates=DATASET["sample_dates"],
+                   hosted=DATASET["hosted"])
 
 
 @app.get("/api/dataset/timestamps")
@@ -1280,7 +1286,11 @@ def api_save():
     if not request.json.get("overwrite") and (SCEN_DIR / f"{name}.json").exists():
         return jsonify(exists=True, name=name, path=str(SCEN_DIR / f"{name}.json"))
     path = SESSION.save_scenario(name)
-    return jsonify(path=path, scenarios=SESSION.list_scenarios())
+    # ``content`` : JSON écrit, renvoyé pour le téléchargement local côté front
+    # (IHM déportée — FS éphémère du Space).
+    content = pathlib.Path(path).read_text(encoding="utf-8")
+    return jsonify(path=path, name=name, content=content,
+                   scenarios=SESSION.list_scenarios())
 
 
 @app.post("/api/load_scenario")
@@ -1307,7 +1317,8 @@ def api_save_sequence():
     if not request.json.get("overwrite") and (SEQ_DIR / f"{name}.json").exists():
         return jsonify(exists=True, name=name, path=str(SEQ_DIR / f"{name}.json"))
     path = SESSION.save_sequence(name)
-    return jsonify(path=path)
+    content = pathlib.Path(path).read_text(encoding="utf-8")   # téléchargement local
+    return jsonify(path=path, name=name, content=content)
 
 
 @app.get("/api/step")
@@ -1380,6 +1391,9 @@ def main():
                     default=os.environ.get("DGITT_DEFAULT_DATE",
                                            dataset_source.DATES_ECHANTILLON[0]),
                     help="Date proposée par défaut dans l'IHM (YYYY-MM-DD)")
+    ap.add_argument("--hosted", action="store_true",
+                    help="IHM déportée (Space) : télécharge aussi en local les "
+                         "fichiers sauvegardés (auto si SPACE_ID/MANOEUVRE_IHM_HOSTED).")
     args = ap.parse_args()
 
     global SCEN_DIR, SEQ_DIR
@@ -1389,7 +1403,8 @@ def main():
     use_dataset = args.dataset or not args.grid
     DATASET.update(enabled=use_dataset, repo=args.dataset_repo,
                    cache_dir=args.cache_dir, token=os.environ.get("HF_TOKEN"),
-                   default_date=args.default_date)
+                   default_date=args.default_date,
+                   hosted=args.hosted or DATASET["hosted"])
 
     if args.grid:
         print(f"Chargement du réseau {args.grid} …")

--- a/scripts/manoeuvre_ihm.py
+++ b/scripts/manoeuvre_ihm.py
@@ -54,7 +54,9 @@ import argparse
 import json
 import os
 import pathlib
+import platform
 import re
+import subprocess
 import sys
 from contextlib import contextmanager
 
@@ -1109,6 +1111,59 @@ def api_load_grid():
     SESSION = Session(net)
     return jsonify(ok=True, postes=SESSION.postes, all=SESSION.all_postes,
                    catalog=SESSION.catalog())
+
+
+def _pick_grid_file_macos() -> dict:
+    """Sélecteur de fichier natif macOS (osascript). Best-effort."""
+    script = ('POSIX path of (choose file with prompt '
+              '"Sélectionner une situation réseau (.xiidm)")')
+    proc = subprocess.run(["osascript", "-e", script],
+                          capture_output=True, text=True, timeout=300)
+    if proc.returncode != 0:
+        err = (proc.stderr or "").strip()
+        if "User canceled" in err or "User cancelled" in err or "(-128)" in err:
+            return {"path": ""}            # annulation = pas une erreur
+        return {"path": "", "error": err or "osascript a échoué"}
+    return {"path": proc.stdout.strip()}
+
+
+def _pick_grid_file_tkinter() -> dict:
+    """Sélecteur de fichier natif via ``tkinter`` (sous-processus isolé). Sans
+    afficheur (Space headless) ou sans tkinter, le sous-processus échoue et on
+    renvoie une ``error`` que l'IHM affiche (invite à coller le chemin)."""
+    script = (
+        "import tkinter as tk\n"
+        "from tkinter import filedialog\n"
+        "root = tk.Tk(); root.withdraw()\n"
+        "root.attributes('-topmost', True)\n"
+        "p = filedialog.askopenfilename(\n"
+        "    title='Sélectionner une situation réseau',\n"
+        "    filetypes=[('Réseau XIIDM', '*.xiidm *.xiidm.bz2 *.xiidm.gz *.zip'),\n"
+        "               ('Tous les fichiers', '*.*')])\n"
+        "root.destroy()\n"
+        "print(p or '')\n")
+    proc = subprocess.run([sys.executable, "-c", script],
+                          capture_output=True, text=True, timeout=300)
+    if proc.returncode != 0:
+        return {"path": "",
+                "error": (proc.stderr or "").strip() or "sélecteur indisponible"}
+    return {"path": proc.stdout.strip()}
+
+
+@app.get("/api/pick_grid_file")
+def api_pick_grid_file():
+    """Ouvre un sélecteur de fichier **natif** (usage local) pour choisir une
+    situation réseau ``.xiidm`` et renvoie ``{path, error?}`` — ``path`` vide si
+    l'utilisateur annule. Sur un serveur sans afficheur (Space), renvoie une
+    ``error`` (l'IHM invite alors à coller le chemin à la main)."""
+    try:
+        if platform.system() == "Darwin":
+            return jsonify(_pick_grid_file_macos())
+        return jsonify(_pick_grid_file_tkinter())
+    except subprocess.TimeoutExpired:
+        return jsonify(path="", error="Sélecteur expiré (aucune sélection).")
+    except Exception as exc:  # pragma: no cover - dépend de l'environnement
+        return jsonify(path="", error=str(exc))
 
 
 @app.post("/api/load")

--- a/scripts/manoeuvre_ihm.py
+++ b/scripts/manoeuvre_ihm.py
@@ -396,6 +396,19 @@ class Session:
         self.current = dict(self.initial)
         self.scenario_name = None
 
+    def promote_cible(self):
+        """Promeut la cible courante (état détaillé édité) en **nouvel état de
+        départ** : ``initial`` prend l'ancienne ``current`` (et ``current`` en
+        repart à l'identique). Séquence et lien de scénario réinitialisés. Permet
+        de **chaîner** depuis une topologie éditée sans passer par un scénario
+        sauvegardé. (Le VL ne change pas : les caches par état restent valides.)"""
+        self.initial = dict(self.current)
+        self.current = dict(self.initial)
+        self.seq_manoeuvres = []
+        self.seq_states, self.seq_highlights, self.seq_labels = [], [], []
+        self.seq_edited = False
+        self.scenario_name = None
+
     def toggle(self, sid):
         if sid in self.current:
             self.current[sid] = not self.current[sid]
@@ -1191,6 +1204,20 @@ def api_reset():
     svg, sw, nb = SESSION.view(SESSION.current)
     return jsonify(svg=svg, switches=sw, nb_noeuds=nb,
                    nodale=SESSION.nodale_state(SESSION.current))
+
+
+@app.post("/api/promote_cible")
+def api_promote_cible():
+    """Promeut la cible courante en **nouvel état de départ** (chaînage sans
+    passer par un scénario sauvegardé). Renvoie les deux schémas (départ + cible)
+    et les vues nodales, comme ``/api/load``."""
+    SESSION.promote_cible()
+    svg_i, _, nb_i = SESSION.view(SESSION.initial)
+    svg_c, sw, nb_c = SESSION.view(SESSION.current)
+    return jsonify(initial_svg=_prefix_svg_ids(svg_i, "A_"), nb_initial=nb_i,
+                   svg=svg_c, switches=sw, nb_noeuds=nb_c, vl=SESSION.vl,
+                   nodale_depart=SESSION.nodale_payload(SESSION.initial),
+                   nodale_cible=SESSION.nodale_state(SESSION.current))
 
 
 @app.post("/api/cible")

--- a/scripts/manoeuvre_ihm_assets/index.html
+++ b/scripts/manoeuvre_ihm_assets/index.html
@@ -256,7 +256,7 @@
       <div class="stitle"><span id="ndCibTitle">Cible (éditable)</span><span class="badge" id="ndCibN">–</span></div>
       <div class="ntools">
         <button onclick="nodNewNode()" title="Créer un nœud vide (puis y glisser des départs ; ou avec la sélection courante)">＋ Nœud</button>
-        <button onclick="nodReset()" title="Réinitialiser la cible nodale = départ">= départ</button>
+        <button onclick="nodReset()" title="Réinitialiser la cible (nodale + détaillée) à la topologie d'origine du poste (départ)">↺ Réinitialiser</button>
         <button onclick="nodClearSel()" title="Vider la sélection">∅ Désélectionner</button>
       </div>
       <div style="font-size:10px;color:#64748b;padding:0 8px">Glisser un <b>départ</b> (ou une sélection : clic pour (dé)sélectionner) sur une autre barre = réaiguillage. Glisser une <b>barre</b> sur une autre = fusion. Flux en MW (état de départ).</div>
@@ -739,10 +739,12 @@ function initNodale(d){
   document.getElementById('nodstatus').textContent='';
   document.getElementById('nodstatus').className='';
   renderNodaleDepart();renderNodaleCible();}
-function nodReset(){NOD.groups=cloneGroups(NOD.depart.groups||[]);
-  NOD.isolated=(NOD.departIso||[]).slice();
-  NOD.colorsCible=Object.assign({},NOD.colors);  // recouleurs = départ
-  NOD.selBranches=new Set();NOD.selNodes=new Set();renderNodaleCible();}
+// « ↺ Réinitialiser » : ramène la cible à la topologie d'origine du poste
+// (départ) — **détaillée ET nodale**. Réutilise le reset complet (/api/reset,
+// même chemin que « État d'origine ») : l'ancien reset nodal client-only ne
+// remettait que la proposition nodale, pas le schéma détaillé → effet « ne
+// réinitialise pas » dès qu'on avait édité le détail ou calculé.
+async function nodReset(){await reset();}
 function nodNormalize(){NOD.groups=NOD.groups.filter(g=>g.length>0);}
 function nodeColor(i){return NODE_COLORS[i%NODE_COLORS.length];}
 // Couleur de la barre = couleur SLD du nœud (via une branche), sinon palette de repli.

--- a/scripts/manoeuvre_ihm_assets/index.html
+++ b/scripts/manoeuvre_ihm_assets/index.html
@@ -89,49 +89,91 @@
  #nodstatus{font-size:11px;padding:4px 8px;white-space:normal}
  #nodstatus.okv{color:#065f46;background:#ecfdf5}
  #nodstatus.kov{color:#92400e;background:#fffbeb}
+ /* Onglets « Situation réseau » (Local / RTE7000) */
+ .tabs{display:flex;gap:0;margin:4px 0 0}
+ .tab{flex:1;padding:6px 4px;border:1px solid #bfdbfe;background:#e9eef5;margin:0;
+   font-size:12px;color:#334155;border-radius:0}
+ .tab:first-child{border-radius:5px 0 0 5px}
+ .tab:last-child{border-radius:0 5px 5px 0;border-left:none}
+ .tab.active{background:#2563eb;color:#fff;border-color:#2563eb;font-weight:bold}
+ .tabpanel{background:#eef6ff;border:1px solid #bfdbfe;border-top:none;
+   border-radius:0 0 6px 6px;padding:8px}
+ /* En-têtes d'étape du « Scénario Topologique » */
+ h2.step{font-size:13px;margin:12px 0 4px;color:#1e3a8a;
+   border-left:3px solid #2563eb;padding-left:6px}
+ .ibubble{cursor:help;color:#2563eb;font-weight:bold}
+ #dsSamples button{display:flex;flex-direction:column;align-items:center;line-height:1.15}
+ #dsSamples .stag{font-size:9px;color:#64748b}
+ .tab.active .stag{color:#dbeafe}
+ /* Petite modale (Recharger un scénario) */
+ .modal{position:fixed;inset:0;background:rgba(0,0,0,.35);display:flex;
+   align-items:center;justify-content:center;z-index:1000}
+ .modalbox{background:#fff;border-radius:8px;padding:16px 18px;min-width:300px;
+   max-width:90vw;box-shadow:0 8px 30px rgba(0,0,0,.25)}
+ .modalbox h3{margin:0 0 10px;font-size:14px}
 </style></head><body>
 <div id="side">
-  <div id="dsBox" style="display:none;background:#eef6ff;border:1px solid #bfdbfe;border-radius:6px;padding:8px;margin-bottom:8px">
-    <h2 style="margin-top:0">📅 Dataset RTE7000</h2>
-    <div style="font-size:11px;color:#555;margin-bottom:4px">Situation réseau France à une date/heure du dataset (téléchargée à la demande).</div>
+  <h2 style="margin-top:0">Situation réseau</h2>
+  <div class="tabs" role="tablist">
+    <button id="tabLocal" class="tab" onclick="selectTab('local')"
+            title="Charger une situation réseau depuis un fichier .xiidm local">📁 Local</button>
+    <button id="tabRte" class="tab" onclick="selectTab('rte')"
+            title="Charger une situation du dataset RTE 7000 (France) par date / heure">📅 RTE7000</button>
+  </div>
+
+  <div id="panelLocal" class="tabpanel">
+    <div style="display:flex;gap:4px">
+      <input id="gridPath" placeholder="chemin .xiidm (situation réseau)" style="flex:1;min-width:0;padding:5px"
+             title="Charge une situation réseau côté serveur, puis liste ses postes">
+      <button onclick="pickGridFile()" title="Parcourir le système de fichiers (sélecteur natif — usage local)">📂</button>
+    </div>
+    <div style="font-size:10px;color:#888;margin-top:2px">Fichier .xiidm côté serveur — 📂 pour parcourir (usage local).</div>
+    <div id="gridMsg" style="font-size:11px;color:#666;margin-top:3px"></div>
+  </div>
+
+  <div id="panelRte" class="tabpanel" style="display:none">
+    <div style="font-size:11px;color:#555;margin-bottom:4px">Situation réseau France à une date/heure du dataset
+      <span class="ibubble" id="dsRepoInfo" title="">RTE 7000&nbsp;ⓘ</span> (téléchargée à la demande).</div>
     <label style="font-size:12px;display:block">Date
       <input id="dsDate" type="date" style="width:100%;padding:5px" title="Jour du dataset (YYYY-MM-DD)">
     </label>
-    <div id="dsSamples" style="margin:4px 0;display:flex;flex-wrap:wrap;gap:4px"></div>
+    <div style="font-size:10px;color:#64748b;margin:4px 0 1px">⚡ Accès rapide — cas d'intérêt
+      <span class="ibubble" title="Journées « connues bonnes » de la documentation (campagne inter-saisons 2021). Survolez une date pour son intérêt.">ⓘ</span></div>
+    <div id="dsSamples" style="margin:0 0 4px;display:flex;flex-wrap:wrap;gap:4px"></div>
     <label style="font-size:12px;display:block;margin-top:2px">Heure (instantané, pas de 5 min)
       <select id="dsTime" style="width:100%;padding:5px" title="Horodatage de l'instantané (midi par défaut)"></select>
     </label>
-    <button class="primary" style="margin-top:6px;width:100%" onclick="loadDataset()">⏬ Charger la situation</button>
     <div id="dsMsg" style="font-size:11px;color:#666;margin-top:3px"></div>
   </div>
 
-  <h2>Situation réseau</h2>
-  <input id="gridPath" placeholder="chemin .xiidm (situation réseau)" style="width:72%;padding:5px"
-         title="Charge une autre situation réseau côté serveur, puis liste ses postes">
-  <button onclick="loadGrid()">Charger</button>
-  <div id="gridMsg" style="font-size:11px;color:#666;margin-top:3px"></div>
+  <button id="btnCharger" class="primary" style="width:100%;margin-top:6px"
+          onclick="chargerSituation()">⏬ Charger la situation</button>
 
-  <h2>Poste</h2>
-  <select id="poste" title="Postes épinglés (jeu de test + 3 jeux de barres identifiés)"></select>
+  <hr style="border:none;border-top:1px solid #d1d5db;margin:12px 0 6px">
+  <h2 style="margin:0;color:#1e3a8a">🗺 Scénario Topologique
+    <button onclick="openReload()" title="Recharger un scénario sauvegardé (départ + cible)"
+            style="float:right;padding:1px 8px;font-size:11px;margin:0;font-weight:normal">⟳ Recharger</button>
+  </h2>
+  <div style="font-size:10px;color:#888;margin:1px 0 0">Poste → topologie cible → séquence de manœuvres.</div>
+
+  <h2 class="step">1 · Poste</h2>
+  <input id="posteSearch" list="allPostes" placeholder="🔎 rechercher un poste (tous)…"
+         style="width:100%;padding:6px" autocomplete="off"
+         title="Rechercher / inspecter n'importe quel poste NODE_BREAKER de la situation chargée (postes épinglés ★ en tête de liste)">
+  <datalist id="allPostes"></datalist>
   <div style="margin-top:6px">
-    <select id="posteCat" title="Explorer les postes par typologie (sections). Les postes grisés ne sont pas dans la situation chargée — charger la grille France pour y accéder."
+    <select id="posteCat" title="Explorer les postes par typologie (sections) — liste curée. Les postes grisés ne sont pas dans la situation chargée — charger la grille France pour y accéder."
             style="width:100%;padding:6px"></select>
-    <div style="font-size:10px;color:#888;margin-top:2px">📂 par typologie — grisé = absent de la situation chargée</div>
+    <div style="font-size:10px;color:#888;margin-top:2px">📂 explorer par typologie — grisé = absent de la situation chargée</div>
   </div>
-  <div style="margin-top:6px">
-    <input id="posteSearch" list="allPostes" placeholder="🔎 rechercher un poste (tous)…"
-           style="width:100%;padding:6px" autocomplete="off"
-           title="Inspecter n'importe quel poste NODE_BREAKER de la situation chargée">
-    <datalist id="allPostes"></datalist>
-  </div>
-  <div style="margin-top:6px"><button onclick="reset()">↺ État de départ</button></div>
 
-  <h2>1 · Valider la cible</h2>
+  <h2 class="step">2 · Topologie cible</h2>
+  <div style="font-size:11px;color:#555;margin:1px 0 3px">Éditez la cible (clic sur un organe du schéma / volet nodal), puis validez-la.</div>
   <input id="scenName" placeholder="nom du scénario" style="width:62%;padding:5px">
   <button onclick="save()">✓ Valider &amp; sauvegarder</button>
   <div id="savemsg" style="font-size:11px;color:#1a7f37;margin-top:3px"></div>
 
-  <h2>2 · Séquence de manœuvres</h2>
+  <h2 class="step">3 · Séquence de manœuvres</h2>
   <div style="font-size:12px;margin:2px 0">Mode :
     <select id="seqMode" style="width:auto;padding:3px" title="Smooth : dé-énergise au plus près, en place (peu d'ouvrages hors tension à la fois). Agressif : dé-énergise en lot (moins de manœuvres, plus d'ouvrages hors tension simultanément).">
       <option value="smooth">Smooth (sûr, en place)</option>
@@ -145,23 +187,21 @@
   <button id="bmanual" onclick="manualSeq()" disabled title="Construire la séquence à la main : cliquez les organes du schéma (départ → …), la cible s'affiche en référence">✋ Séquence manuelle</button>
   <div id="calchint" style="font-size:11px;color:#b45309">Validez d'abord la cible pour activer le calcul.</div>
 
-  <h2>Scénarios sauvegardés</h2>
-  <select id="scenSel" style="width:100%"><option value="">—</option></select>
-  <div style="display:flex;gap:4px;margin-top:4px">
-    <button onclick="loadScen('both')" title="départ + cible sauvegardés">▷ Rejouer</button>
-    <button onclick="loadScen('as_depart')" title="la cible sauvegardée devient le nouvel état de départ">⇧ Comme départ</button>
-  </div>
   <h2>Nœuds électriques : <span id="nbn" class="badge">–</span></h2>
   <div style="font-size:11px;color:#555">Clic sur un organe du schéma pour basculer son état (départ ➜ cible).</div>
 </div>
 <div id="main">
   <div class="pane" id="paneTop">
     <div class="ttl"><button class="cbtn" onclick="togglePane('paneTop')" title="Réduire / agrandir">▾</button>
+      <button onclick="reset()" title="Réinitialiser la cible à l'état d'origine du poste"
+              style="float:right;padding:1px 8px;font-size:11px;margin:0;font-weight:normal">↺ État d'origine</button>
       <span id="ttlA">Topologie de départ</span> — <span id="nbA" class="badge">–</span> nœud(s)</div>
     <div class="diag" id="diagTop">Choisissez un poste…</div>
   </div>
   <div class="pane" id="paneBot">
     <div class="ttl"><button class="cbtn" onclick="togglePane('paneBot')" title="Réduire / agrandir">▾</button>
+      <button onclick="loadScen('as_depart')" title="La cible sélectionnée dans « Scénarios sauvegardés » devient le nouvel état de départ"
+              style="float:right;padding:1px 8px;font-size:11px;margin:0;font-weight:normal">⇧ Nouvelle Topologie Départ</button>
       Topologie cible (éditable, clic sur un organe) — <span id="nbB" class="badge">–</span> nœud(s)
         · animation de la séquence ici</div>
     <div class="diag" id="diagBottom"></div>
@@ -221,11 +261,50 @@
     <div id="nodstatus"></div>
   </div>
 </div>
+<div id="reloadModal" class="modal" style="display:none" onclick="if(event.target===this)closeReload()">
+  <div class="modalbox">
+    <h3>⟳ Recharger un scénario</h3>
+    <select id="scenSel" style="width:100%"><option value="">—</option></select>
+    <div style="font-size:10px;color:#888;margin-top:6px">« Valider » rejoue le scénario (départ + cible). Pour repartir de sa cible, utilisez « ⇧ Nouvelle Topologie Départ » sur le schéma cible.</div>
+    <div style="display:flex;gap:6px;justify-content:flex-end;margin-top:10px">
+      <button onclick="closeReload()">Annuler</button>
+      <button class="primary" onclick="validateReload()">Valider</button>
+    </div>
+  </div>
+</div>
 <script>
 let S={n:0,idx:0,timer:null,labels:[],algo:{},sel:new Set(),lastSel:null,manual:false,
-  editTarget:false,stale:false,currentVL:null};
-// État de la source « dataset RTE7000 » (bandeau de choix date/heure).
+  editTarget:false,stale:false,currentVL:null,tab:'local'};
+// État de la source « dataset RTE7000 » (onglet de choix date/heure).
 let DS={enabled:false,repo:'',defaultTime:'12:00'};
+// Cas d'intérêt documentés (campagne inter-saisons 2021, cf.
+// docs/dataset_rte7000/) : libellé court + intérêt, affichés en bulle sur les
+// puces d'accès rapide de l'onglet RTE7000.
+const DATE_INFO={
+  '2021-01-03':{tag:'dim. · hiver',desc:"Journée pilote, week-end calme : le MOINS de reconfigurations structurelles (36) — cas « simple » de référence."},
+  '2021-01-05':{tag:'mar. · hiver',desc:"Jour ouvré d'hiver : 123 reconfigurations structurelles, 2 011 postes actifs."},
+  '2021-04-14':{tag:'mer. · printemps',desc:"Mi-saison : 158 reconfigurations structurelles, charge modérée."},
+  '2021-07-15':{tag:'jeu. · été',desc:"Pointe estivale : le PLUS de postes actifs (2 096), 203 reconfigurations."},
+  '2021-10-12':{tag:'mar. · automne',desc:"Le PLUS de reconfigurations structurelles (208) — chantiers d'automne, cas « riche »."},
+};
+// --- Onglets « Situation réseau » (Local ⇄ RTE7000) -----------------------
+function selectTab(which){
+  const local=(which==='local');S.tab=local?'local':'rte';
+  document.getElementById('tabLocal').classList.toggle('active',local);
+  document.getElementById('tabRte').classList.toggle('active',!local);
+  document.getElementById('panelLocal').style.display=local?'block':'none';
+  document.getElementById('panelRte').style.display=local?'none':'block';}
+// Bouton « Charger » unique : aiguille vers l'onglet actif.
+function chargerSituation(){if(S.tab==='rte')loadDataset();else loadGrid();}
+// Sélecteur de fichier natif (onglet Local, usage local) : remplit le chemin.
+async function pickGridFile(){
+  const msg=document.getElementById('gridMsg');msg.textContent='Ouverture du sélecteur…';
+  let r;try{r=await (await fetch('/api/pick_grid_file')).json();}
+  catch(e){msg.textContent='sélecteur indisponible — collez le chemin manuellement.';return;}
+  if(r.error){msg.textContent='Sélecteur indisponible ('+r.error+') — collez le chemin.';return;}
+  if(r.path){document.getElementById('gridPath').value=r.path;
+    msg.textContent='Fichier sélectionné — cliquez « Charger la situation ».';}
+  else msg.textContent='';}
 // État de l'éditeur de topologie nodale (volet de droite).
 let NOD={depart:{groups:[]},departIso:[],labels:{},types:{},flows:{},dirs:{},order:{},
   colors:{},colorsCible:{},groups:[],isolated:[],selBranches:new Set(),selNodes:new Set()};
@@ -235,12 +314,19 @@ function setValidated(v){document.getElementById('bcalc').disabled=!v;
   document.getElementById('bmanual').disabled=!v;
   document.getElementById('calchint').style.display=v?'none':'block';}
 let ALL_POSTES=[];
+// Champ poste **unique** (recherche sur TOUS les postes de la situation) : le
+// menu épinglé d'autrefois est fusionné ici — les postes épinglés (★) sont
+// listés en tête de la datalist pour rester d'accès rapide ; l'explorateur
+// « par typologie » (liste curée) reste à part.
 function populatePostes(r){
   ALL_POSTES=r.all||r.postes||[];
-  const sel=document.getElementById('poste');sel.innerHTML='';
-  (r.postes||[]).forEach(p=>{const o=document.createElement('option');o.value=p;o.text=p;sel.add(o);});
+  const pinned=r.postes||[];
   const dl=document.getElementById('allPostes');dl.innerHTML='';
-  ALL_POSTES.forEach(p=>{const o=document.createElement('option');o.value=p;dl.appendChild(o);});
+  const seen=new Set();
+  const addOpt=(p,label)=>{if(seen.has(p))return;seen.add(p);
+    const o=document.createElement('option');o.value=p;if(label)o.label=label;dl.appendChild(o);};
+  pinned.forEach(p=>addOpt(p,'★ épinglé'));
+  ALL_POSTES.forEach(p=>addOpt(p));
   populateCatalog(r.catalog||[]);}
 // Sélecteur « par typologie » : un <optgroup> par section ; postes absents de la
 // situation chargée grisés (option disabled).
@@ -275,29 +361,37 @@ function fillAlgoSel(id,phase,r){
   sel.title=sel.disabled?sel.title+' (un seul algorithme disponible)':sel.title;}
 async function init(){const r=await (await fetch('/api/postes')).json();
   populatePostes(r);await refreshAlgos();
-  const sel=document.getElementById('poste');sel.onchange=()=>load(sel.value);
   const cs=document.getElementById('posteCat');cs.onchange=()=>{if(cs.value)load(cs.value);};
-  // Recherche « tous postes » : datalist de tous les VL NODE_BREAKER de la situation.
+  // Champ poste unique : datalist de tous les VL NODE_BREAKER de la situation
+  // (postes épinglés ★ en tête). Charge au choix (Entrée ou sélection).
   const search=document.getElementById('posteSearch');
   const go=()=>{const v=search.value.trim();if(v&&ALL_POSTES.includes(v))load(v);};
   search.onchange=go;search.addEventListener('keydown',e=>{if(e.key==='Enter')go();});
   initNodalResize(); initNodalDnD(); await refreshScenarios(); await initDataset();
-  if(r.postes.length) load(r.postes[0]);}
-// ---- Source « dataset RTE7000 » : choisir une date/heure, charger la situation ----
+  if(r.postes&&r.postes.length) load(r.postes[0]);}
+// ---- Onglet « RTE7000 » : choisir une date/heure, charger la situation -------
+// L'onglet est **toujours présent** (Local d'abord, RTE7000 ensuite) ; le drapeau
+// ``enabled`` du backend ne décide que de l'**onglet actif par défaut** (RTE7000
+// « en avant » sur le Space, Local en usage local). Les endpoints dataset
+// fonctionnent dans les deux modes (accès HuggingFace à la demande).
 async function initDataset(){
-  let cfg;try{cfg=await (await fetch('/api/dataset/config')).json();}catch(e){return;}
-  if(!cfg||!cfg.enabled)return;   // mode local (--grid) : bandeau masqué
-  DS.enabled=true;DS.repo=cfg.repo;DS.defaultTime=cfg.default_time||'12:00';
-  document.getElementById('dsBox').style.display='block';
-  const di=document.getElementById('dsDate');di.value=cfg.default_date||'';
-  di.onchange=()=>loadDatasetTimestamps(di.value);
-  const sm=document.getElementById('dsSamples');sm.innerHTML='';
-  (cfg.sample_dates||[]).forEach(d=>{const b=document.createElement('button');
-    b.textContent=d;b.style.cssText='padding:2px 6px;font-size:11px;margin:0';
-    b.onclick=()=>{di.value=d;loadDatasetTimestamps(d);};sm.appendChild(b);});
-  if(!S.currentVL){const t=document.getElementById('diagTop');
-    if(t)t.textContent='Choisissez une date puis « Charger la situation »…';}
-  await loadDatasetTimestamps(di.value);}
+  let cfg;try{cfg=await (await fetch('/api/dataset/config')).json();}catch(e){cfg=null;}
+  if(cfg){DS.enabled=!!cfg.enabled;DS.repo=cfg.repo||'';DS.defaultTime=cfg.default_time||'12:00';
+    const di=document.getElementById('dsDate');di.value=cfg.default_date||'';
+    di.onchange=()=>loadDatasetTimestamps(di.value);
+    const info=document.getElementById('dsRepoInfo');
+    if(info)info.title='Dataset HuggingFace : '+(cfg.repo||'OpenSynth/D-GITT-RTE7000-*')
+      +' — réseau France, 1 instantané / 5 min, téléchargé à la demande.';
+    const sm=document.getElementById('dsSamples');sm.innerHTML='';
+    (cfg.sample_dates||[]).forEach(d=>{const meta=DATE_INFO[d]||{tag:'',desc:'Journée du dataset.'};
+      const b=document.createElement('button');b.style.cssText='padding:2px 6px;font-size:11px;margin:0';
+      b.title=d+' — '+meta.desc;
+      b.innerHTML=xesc(d)+(meta.tag?'<span class="stag">'+xesc(meta.tag)+'</span>':'');
+      b.onclick=()=>{di.value=d;loadDatasetTimestamps(d);};sm.appendChild(b);});
+    await loadDatasetTimestamps(di.value);}
+  selectTab(DS.enabled?'rte':'local');   // RTE7000 « en avant » sur le Space
+  if(DS.enabled&&!S.currentVL){const t=document.getElementById('diagTop');
+    if(t)t.textContent='Choisissez une date puis « Charger la situation »…';}}
 async function loadDatasetTimestamps(date){
   const sel=document.getElementById('dsTime'),msg=document.getElementById('dsMsg');
   sel.innerHTML='';if(!date)return;
@@ -333,8 +427,7 @@ async function loadGrid(){
   msg.textContent=`✓ ${r.postes.length} postes épinglés, ${(r.all||[]).length} postes NODE_BREAKER`;
   if(r.postes.length)load(r.postes[0]);else if(ALL_POSTES.length)load(ALL_POSTES[0]);}
 async function load(vl){stopAnim();S.currentVL=vl;const d=await api('/api/load',{vl});show(d);initNodale(d);hideSeq();setValidated(false);
-  document.getElementById('poste').value=vl;            // sync menu épinglé (vide si non listé)
-  document.getElementById('posteSearch').value=vl;      // sync champ de recherche
+  document.getElementById('posteSearch').value=vl;      // sync champ poste unique
   document.getElementById('scenName').value=vl+'_cible';}
 async function reset(){stopAnim();const d=await api('/api/reset',{});show(d);
   syncNodalCible(d.nodale);hideSeq();setValidated(false);}
@@ -383,6 +476,14 @@ function syncNodalCible(n){if(!n)return;
 async function refreshScenarios(){const r=await (await fetch('/api/scenarios')).json();
   const sel=document.getElementById('scenSel');sel.innerHTML='<option value="">—</option>';
   r.scenarios.forEach(s=>{const o=document.createElement('option');o.value=s;o.text=s;sel.add(o);});}
+// Modale « Recharger un scénario » (remplace l'ancienne section « Scénarios
+// sauvegardés ») : rafraîchit la liste puis ouvre ; « Valider » rejoue le
+// scénario (départ + cible), « Annuler » referme sans rien recharger.
+async function openReload(){await refreshScenarios();
+  document.getElementById('reloadModal').style.display='flex';}
+function closeReload(){document.getElementById('reloadModal').style.display='none';}
+async function validateReload(){const name=document.getElementById('scenSel').value;
+  if(name)await loadScen('both');closeReload();}
 async function saveWithConfirm(url,name,msgEl){
   let r=await api(url,{name});
   while(r.exists){
@@ -403,7 +504,7 @@ async function save(){const name=document.getElementById('scenName').value;
   setValidated(true);await refreshScenarios();}
 async function loadScen(mode){const name=document.getElementById('scenSel').value;if(!name)return;
   stopAnim();const d=await api('/api/load_scenario',{name,mode});
-  document.getElementById('poste').value=d.vl;show(d);initNodale(d);hideSeq();
+  document.getElementById('posteSearch').value=d.vl;show(d);initNodale(d);hideSeq();
   if(mode==='as_depart'){
     document.getElementById('scenName').value=name+'_suite';
     document.getElementById('savemsg').textContent='« '+name+' » chargé comme état de départ — éditez puis validez une nouvelle cible.';

--- a/scripts/manoeuvre_ihm_assets/index.html
+++ b/scripts/manoeuvre_ihm_assets/index.html
@@ -91,6 +91,20 @@
  #nodstatus.kov{color:#92400e;background:#fffbeb}
 </style></head><body>
 <div id="side">
+  <div id="dsBox" style="display:none;background:#eef6ff;border:1px solid #bfdbfe;border-radius:6px;padding:8px;margin-bottom:8px">
+    <h2 style="margin-top:0">📅 Dataset RTE7000</h2>
+    <div style="font-size:11px;color:#555;margin-bottom:4px">Situation réseau France à une date/heure du dataset (téléchargée à la demande).</div>
+    <label style="font-size:12px;display:block">Date
+      <input id="dsDate" type="date" style="width:100%;padding:5px" title="Jour du dataset (YYYY-MM-DD)">
+    </label>
+    <div id="dsSamples" style="margin:4px 0;display:flex;flex-wrap:wrap;gap:4px"></div>
+    <label style="font-size:12px;display:block;margin-top:2px">Heure (instantané, pas de 5 min)
+      <select id="dsTime" style="width:100%;padding:5px" title="Horodatage de l'instantané (midi par défaut)"></select>
+    </label>
+    <button class="primary" style="margin-top:6px;width:100%" onclick="loadDataset()">⏬ Charger la situation</button>
+    <div id="dsMsg" style="font-size:11px;color:#666;margin-top:3px"></div>
+  </div>
+
   <h2>Situation réseau</h2>
   <input id="gridPath" placeholder="chemin .xiidm (situation réseau)" style="width:72%;padding:5px"
          title="Charge une autre situation réseau côté serveur, puis liste ses postes">
@@ -209,7 +223,9 @@
 </div>
 <script>
 let S={n:0,idx:0,timer:null,labels:[],algo:{},sel:new Set(),lastSel:null,manual:false,
-  editTarget:false,stale:false};
+  editTarget:false,stale:false,currentVL:null};
+// État de la source « dataset RTE7000 » (bandeau de choix date/heure).
+let DS={enabled:false,repo:'',defaultTime:'12:00'};
 // État de l'éditeur de topologie nodale (volet de droite).
 let NOD={depart:{groups:[]},departIso:[],labels:{},types:{},flows:{},dirs:{},order:{},
   colors:{},colorsCible:{},groups:[],isolated:[],selBranches:new Set(),selNodes:new Set()};
@@ -265,7 +281,47 @@ async function init(){const r=await (await fetch('/api/postes')).json();
   const search=document.getElementById('posteSearch');
   const go=()=>{const v=search.value.trim();if(v&&ALL_POSTES.includes(v))load(v);};
   search.onchange=go;search.addEventListener('keydown',e=>{if(e.key==='Enter')go();});
-  initNodalResize(); initNodalDnD(); await refreshScenarios(); if(r.postes.length) load(r.postes[0]);}
+  initNodalResize(); initNodalDnD(); await refreshScenarios(); await initDataset();
+  if(r.postes.length) load(r.postes[0]);}
+// ---- Source « dataset RTE7000 » : choisir une date/heure, charger la situation ----
+async function initDataset(){
+  let cfg;try{cfg=await (await fetch('/api/dataset/config')).json();}catch(e){return;}
+  if(!cfg||!cfg.enabled)return;   // mode local (--grid) : bandeau masqué
+  DS.enabled=true;DS.repo=cfg.repo;DS.defaultTime=cfg.default_time||'12:00';
+  document.getElementById('dsBox').style.display='block';
+  const di=document.getElementById('dsDate');di.value=cfg.default_date||'';
+  di.onchange=()=>loadDatasetTimestamps(di.value);
+  const sm=document.getElementById('dsSamples');sm.innerHTML='';
+  (cfg.sample_dates||[]).forEach(d=>{const b=document.createElement('button');
+    b.textContent=d;b.style.cssText='padding:2px 6px;font-size:11px;margin:0';
+    b.onclick=()=>{di.value=d;loadDatasetTimestamps(d);};sm.appendChild(b);});
+  if(!S.currentVL){const t=document.getElementById('diagTop');
+    if(t)t.textContent='Choisissez une date puis « Charger la situation »…';}
+  await loadDatasetTimestamps(di.value);}
+async function loadDatasetTimestamps(date){
+  const sel=document.getElementById('dsTime'),msg=document.getElementById('dsMsg');
+  sel.innerHTML='';if(!date)return;
+  msg.textContent='Liste des instantanés…';
+  let r;try{r=await (await fetch('/api/dataset/timestamps?date='+encodeURIComponent(date))).json();}
+  catch(e){msg.textContent='erreur réseau (HuggingFace)';return;}
+  if(!r||!r.ok){msg.textContent=(r&&r.error)||'aucun instantané pour cette date';return;}
+  (r.timestamps||[]).forEach(t=>{const o=document.createElement('option');o.value=t.ts;o.text=t.ts;sel.add(o);});
+  if(r.default)sel.value=r.default;
+  msg.textContent=(r.timestamps||[]).length+' instantané(s) — '+(r.default||'midi')+' présélectionné';}
+async function loadDataset(){
+  const date=document.getElementById('dsDate').value;
+  const time=document.getElementById('dsTime').value||DS.defaultTime;
+  const msg=document.getElementById('dsMsg');
+  if(!date){msg.textContent='choisir une date';return;}
+  msg.textContent='Chargement '+date+' '+time+' … (téléchargement + réseau France, quelques secondes)';
+  let r;try{r=await api('/api/dataset/load',{date,time});}catch(e){msg.textContent='erreur réseau';return;}
+  if(!r||!r.ok){msg.textContent=(r&&r.error)||'échec du chargement';return;}
+  populatePostes(r);await refreshAlgos();await refreshScenarios();
+  msg.textContent='✓ '+r.date+' '+r.time+' — '+(r.all||[]).length+' postes NODE_BREAKER';
+  // Préserver le poste courant si encore présent à la nouvelle date, sinon premier.
+  const keep=(S.currentVL&&(r.all||[]).includes(S.currentVL))?S.currentVL
+            :((r.postes&&r.postes.length)?r.postes[0]:((r.all||[])[0]));
+  if(keep)load(keep);}
 // Charger une **situation réseau** quelconque (chemin .xiidm côté serveur).
 async function loadGrid(){
   const path=document.getElementById('gridPath').value.trim();if(!path)return;
@@ -276,7 +332,7 @@ async function loadGrid(){
   populatePostes(r);await refreshAlgos();   // nouvelle session => sélection d'algos réinitialisée
   msg.textContent=`✓ ${r.postes.length} postes épinglés, ${(r.all||[]).length} postes NODE_BREAKER`;
   if(r.postes.length)load(r.postes[0]);else if(ALL_POSTES.length)load(ALL_POSTES[0]);}
-async function load(vl){stopAnim();const d=await api('/api/load',{vl});show(d);initNodale(d);hideSeq();setValidated(false);
+async function load(vl){stopAnim();S.currentVL=vl;const d=await api('/api/load',{vl});show(d);initNodale(d);hideSeq();setValidated(false);
   document.getElementById('poste').value=vl;            // sync menu épinglé (vide si non listé)
   document.getElementById('posteSearch').value=vl;      // sync champ de recherche
   document.getElementById('scenName').value=vl+'_cible';}

--- a/scripts/manoeuvre_ihm_assets/index.html
+++ b/scripts/manoeuvre_ihm_assets/index.html
@@ -187,8 +187,6 @@
   <button id="bmanual" onclick="manualSeq()" disabled title="Construire la séquence à la main : cliquez les organes du schéma (départ → …), la cible s'affiche en référence">✋ Séquence manuelle</button>
   <div id="calchint" style="font-size:11px;color:#b45309">Validez d'abord la cible pour activer le calcul.</div>
 
-  <h2>Nœuds électriques : <span id="nbn" class="badge">–</span></h2>
-  <div style="font-size:11px;color:#555">Clic sur un organe du schéma pour basculer son état (départ ➜ cible).</div>
 </div>
 <div id="main">
   <div class="pane" id="paneTop">
@@ -445,7 +443,6 @@ async function toggleEditTarget(){
     const d=await api('/api/cible',{});
     document.getElementById('diagBottom').innerHTML=d.svg;
     document.getElementById('nbB').textContent=d.nb_noeuds;
-    document.getElementById('nbn').textContent=d.nb_noeuds;
     bind(d.switches);syncNodalCible(d.nodale);
     document.getElementById('paneBot').classList.remove('reached');
     b.textContent='▶ Revenir à la séquence';b.classList.add('primary');
@@ -524,7 +521,6 @@ function show(d){
     document.getElementById('ttlA').textContent='Topologie de départ';S.manual=false;}
   document.getElementById('diagBottom').innerHTML=d.svg;
   document.getElementById('nbB').textContent=d.nb_noeuds;
-  document.getElementById('nbn').textContent=d.nb_noeuds;
   bind(d.switches);}
 function bind(switches){const root=document.getElementById('diagBottom');
   switches.forEach(s=>{const el=root.querySelector('[id="'+s.svgId+'"]');
@@ -847,7 +843,6 @@ async function nodCompute(){
   // Charger la topologie détaillée d'intérêt comme cible (volet du bas).
   document.getElementById('diagBottom').innerHTML=d.svg;
   document.getElementById('nbB').textContent=d.nb_noeuds;
-  document.getElementById('nbn').textContent=d.nb_noeuds;
   bind(d.switches);hideSeq();setValidated(false);
   // Resynchroniser la cible nodale sur la topologie détaillée RÉALISÉE
   // (partition + couleurs + isolés des nœuds obtenus).

--- a/scripts/manoeuvre_ihm_assets/index.html
+++ b/scripts/manoeuvre_ihm_assets/index.html
@@ -175,7 +175,8 @@
   <h2 class="step">1 · Poste</h2>
   <input id="posteSearch" placeholder="🔎 rechercher un poste (tous)…"
          style="width:100%;padding:6px" autocomplete="off"
-         title="Rechercher n'importe quel poste NODE_BREAKER de la situation chargée. Vide : exploration curée par typologie (postes épinglés ★ en tête).">
+         title="Rechercher n'importe quel poste NODE_BREAKER de la situation chargée. Vide : pré-sélection de postes typiques par typologie.">
+  <div id="posteListTitle" style="font-size:11px;font-weight:bold;color:#475569;margin:5px 0 1px">📂 Pré-sélection de postes typiques</div>
   <div id="posteList"></div>
   <div style="font-size:10px;color:#888;margin-top:2px">🔎 recherche sur tous les postes · 📂 vide = exploration curée par typologie (grisé = absent)</div>
 
@@ -372,6 +373,10 @@ function _posteItem(vl,pinned,available){
 function renderPosteList(query){
   const root=document.getElementById('posteList');if(!root)return;root.innerHTML='';
   const q=(query||'').trim().toLowerCase();
+  // Le titre « Pré-sélection de postes typiques » ne concerne que la vue curée
+  // (champ vide) ; masqué pendant une recherche.
+  const title=document.getElementById('posteListTitle');
+  if(title)title.style.display=q?'none':'block';
   if(q){   // recherche plein-texte sur TOUS les postes de la situation
     const pin=new Set(PINNED);
     const hits=ALL_POSTES.filter(p=>p.toLowerCase().includes(q));
@@ -414,7 +419,16 @@ async function init(){const r=await (await fetch('/api/postes')).json();
   search.addEventListener('keydown',e=>{if(e.key==='Enter'){
     const v=search.value.trim();if(v&&ALL_POSTES.includes(v))load(v);}});
   initNodalResize(); initNodalDnD(); await refreshScenarios(); await initDataset();
-  if(r.postes&&r.postes.length) load(r.postes[0]);}
+  // Pas d'auto-chargement de poste : on attend que l'utilisateur en choisisse un
+  // (le schéma reste sur « Choisissez un poste… » tant qu'aucun n'est sélectionné).
+  if(r.postes&&r.postes.length){const t=document.getElementById('diagTop');
+    if(t&&!DS.enabled)t.textContent='Choisissez un poste…';}}
+// Réinitialise les vues quand aucun poste n'est encore choisi (après chargement
+// d'une situation, en attente du choix de poste).
+function awaitPosteChoice(){S.currentVL=null;
+  const t=document.getElementById('diagTop');if(t)t.textContent='Choisissez un poste…';
+  const b=document.getElementById('diagBottom');if(b)b.innerHTML='';
+  renderPosteList((document.getElementById('posteSearch')||{}).value||'');}
 // ---- Onglet « RTE7000 » : choisir une date/heure, charger la situation -------
 // L'onglet est **toujours présent** (Local d'abord, RTE7000 ensuite) ; le drapeau
 // ``enabled`` du backend ne décide que de l'**onglet actif par défaut** (RTE7000
@@ -459,10 +473,10 @@ async function loadDataset(){
   if(!r||!r.ok){msg.textContent=(r&&r.error)||'échec du chargement';return;}
   populatePostes(r);await refreshAlgos();await refreshScenarios();
   msg.textContent='✓ '+r.date+' '+r.time+' — '+(r.all||[]).length+' postes NODE_BREAKER';
-  // Préserver le poste courant si encore présent à la nouvelle date, sinon premier.
-  const keep=(S.currentVL&&(r.all||[]).includes(S.currentVL))?S.currentVL
-            :((r.postes&&r.postes.length)?r.postes[0]:((r.all||[])[0]));
-  if(keep)load(keep);}
+  // Préserver le poste courant s'il existe encore (changement de date) ; sinon
+  // **ne pas** auto-charger — attendre que l'utilisateur choisisse un poste.
+  if(S.currentVL&&(r.all||[]).includes(S.currentVL))load(S.currentVL);
+  else awaitPosteChoice();}
 // Charger une **situation réseau** quelconque (chemin .xiidm côté serveur).
 async function loadGrid(){
   const path=document.getElementById('gridPath').value.trim();if(!path)return;
@@ -472,7 +486,7 @@ async function loadGrid(){
   if(!r||!r.ok){msg.textContent=(r&&r.error)||'échec du chargement';return;}
   populatePostes(r);await refreshAlgos();   // nouvelle session => sélection d'algos réinitialisée
   msg.textContent=`✓ ${r.postes.length} postes épinglés, ${(r.all||[]).length} postes NODE_BREAKER`;
-  if(r.postes.length)load(r.postes[0]);else if(ALL_POSTES.length)load(ALL_POSTES[0]);}
+  awaitPosteChoice();}   // pas d'auto-chargement : l'utilisateur choisit un poste
 async function load(vl){stopAnim();S.currentVL=vl;const d=await api('/api/load',{vl});show(d);initNodale(d);hideSeq();setValidated(false);
   renderPosteList((document.getElementById('posteSearch')||{}).value||'');  // surligne le poste courant
   document.getElementById('scenName').value=vl+'_cible';}

--- a/scripts/manoeuvre_ihm_assets/index.html
+++ b/scripts/manoeuvre_ihm_assets/index.html
@@ -150,7 +150,7 @@
       <input id="dsDate" type="date" style="width:100%;padding:5px" title="Jour du dataset (YYYY-MM-DD)">
     </label>
     <div style="font-size:10px;color:#64748b;margin:4px 0 1px">⚡ Accès rapide — cas d'intérêt
-      <span class="ibubble" title="Journées « connues bonnes » de la documentation (campagne inter-saisons 2021). Survolez une date pour son intérêt.">ⓘ</span></div>
+      <span class="ibubble" title="Journées identifiées intéressantes de la documentation (campagne RTE 7000, 2021-2023). Survolez une date pour son intérêt.">ⓘ</span></div>
     <div id="dsSamples" style="margin:0 0 4px;display:flex;flex-wrap:wrap;gap:4px"></div>
     <label style="font-size:12px;display:block;margin-top:2px">Heure (instantané, pas de 5 min)
       <select id="dsTime" style="width:100%;padding:5px" title="Horodatage de l'instantané (midi par défaut)"></select>
@@ -283,16 +283,19 @@ let S={n:0,idx:0,timer:null,labels:[],algo:{},sel:new Set(),lastSel:null,manual:
   editTarget:false,stale:false,currentVL:null,tab:'local'};
 // État de la source « dataset RTE7000 » (onglet de choix date/heure).
 let DS={enabled:false,repo:'',defaultTime:'12:00'};
-// Cas d'intérêt documentés — repris de la « Table de campagne »
-// (docs/dataset_rte7000/#table-de-campagne-campagnecampagnejson) :
+// Cas d'intérêt documentés — repris de la « Table de campagne » (3 ans
+// 2021-2023, docs/dataset_rte7000/#table-de-campagne-campagnecampagnejson) :
 // jour · saison + blocs / postes actifs / reconfigurations structurelles,
-// affichés en bulle sur les puces d'accès rapide de l'onglet RTE7000.
+// affichés en bulle sur les puces d'accès rapide de l'onglet RTE7000. L'année
+// de la date détermine le dataset HuggingFace interrogé (repo -YYYY).
 const DATE_INFO={
   '2021-01-03':{tag:'dim. · hiver',desc:"Dimanche, hiver — 6 233 blocs, 1 861 postes actifs, 36 reconfigurations structurelles (le MINIMUM) : week-end calme, cas « simple » de référence (journée pilote)."},
   '2021-01-05':{tag:'mar. · hiver',desc:"Mardi, hiver — 6 554 blocs, 2 011 postes actifs, 123 reconfigurations structurelles : jour ouvré d'hiver."},
   '2021-04-14':{tag:'mer. · printemps',desc:"Mercredi, printemps — 7 216 blocs, 2 024 postes actifs, 158 reconfigurations structurelles : mi-saison."},
   '2021-07-15':{tag:'jeu. · été',desc:"Jeudi, été — 7 127 blocs, 2 096 postes actifs (le PLUS), 203 reconfigurations structurelles : pointe estivale."},
   '2021-10-12':{tag:'mar. · automne',desc:"Mardi, automne — 6 760 blocs, 2 056 postes actifs, 208 reconfigurations structurelles (le MAXIMUM) : chantiers d'automne, cas « riche »."},
+  '2022-06-15':{tag:'mer. · été',desc:"Mercredi, été — 6 400 blocs, 2 037 postes actifs, 181 reconfigurations structurelles : autre année (dataset 2022)."},
+  '2023-02-08':{tag:'mer. · hiver',desc:"Mercredi, hiver — 6 442 blocs, 1 984 postes actifs, 185 reconfigurations structurelles, jusqu'à 38 organes manœuvrés (le plus profond) : autre année (dataset 2023)."},
 };
 // --- Onglets « Situation réseau » (Local ⇄ RTE7000) -----------------------
 function selectTab(which){
@@ -354,13 +357,12 @@ function renderPosteList(query){
       d.textContent='… '+(hits.length-POSTE_CAP)+' autres — affinez la recherche.';
       root.appendChild(d);}
     return;}
-  // vide : exploration curée (épinglés + sections par typologie)
-  if(PINNED.length){root.appendChild(_posteSec('★ Postes épinglés'));
-    PINNED.forEach(p=>root.appendChild(_posteItem(p,true,true)));}
+  // vide : exploration curée par typologie (les postes épinglés ★ restent
+  // repérables dans les résultats de recherche, sans section dédiée).
   CATALOG.forEach(sec=>{
     root.appendChild(_posteSec(sec.title+'  ('+sec.n_available+'/'+sec.postes.length+')'));
     sec.postes.forEach(p=>root.appendChild(_posteItem(p.vl,false,p.available)));});
-  if(!PINNED.length&&!CATALOG.length)
+  if(!CATALOG.length)
     root.innerHTML='<div class="empty">Aucun poste — charger une situation.</div>';}
 // Sélecteurs d'algorithme pluggable (manoeuvre.plugins) : phase A (nodale →
 // détaillée, volet nodal) et phase B (séquencement, panneau latéral). Les

--- a/scripts/manoeuvre_ihm_assets/index.html
+++ b/scripts/manoeuvre_ihm_assets/index.html
@@ -57,7 +57,10 @@
  #nodal.collapsed .nbody{display:none}
  #nodal .nhead{font-size:12px;font-weight:bold;padding:6px 8px;background:#ecfdf5;border-bottom:1px solid #ccc;display:flex;align-items:center;gap:6px}
  #nodal .nsec{display:flex;flex-direction:column;min-height:0;border-bottom:2px solid #d1fae5}
- #nodal .nsec .stitle{font-size:11px;font-weight:bold;padding:4px 8px;color:#065f46;display:flex;justify-content:space-between}
+ #nodal .nsec.collapsed{flex:0 0 auto !important}
+ /* !important : renderIso pose un display:block inline qu'il faut surclasser */
+ #nodal .nsec.collapsed > :not(.stitle){display:none !important}
+ #nodal .nsec .stitle{font-size:11px;font-weight:bold;padding:4px 8px;color:#065f46;display:flex;align-items:center;justify-content:space-between}
  #nodal .nbody{flex:1;overflow:auto;padding:4px}
  #nodal .ntools{padding:4px 8px;display:flex;flex-wrap:wrap;gap:4px;background:#fff;border-bottom:1px solid #e5e7eb}
  #nodal .ntools button{padding:3px 7px;font-size:11px;margin:0}
@@ -77,8 +80,9 @@
  .nbus.droptarget .nbushit{fill:rgba(99,102,241,.13)}
  .nbus.droptarget .nbusbar{stroke-dasharray:5 3}
  body.ndndrag,body.ndndrag *{cursor:grabbing !important}
- /* Ouvrages isolés (déconnectés) : liste compacte, pas de nœud électrique */
- .nodiso{flex:0 0 auto;padding:3px 8px 6px;border-top:1px dashed #e2e8f0;background:#fffdf7}
+ /* Ouvrages isolés (déconnectés) : liste compacte en TÊTE de cadre (pas de nœud
+    électrique) — chips individuellement sélectionnables / glissables sur un nœud */
+ .nodiso{flex:0 0 auto;padding:4px 8px 5px;border-bottom:1px dashed #e2e8f0;background:#fffdf7}
  .nodiso .isohd{font-size:10px;color:#b45309;font-weight:bold;margin:2px 0}
  .nodiso.ro{background:#f8fafc}
  .nodiso.ro .isohd{color:#64748b}
@@ -248,12 +252,15 @@
     Topologie nodale</div>
   <div class="nbody" style="display:flex;flex-direction:column;flex:1;min-height:0;overflow:hidden">
     <div class="nsec" style="flex:1">
-      <div class="stitle"><span>Départ</span><span class="badge" id="ndDepN">–</span></div>
-      <div class="nbody" id="ndDepart"></div>
+      <div class="stitle"><button class="cbtn" onclick="toggleNsec(this)" title="Replier / déplier">▾</button>
+        <span style="flex:1">Départ</span><span class="badge" id="ndDepN">–</span></div>
       <div class="nodiso ro" id="ndDepartIso" style="display:none"></div>
+      <div class="nbody" id="ndDepart"></div>
     </div>
     <div class="nsec" style="flex:2">
-      <div class="stitle"><span id="ndCibTitle">Cible (éditable)</span><span class="badge" id="ndCibN">–</span></div>
+      <div class="stitle"><button class="cbtn" onclick="toggleNsec(this)" title="Replier / déplier">▾</button>
+        <span id="ndCibTitle" style="flex:1">Cible (éditable)</span><span class="badge" id="ndCibN">–</span></div>
+      <div class="nodiso ed" id="ndCibleIso" style="display:none"></div>
       <div class="ntools">
         <button onclick="nodNewNode()" title="Créer un nœud vide (puis y glisser des départs ; ou avec la sélection courante)">＋ Nœud</button>
         <button onclick="nodReset()" title="Réinitialiser la cible (nodale + détaillée) à la topologie d'origine du poste (départ)">↺ Réinitialiser</button>
@@ -261,7 +268,6 @@
       </div>
       <div style="font-size:10px;color:#64748b;padding:0 8px">Glisser un <b>départ</b> (ou une sélection : clic pour (dé)sélectionner) sur une autre barre = réaiguillage. Glisser une <b>barre</b> sur une autre = fusion. Flux en MW (état de départ).</div>
       <div class="nbody" id="ndCible"></div>
-      <div class="nodiso ed" id="ndCibleIso" style="display:none"></div>
     </div>
     <div style="font-size:11px;color:#555;margin:4px 8px 0">Algo :
       <select id="nodAlgo" style="width:auto;padding:2px" title="Algorithme d'identification de la topologie détaillée depuis la cible nodale (phase A de manoeuvre.plugins) : « libtopo » natif + plugins enregistrés."></select>
@@ -707,6 +713,9 @@ function toggleNodal(){const p=document.getElementById('nodal');
   if(p.classList.toggle('collapsed')){p.dataset.w=p.style.width||'';p.style.width='';}
   else if(p.dataset.w){p.style.width=p.dataset.w;}
   const b=p.querySelector('.cbtn');if(b)b.textContent=p.classList.contains('collapsed')?'▸':'◂';}
+// Replier / déplier une section nodale (Départ / Cible) — l'autre prend l'espace.
+function toggleNsec(btn){const sec=btn.closest('.nsec');if(!sec)return;
+  btn.textContent=sec.classList.toggle('collapsed')?'▸':'▾';}
 function initNodalResize(){const rz=document.getElementById('ndresize');
   const nod=document.getElementById('nodal');let drag=false;
   rz.addEventListener('mousedown',e=>{if(nod.classList.contains('collapsed'))return;

--- a/scripts/manoeuvre_ihm_assets/index.html
+++ b/scripts/manoeuvre_ihm_assets/index.html
@@ -111,6 +111,18 @@
  .modalbox{background:#fff;border-radius:8px;padding:16px 18px;min-width:300px;
    max-width:90vw;box-shadow:0 8px 30px rgba(0,0,0,.25)}
  .modalbox h3{margin:0 0 10px;font-size:14px}
+ /* Liste de postes unifiée (recherche + exploration curée par typologie) */
+ #posteList{max-height:240px;overflow:auto;border:1px solid #cbd5e1;border-radius:5px;
+   background:#fff;margin-top:4px}
+ #posteList .sec{font-size:10px;font-weight:bold;color:#475569;background:#f1f5f9;
+   padding:3px 8px;position:sticky;top:0}
+ #posteList .it{padding:3px 10px;cursor:pointer;font-size:12px;white-space:nowrap;
+   overflow:hidden;text-overflow:ellipsis}
+ #posteList .it:hover{background:#eef2ff}
+ #posteList .it.cur{background:#dbeafe;font-weight:bold}
+ #posteList .it.off{color:#9ca3af;cursor:not-allowed}
+ #posteList .it .pin{color:#d97706}
+ #posteList .empty{padding:6px 10px;font-size:11px;color:#888}
 </style></head><body>
 <div id="side">
   <h2 style="margin-top:0">Situation réseau</h2>
@@ -157,15 +169,11 @@
   <div style="font-size:10px;color:#888;margin:1px 0 0">Poste → topologie cible → séquence de manœuvres.</div>
 
   <h2 class="step">1 · Poste</h2>
-  <input id="posteSearch" list="allPostes" placeholder="🔎 rechercher un poste (tous)…"
+  <input id="posteSearch" placeholder="🔎 rechercher un poste (tous)…"
          style="width:100%;padding:6px" autocomplete="off"
-         title="Rechercher / inspecter n'importe quel poste NODE_BREAKER de la situation chargée (postes épinglés ★ en tête de liste)">
-  <datalist id="allPostes"></datalist>
-  <div style="margin-top:6px">
-    <select id="posteCat" title="Explorer les postes par typologie (sections) — liste curée. Les postes grisés ne sont pas dans la situation chargée — charger la grille France pour y accéder."
-            style="width:100%;padding:6px"></select>
-    <div style="font-size:10px;color:#888;margin-top:2px">📂 explorer par typologie — grisé = absent de la situation chargée</div>
-  </div>
+         title="Rechercher n'importe quel poste NODE_BREAKER de la situation chargée. Vide : exploration curée par typologie (postes épinglés ★ en tête).">
+  <div id="posteList"></div>
+  <div style="font-size:10px;color:#888;margin-top:2px">🔎 recherche sur tous les postes · 📂 vide = exploration curée par typologie (grisé = absent)</div>
 
   <h2 class="step">2 · Topologie cible</h2>
   <div style="font-size:11px;color:#555;margin:1px 0 3px">Éditez la cible (clic sur un organe du schéma / volet nodal), puis validez-la.</div>
@@ -198,7 +206,7 @@
   </div>
   <div class="pane" id="paneBot">
     <div class="ttl"><button class="cbtn" onclick="togglePane('paneBot')" title="Réduire / agrandir">▾</button>
-      <button onclick="loadScen('as_depart')" title="La cible sélectionnée dans « Scénarios sauvegardés » devient le nouvel état de départ"
+      <button onclick="promoteCible()" title="Promouvoir la cible courante (éditée) en nouvel état de départ — pour chaîner les scénarios"
               style="float:right;padding:1px 8px;font-size:11px;margin:0;font-weight:normal">⇧ Nouvelle Topologie Départ</button>
       Topologie cible (éditable, clic sur un organe) — <span id="nbB" class="badge">–</span> nœud(s)
         · animation de la séquence ici</div>
@@ -263,7 +271,7 @@
   <div class="modalbox">
     <h3>⟳ Recharger un scénario</h3>
     <select id="scenSel" style="width:100%"><option value="">—</option></select>
-    <div style="font-size:10px;color:#888;margin-top:6px">« Valider » rejoue le scénario (départ + cible). Pour repartir de sa cible, utilisez « ⇧ Nouvelle Topologie Départ » sur le schéma cible.</div>
+    <div style="font-size:10px;color:#888;margin-top:6px">« Valider » rejoue le scénario sauvegardé (départ + cible).</div>
     <div style="display:flex;gap:6px;justify-content:flex-end;margin-top:10px">
       <button onclick="closeReload()">Annuler</button>
       <button class="primary" onclick="validateReload()">Valider</button>
@@ -275,15 +283,16 @@ let S={n:0,idx:0,timer:null,labels:[],algo:{},sel:new Set(),lastSel:null,manual:
   editTarget:false,stale:false,currentVL:null,tab:'local'};
 // État de la source « dataset RTE7000 » (onglet de choix date/heure).
 let DS={enabled:false,repo:'',defaultTime:'12:00'};
-// Cas d'intérêt documentés (campagne inter-saisons 2021, cf.
-// docs/dataset_rte7000/) : libellé court + intérêt, affichés en bulle sur les
-// puces d'accès rapide de l'onglet RTE7000.
+// Cas d'intérêt documentés — repris de la « Table de campagne »
+// (docs/dataset_rte7000/#table-de-campagne-campagnecampagnejson) :
+// jour · saison + blocs / postes actifs / reconfigurations structurelles,
+// affichés en bulle sur les puces d'accès rapide de l'onglet RTE7000.
 const DATE_INFO={
-  '2021-01-03':{tag:'dim. · hiver',desc:"Journée pilote, week-end calme : le MOINS de reconfigurations structurelles (36) — cas « simple » de référence."},
-  '2021-01-05':{tag:'mar. · hiver',desc:"Jour ouvré d'hiver : 123 reconfigurations structurelles, 2 011 postes actifs."},
-  '2021-04-14':{tag:'mer. · printemps',desc:"Mi-saison : 158 reconfigurations structurelles, charge modérée."},
-  '2021-07-15':{tag:'jeu. · été',desc:"Pointe estivale : le PLUS de postes actifs (2 096), 203 reconfigurations."},
-  '2021-10-12':{tag:'mar. · automne',desc:"Le PLUS de reconfigurations structurelles (208) — chantiers d'automne, cas « riche »."},
+  '2021-01-03':{tag:'dim. · hiver',desc:"Dimanche, hiver — 6 233 blocs, 1 861 postes actifs, 36 reconfigurations structurelles (le MINIMUM) : week-end calme, cas « simple » de référence (journée pilote)."},
+  '2021-01-05':{tag:'mar. · hiver',desc:"Mardi, hiver — 6 554 blocs, 2 011 postes actifs, 123 reconfigurations structurelles : jour ouvré d'hiver."},
+  '2021-04-14':{tag:'mer. · printemps',desc:"Mercredi, printemps — 7 216 blocs, 2 024 postes actifs, 158 reconfigurations structurelles : mi-saison."},
+  '2021-07-15':{tag:'jeu. · été',desc:"Jeudi, été — 7 127 blocs, 2 096 postes actifs (le PLUS), 203 reconfigurations structurelles : pointe estivale."},
+  '2021-10-12':{tag:'mar. · automne',desc:"Mardi, automne — 6 760 blocs, 2 056 postes actifs, 208 reconfigurations structurelles (le MAXIMUM) : chantiers d'automne, cas « riche »."},
 };
 // --- Onglets « Situation réseau » (Local ⇄ RTE7000) -----------------------
 function selectTab(which){
@@ -311,35 +320,48 @@ const api=(p,b)=>fetch(p,{method:'POST',headers:{'Content-Type':'application/jso
 function setValidated(v){document.getElementById('bcalc').disabled=!v;
   document.getElementById('bmanual').disabled=!v;
   document.getElementById('calchint').style.display=v?'none':'block';}
-let ALL_POSTES=[];
-// Champ poste **unique** (recherche sur TOUS les postes de la situation) : le
-// menu épinglé d'autrefois est fusionné ici — les postes épinglés (★) sont
-// listés en tête de la datalist pour rester d'accès rapide ; l'explorateur
-// « par typologie » (liste curée) reste à part.
+let ALL_POSTES=[],PINNED=[],CATALOG=[];
+const POSTE_CAP=300;   // borne d'affichage des résultats de recherche (perf)
+// Champ poste **unique** : un champ de recherche sur TOUS les postes de la
+// situation, et **en dessous** une liste browsable — vide = exploration curée
+// par typologie (postes épinglés ★ en tête) ; saisie = recherche plein-texte
+// sur tous les postes. Fusionne l'ancien champ de recherche et le sélecteur
+// « par typologie » dans une même interaction.
 function populatePostes(r){
   ALL_POSTES=r.all||r.postes||[];
-  const pinned=r.postes||[];
-  const dl=document.getElementById('allPostes');dl.innerHTML='';
-  const seen=new Set();
-  const addOpt=(p,label)=>{if(seen.has(p))return;seen.add(p);
-    const o=document.createElement('option');o.value=p;if(label)o.label=label;dl.appendChild(o);};
-  pinned.forEach(p=>addOpt(p,'★ épinglé'));
-  ALL_POSTES.forEach(p=>addOpt(p));
-  populateCatalog(r.catalog||[]);}
-// Sélecteur « par typologie » : un <optgroup> par section ; postes absents de la
-// situation chargée grisés (option disabled).
-function populateCatalog(catalog){
-  const cs=document.getElementById('posteCat');cs.innerHTML='';
-  const ph=document.createElement('option');ph.value='';ph.text='📂 explorer par typologie…';
-  ph.disabled=true;ph.selected=true;cs.add(ph);
-  catalog.forEach(sec=>{
-    const og=document.createElement('optgroup');
-    og.label=`${sec.title}  (${sec.n_available}/${sec.postes.length})`;
-    sec.postes.forEach(p=>{const o=document.createElement('option');
-      o.value=p.vl;o.text=(p.available?'':'⚠ ')+p.vl;o.disabled=!p.available;
-      if(!p.available)o.title='absent de la situation chargée — charger la grille France';
-      og.appendChild(o);});
-    cs.appendChild(og);});}
+  PINNED=r.postes||[];
+  CATALOG=r.catalog||[];
+  renderPosteList((document.getElementById('posteSearch')||{}).value||'');}
+function _posteSec(title){const d=document.createElement('div');
+  d.className='sec';d.textContent=title;return d;}
+function _posteItem(vl,pinned,available){
+  const d=document.createElement('div');
+  d.className='it'+(available?'':' off')+(vl===S.currentVL?' cur':'');
+  d.innerHTML=(pinned?'<span class="pin">★ </span>':'')+xesc(vl)
+    +(available?'':' <span style="font-size:9px">⚠ absent</span>');
+  if(available)d.onclick=()=>load(vl);
+  else d.title='absent de la situation chargée — charger la grille France';
+  return d;}
+function renderPosteList(query){
+  const root=document.getElementById('posteList');if(!root)return;root.innerHTML='';
+  const q=(query||'').trim().toLowerCase();
+  if(q){   // recherche plein-texte sur TOUS les postes de la situation
+    const pin=new Set(PINNED);
+    const hits=ALL_POSTES.filter(p=>p.toLowerCase().includes(q));
+    if(!hits.length){root.innerHTML='<div class="empty">Aucun poste ne correspond.</div>';return;}
+    hits.slice(0,POSTE_CAP).forEach(p=>root.appendChild(_posteItem(p,pin.has(p),true)));
+    if(hits.length>POSTE_CAP){const d=document.createElement('div');d.className='empty';
+      d.textContent='… '+(hits.length-POSTE_CAP)+' autres — affinez la recherche.';
+      root.appendChild(d);}
+    return;}
+  // vide : exploration curée (épinglés + sections par typologie)
+  if(PINNED.length){root.appendChild(_posteSec('★ Postes épinglés'));
+    PINNED.forEach(p=>root.appendChild(_posteItem(p,true,true)));}
+  CATALOG.forEach(sec=>{
+    root.appendChild(_posteSec(sec.title+'  ('+sec.n_available+'/'+sec.postes.length+')'));
+    sec.postes.forEach(p=>root.appendChild(_posteItem(p.vl,false,p.available)));});
+  if(!PINNED.length&&!CATALOG.length)
+    root.innerHTML='<div class="empty">Aucun poste — charger une situation.</div>';}
 // Sélecteurs d'algorithme pluggable (manoeuvre.plugins) : phase A (nodale →
 // détaillée, volet nodal) et phase B (séquencement, panneau latéral). Les
 // plugins tiers enregistrés (registre / entry points) y apparaissent d'office.
@@ -359,12 +381,12 @@ function fillAlgoSel(id,phase,r){
   sel.title=sel.disabled?sel.title+' (un seul algorithme disponible)':sel.title;}
 async function init(){const r=await (await fetch('/api/postes')).json();
   populatePostes(r);await refreshAlgos();
-  const cs=document.getElementById('posteCat');cs.onchange=()=>{if(cs.value)load(cs.value);};
-  // Champ poste unique : datalist de tous les VL NODE_BREAKER de la situation
-  // (postes épinglés ★ en tête). Charge au choix (Entrée ou sélection).
+  // Champ poste unique : la saisie filtre la liste (recherche sur tous les
+  // postes) ; Entrée charge le poste si la saisie correspond exactement.
   const search=document.getElementById('posteSearch');
-  const go=()=>{const v=search.value.trim();if(v&&ALL_POSTES.includes(v))load(v);};
-  search.onchange=go;search.addEventListener('keydown',e=>{if(e.key==='Enter')go();});
+  search.addEventListener('input',()=>renderPosteList(search.value));
+  search.addEventListener('keydown',e=>{if(e.key==='Enter'){
+    const v=search.value.trim();if(v&&ALL_POSTES.includes(v))load(v);}});
   initNodalResize(); initNodalDnD(); await refreshScenarios(); await initDataset();
   if(r.postes&&r.postes.length) load(r.postes[0]);}
 // ---- Onglet « RTE7000 » : choisir une date/heure, charger la situation -------
@@ -425,8 +447,17 @@ async function loadGrid(){
   msg.textContent=`✓ ${r.postes.length} postes épinglés, ${(r.all||[]).length} postes NODE_BREAKER`;
   if(r.postes.length)load(r.postes[0]);else if(ALL_POSTES.length)load(ALL_POSTES[0]);}
 async function load(vl){stopAnim();S.currentVL=vl;const d=await api('/api/load',{vl});show(d);initNodale(d);hideSeq();setValidated(false);
-  document.getElementById('posteSearch').value=vl;      // sync champ poste unique
+  renderPosteList((document.getElementById('posteSearch')||{}).value||'');  // surligne le poste courant
   document.getElementById('scenName').value=vl+'_cible';}
+// Promouvoir la cible courante (éditée) en nouvel état de DÉPART — met à jour le
+// schéma du haut (départ) et repart d'une cible = nouveau départ ; permet de
+// chaîner sans passer par un scénario sauvegardé.
+async function promoteCible(){stopAnim();
+  const d=await api('/api/promote_cible',{});
+  if(d&&d.vl)S.currentVL=d.vl;
+  show(d);initNodale(d);hideSeq();setValidated(false);
+  document.getElementById('scenName').value=(S.currentVL||'')+'_cible';
+  document.getElementById('savemsg').textContent='Cible promue en nouvel état de départ — éditez puis validez une nouvelle cible.';}
 async function reset(){stopAnim();const d=await api('/api/reset',{});show(d);
   syncNodalCible(d.nodale);hideSeq();setValidated(false);}
 async function toggle(id){stopAnim();const d=await api('/api/toggle',{id});show(d);
@@ -501,7 +532,9 @@ async function save(){const name=document.getElementById('scenName').value;
   setValidated(true);await refreshScenarios();}
 async function loadScen(mode){const name=document.getElementById('scenSel').value;if(!name)return;
   stopAnim();const d=await api('/api/load_scenario',{name,mode});
-  document.getElementById('posteSearch').value=d.vl;show(d);initNodale(d);hideSeq();
+  if(d&&d.vl)S.currentVL=d.vl;
+  renderPosteList((document.getElementById('posteSearch')||{}).value||'');
+  show(d);initNodale(d);hideSeq();
   if(mode==='as_depart'){
     document.getElementById('scenName').value=name+'_suite';
     document.getElementById('savemsg').textContent='« '+name+' » chargé comme état de départ — éditez puis validez une nouvelle cible.';

--- a/scripts/manoeuvre_ihm_assets/index.html
+++ b/scripts/manoeuvre_ihm_assets/index.html
@@ -177,8 +177,11 @@
 
   <h2 class="step">2 · Topologie cible</h2>
   <div style="font-size:11px;color:#555;margin:1px 0 3px">Éditez la cible (clic sur un organe du schéma / volet nodal), puis validez-la.</div>
-  <input id="scenName" placeholder="nom du scénario" style="width:62%;padding:5px">
-  <button onclick="save()">✓ Valider &amp; sauvegarder</button>
+  <button onclick="validateCible()" title="Valider la cible courante pour activer le calcul de séquence (sans sauvegarder de fichier)">✓ Valider</button>
+  <div style="display:flex;gap:4px;margin-top:4px">
+    <input id="scenName" placeholder="nom du scénario" style="flex:1;min-width:0;padding:5px">
+    <button onclick="save()" title="Sauvegarder le scénario (départ + cible). Sur le Space, le fichier est aussi téléchargé en local.">💾 Sauvegarder</button>
+  </div>
   <div id="savemsg" style="font-size:11px;color:#1a7f37;margin-top:3px"></div>
 
   <h2 class="step">3 · Séquence de manœuvres</h2>
@@ -282,7 +285,22 @@
 let S={n:0,idx:0,timer:null,labels:[],algo:{},sel:new Set(),lastSel:null,manual:false,
   editTarget:false,stale:false,currentVL:null,tab:'local'};
 // État de la source « dataset RTE7000 » (onglet de choix date/heure).
-let DS={enabled:false,repo:'',defaultTime:'12:00'};
+// ``hosted`` = IHM déportée (Space HuggingFace) : les fichiers sauvegardés
+// côté serveur y sont éphémères → on les télécharge aussi en local.
+let DS={enabled:false,repo:'',defaultTime:'12:00',hosted:false};
+// Validation de la cible (étape 2) : active le calcul de séquence, **sans**
+// écrire de fichier (la sauvegarde est l'action séparée « 💾 Sauvegarder »).
+function validateCible(){setValidated(true);
+  document.getElementById('savemsg').textContent='✓ Cible validée — calcul de séquence activé (ou « 💾 Sauvegarder »).';}
+// Télécharge le fichier sauvegardé (JSON renvoyé par le backend) **si l'IHM est
+// déportée** (Space) — pour en garder une copie locale malgré le FS éphémère.
+function maybeDownload(r){
+  if(!DS.hosted||!r||!r.content)return false;
+  const blob=new Blob([r.content],{type:'application/json'});
+  const a=document.createElement('a');a.href=URL.createObjectURL(blob);
+  a.download=(r.name||'scenario')+'.json';
+  document.body.appendChild(a);a.click();a.remove();
+  setTimeout(()=>URL.revokeObjectURL(a.href),2000);return true;}
 // Cas d'intérêt documentés — repris de la « Table de campagne » (3 ans
 // 2021-2023, docs/dataset_rte7000/#table-de-campagne-campagnecampagnejson) :
 // jour · saison + blocs / postes actifs / reconfigurations structurelles,
@@ -399,6 +417,7 @@ async function init(){const r=await (await fetch('/api/postes')).json();
 async function initDataset(){
   let cfg;try{cfg=await (await fetch('/api/dataset/config')).json();}catch(e){cfg=null;}
   if(cfg){DS.enabled=!!cfg.enabled;DS.repo=cfg.repo||'';DS.defaultTime=cfg.default_time||'12:00';
+    DS.hosted=!!cfg.hosted;
     const di=document.getElementById('dsDate');di.value=cfg.default_date||'';
     di.onchange=()=>loadDatasetTimestamps(di.value);
     const info=document.getElementById('dsRepoInfo');
@@ -530,8 +549,10 @@ async function saveWithConfirm(url,name,msgEl){
 async function save(){const name=document.getElementById('scenName').value;
   const r=await saveWithConfirm('/api/save',name,document.getElementById('savemsg'));
   if(!r)return;
-  document.getElementById('savemsg').textContent='✓ Sauvegardé : '+r.path;
-  setValidated(true);await refreshScenarios();}
+  setValidated(true);await refreshScenarios();
+  const dl=maybeDownload(r);   // copie locale si IHM déportée (Space)
+  document.getElementById('savemsg').textContent='✓ Sauvegardé : '+r.path
+    +(dl?' · téléchargé en local':'');}
 async function loadScen(mode){const name=document.getElementById('scenSel').value;if(!name)return;
   stopAnim();const d=await api('/api/load_scenario',{name,mode});
   if(d&&d.vl)S.currentVL=d.vl;
@@ -650,7 +671,8 @@ async function saveSeq(){const name=document.getElementById('seqName').value;
   const msg=document.getElementById('seqsavemsg');
   const r=await saveWithConfirm('/api/save_sequence',name,msg);
   if(!r)return;
-  msg.textContent='✓ '+r.path;}
+  const dl=maybeDownload(r);   // copie locale si IHM déportée (Space)
+  msg.textContent='✓ '+r.path+(dl?' · téléchargé en local':'');}
 function bindStep(switches){const root=document.getElementById('diagBottom');
   switches.forEach(s=>{const el=root.querySelector('[id="'+s.svgId+'"]');
     if(el){el.style.cursor='pointer';el.onclick=()=>seqInsert(S.idx,s.id);
@@ -800,7 +822,11 @@ function renderNodaleDepart(){const gs=NOD.depart.groups||[];
   document.getElementById('ndDepN').textContent=gs.length;
   renderNodaleSVG('ndDepart',gs,false,NOD.colors);
   renderIso('ndDepartIso',NOD.departIso,false);}
-function renderNodaleCible(){nodNormalize();
+// NB : on NE normalise PAS ici (sinon un nœud vide tout juste créé via « ＋ Nœud »
+// serait supprimé au re-rendu). Les nœuds vides sont des **cibles de dépose**
+// valides ; ils sont nettoyés par les opérations (déplacement / fusion) et
+// ignorés au calcul de la topologie détaillée.
+function renderNodaleCible(){
   document.getElementById('ndCibTitle').textContent='Cible (éditable)';  // restaure le mode édition
   document.getElementById('ndCibN').textContent=NOD.groups.length;
   renderNodaleSVG('ndCible',NOD.groups,true,NOD.colorsCible);
@@ -862,18 +888,23 @@ function nodMoveBranchesTo(eqs,target){
   NOD.isolated=NOD.isolated.filter(eq=>eqs.indexOf(eq)<0);   // reconnecte les isolés
   NOD.groups=NOD.groups.map(g=>g.filter(eq=>eqs.indexOf(eq)<0));
   eqs.forEach(eq=>{if(!NOD.groups[target].includes(eq))NOD.groups[target].push(eq);});
-  NOD.selBranches=new Set();renderNodaleCible();}
+  NOD.selBranches=new Set();nodNormalize();renderNodaleCible();}  // nettoie les nœuds vidés
 function nodMergeNodes(src,dst){
   if(src===dst||src<0||dst<0||src>=NOD.groups.length||dst>=NOD.groups.length)return;
   NOD.groups[dst]=NOD.groups[dst].concat(
     NOD.groups[src].filter(eq=>NOD.groups[dst].indexOf(eq)<0));
-  NOD.groups[src]=[];NOD.selBranches=new Set();renderNodaleCible();}
+  NOD.groups[src]=[];NOD.selBranches=new Set();nodNormalize();renderNodaleCible();}  // retire le nœud fusionné
+// « ＋ Nœud » : crée un nœud **vide** (cible de dépose). Avec une sélection, on y
+// déplace directement les départs sélectionnés ; sinon le nœud vide persiste —
+// glisser-y ensuite des départs. Un nœud resté vide est ignoré au calcul.
 function nodNewNode(){NOD.groups.push([]);const idx=NOD.groups.length-1;
   if(NOD.selBranches.size)nodMoveSelTo(idx);else renderNodaleCible();}
 function nodClearSel(){NOD.selBranches=new Set();renderNodaleCible();}
 async function nodCompute(){
   const st=document.getElementById('nodstatus');st.className='';st.textContent='Calcul en cours…';
-  const d=await api('/api/nodale_to_detaillee',{groups:NOD.groups,isolated:NOD.isolated});
+  // Les nœuds restés vides sont écartés (ignorés par le calcul de toute façon).
+  const groups=NOD.groups.filter(g=>g.length);
+  const d=await api('/api/nodale_to_detaillee',{groups,isolated:NOD.isolated});
   stopAnim();S.manual=false;
   // Charger la topologie détaillée d'intérêt comme cible (volet du bas).
   document.getElementById('diagBottom').innerHTML=d.svg;

--- a/tests/manoeuvre/test_dataset_source.py
+++ b/tests/manoeuvre/test_dataset_source.py
@@ -1,0 +1,137 @@
+"""
+tests/manoeuvre/test_dataset_source.py
+--------------------------------------
+Couche « source instantané par date » du dataset RTE 7000
+(``manoeuvre/dataset/source.py``) : résolution date/heure → instantané,
+téléchargement (reprise + md5) — **sans aucun appel réseau** (la frontière HTTP
+est monkeypatchée). Branche l'IHM de manœuvre sur le dataset HuggingFace.
+"""
+
+from __future__ import annotations
+
+import hashlib
+
+import pytest
+
+from expert_op4grid_recommender.manoeuvre.dataset import source
+
+
+# --- prefixe_jour / _minutes -----------------------------------------------
+
+def test_prefixe_jour_ok():
+    assert source.prefixe_jour("2021-01-03") == "2021/01/03"
+    assert source.prefixe_jour("  2022-12-31 ") == "2022/12/31"
+
+
+@pytest.mark.parametrize("bad", ["notadate", "2021/01/03", "2021-1-3", ""])
+def test_prefixe_jour_invalide(bad):
+    with pytest.raises(ValueError):
+        source.prefixe_jour(bad)
+
+
+def test_minutes_parsing():
+    assert source._minutes("12:00") == 720
+    assert source._minutes("09h05") == 545
+    assert source._minutes("0000") == 0
+    assert source._minutes("bof") == 12 * 60   # repli midi
+
+
+# --- choisir_instantane (le plus proche de l'heure) ------------------------
+
+def test_choisir_instantane_proche_midi():
+    insts = [{"ts": "00:05"}, {"ts": "11:55"}, {"ts": "12:10"}, {"ts": "23:55"}]
+    assert source.choisir_instantane(insts, "12:00")["ts"] == "11:55"  # 5 min < 10 min
+
+
+def test_choisir_instantane_heure_visee():
+    insts = [{"ts": "08:00"}, {"ts": "18:30"}]
+    assert source.choisir_instantane(insts, "18:00")["ts"] == "18:30"
+
+
+def test_choisir_instantane_vide():
+    assert source.choisir_instantane([]) is None
+
+
+# --- lister_instantanes (parse les noms, trie, ignore l'inhorodatable) -----
+
+def test_lister_instantanes(monkeypatch):
+    paths = [
+        "2021/01/03/recollement-auto-20210103-1200-enrichi.xiidm.bz2",
+        "2021/01/03/recollement-auto-20210103-0005-enrichi.xiidm.bz2",
+        "2021/01/03/sans-horodatage.xiidm.bz2",   # ignoré (ValueError)
+    ]
+    monkeypatch.setattr(source, "lister_fichiers",
+                        lambda repo, prefix, token=None: paths)
+    insts = source.lister_instantanes("repo", "2021-01-03")
+    assert [d["ts"] for d in insts] == ["00:05", "12:00"]        # trié, junk écarté
+    assert insts[0]["iso"] == "2021-01-03T00:05"
+    assert insts[1]["path"].endswith("1200-enrichi.xiidm.bz2")
+
+
+def test_lister_instantanes_date_invalide(monkeypatch):
+    # prefixe_jour lève AVANT tout accès réseau.
+    monkeypatch.setattr(source, "lister_fichiers",
+                        lambda *a, **k: pytest.fail("ne doit pas lister"))
+    with pytest.raises(ValueError):
+        source.lister_instantanes("repo", "notadate")
+
+
+# --- resoudre_et_telecharger -----------------------------------------------
+
+def test_resoudre_et_telecharger(monkeypatch, tmp_path):
+    monkeypatch.setattr(source, "lister_instantanes",
+                        lambda repo, date, token=None: [
+                            {"ts": "12:00", "iso": date + "T12:00", "path": "P12"},
+                            {"ts": "00:00", "iso": date + "T00:00", "path": "P00"}])
+    capt = {}
+
+    def fake_dl(repo, hf_path, cache, token=None):
+        capt["path"] = hf_path
+        return tmp_path / hf_path
+
+    monkeypatch.setattr(source, "telecharger_instantane", fake_dl)
+    local, meta = source.resoudre_et_telecharger(
+        "repo", "2021-01-03", tmp_path, heure="12:00")
+    assert capt["path"] == "P12"                  # midi choisi
+    assert meta["ts"] == "12:00" and meta["date"] == "2021-01-03"
+    assert local == tmp_path / "P12"
+
+
+def test_resoudre_aucun_instantane(monkeypatch, tmp_path):
+    monkeypatch.setattr(source, "lister_instantanes",
+                        lambda repo, date, token=None: [])
+    with pytest.raises(FileNotFoundError):
+        source.resoudre_et_telecharger("repo", "2021-01-03", tmp_path)
+
+
+# --- telecharger_un (reprise / téléchargement / md5) -----------------------
+
+def test_telecharger_un_reprise(monkeypatch, tmp_path):
+    """Fichier déjà présent + md5 concordant => aucun téléchargement."""
+    data = b"hello"
+    dest = tmp_path / "2021/01/03/x.xiidm.bz2"
+    dest.parent.mkdir(parents=True)
+    dest.write_bytes(data)
+    monkeypatch.setattr(source, "_md5_attendu",
+                        lambda repo, path, token=None: hashlib.md5(data).hexdigest())
+    monkeypatch.setattr(source, "_http_get",
+                        lambda *a, **k: pytest.fail("ne doit pas télécharger"))
+    out = source.telecharger_un("repo", "2021/01/03/x.xiidm.bz2", tmp_path)
+    assert out == dest
+
+
+def test_telecharger_un_download(monkeypatch, tmp_path):
+    data = b"world"
+    monkeypatch.setattr(source, "_md5_attendu",
+                        lambda repo, path, token=None: hashlib.md5(data).hexdigest())
+    monkeypatch.setattr(source, "_http_get", lambda url, token=None, **k: data)
+    out = source.telecharger_un("repo", "2021/01/03/y.xiidm.bz2", tmp_path)
+    assert out.read_bytes() == data
+
+
+def test_telecharger_un_md5_invalide(monkeypatch, tmp_path):
+    monkeypatch.setattr(source, "_md5_attendu",
+                        lambda repo, path, token=None: "0" * 32)
+    monkeypatch.setattr(source, "_http_get", lambda url, token=None, **k: b"data")
+    with pytest.raises(IOError):
+        source.telecharger_un("repo", "2021/01/03/z.xiidm.bz2", tmp_path)

--- a/tests/manoeuvre/test_ihm_cache_and_api.py
+++ b/tests/manoeuvre/test_ihm_cache_and_api.py
@@ -234,6 +234,15 @@ def test_api_save_returns_content_for_download(session, monkeypatch, tmp_path):
     assert (tmp_path / "t.json").exists()
 
 
+def test_api_save_sequence_returns_content_for_download(session, monkeypatch, tmp_path):
+    monkeypatch.setattr(ihm, "SESSION", session)
+    monkeypatch.setattr(ihm, "SEQ_DIR", tmp_path)
+    d = ihm.app.test_client().post("/api/save_sequence", json={"name": "sq"}).get_json()
+    assert d["name"] == "sq"
+    assert d["content"] and '"manoeuvres"' in d["content"]
+    assert (tmp_path / "sq.json").exists()
+
+
 def test_normalize_groups_ignores_empty_nodes():
     # Un groupe vide (nœud « ＋ Nœud » resté vide) est ignoré ; l'orphelin va
     # dans un nœud dédié → aucun nœud vide dans le résultat.

--- a/tests/manoeuvre/test_ihm_cache_and_api.py
+++ b/tests/manoeuvre/test_ihm_cache_and_api.py
@@ -219,3 +219,24 @@ def test_api_promote_cible_returns_both_panes(session, monkeypatch):
     d = ihm.app.test_client().post("/api/promote_cible", json={}).get_json()
     assert {"initial_svg", "svg", "switches", "nb_noeuds",
             "nodale_depart", "nodale_cible", "vl"} <= set(d)
+
+
+# --------------------------------------------------------------------------
+# Sauvegarde : contenu renvoyé (téléchargement local) + nœuds vides ignorés
+# --------------------------------------------------------------------------
+
+def test_api_save_returns_content_for_download(session, monkeypatch, tmp_path):
+    monkeypatch.setattr(ihm, "SESSION", session)
+    monkeypatch.setattr(ihm, "SCEN_DIR", tmp_path)
+    d = ihm.app.test_client().post("/api/save", json={"name": "t"}).get_json()
+    assert d["name"] == "t"
+    assert d["content"] and '"voltage_level_id"' in d["content"]
+    assert (tmp_path / "t.json").exists()
+
+
+def test_normalize_groups_ignores_empty_nodes():
+    # Un groupe vide (nœud « ＋ Nœud » resté vide) est ignoré ; l'orphelin va
+    # dans un nœud dédié → aucun nœud vide dans le résultat.
+    out = ihm._normalize_groups(["a", "b", "c"], [["a"], [], ["b"]])
+    assert [] not in out
+    assert ["a"] in out and ["b"] in out and ["c"] in out

--- a/tests/manoeuvre/test_ihm_cache_and_api.py
+++ b/tests/manoeuvre/test_ihm_cache_and_api.py
@@ -195,3 +195,27 @@ def test_pick_grid_file_timeout_is_graceful(monkeypatch):
     d = ihm.app.test_client().get("/api/pick_grid_file").get_json()
     assert d["path"] == ""
     assert "expiré" in d["error"]
+
+
+# --------------------------------------------------------------------------
+# promote_cible : promouvoir la cible courante en nouvel état de départ
+# --------------------------------------------------------------------------
+
+def test_promote_cible_makes_target_the_new_departure(session):
+    sid = next(iter(session.current))
+    session.toggle(sid)                       # édite la cible
+    edited = dict(session.current)
+    session.seq_manoeuvres = [
+        {"switch_id": sid, "action": "OPEN", "raison": "x", "boucle": None}]
+    session.promote_cible()
+    assert session.initial == edited          # départ = ancienne cible
+    assert session.current == edited          # cible repart = nouveau départ
+    assert session.seq_manoeuvres == []       # séquence réinitialisée
+    assert session.scenario_name is None
+
+
+def test_api_promote_cible_returns_both_panes(session, monkeypatch):
+    monkeypatch.setattr(ihm, "SESSION", session)
+    d = ihm.app.test_client().post("/api/promote_cible", json={}).get_json()
+    assert {"initial_svg", "svg", "switches", "nb_noeuds",
+            "nodale_depart", "nodale_cible", "vl"} <= set(d)

--- a/tests/manoeuvre/test_ihm_cache_and_api.py
+++ b/tests/manoeuvre/test_ihm_cache_and_api.py
@@ -154,3 +154,44 @@ def test_memoized_topo_matches_fresh_build(session):
         ihm.build_vl_graph(session.net, VL), VL)
     cached = session._topo(session.initial)
     assert cached.meme_topologie(fresh)
+
+
+# --------------------------------------------------------------------------
+# Sélecteur de fichier natif (/api/pick_grid_file) — onglet « Local »
+# --------------------------------------------------------------------------
+
+class _FakeProc:
+    def __init__(self, returncode, stdout="", stderr=""):
+        self.returncode = returncode
+        self.stdout = stdout
+        self.stderr = stderr
+
+
+def test_pick_grid_file_returns_selected_path(monkeypatch):
+    monkeypatch.setattr(ihm.platform, "system", lambda: "Linux")
+    monkeypatch.setattr(ihm.subprocess, "run",
+                        lambda *a, **k: _FakeProc(0, stdout="/data/grid.xiidm\n"))
+    r = ihm.app.test_client().get("/api/pick_grid_file")
+    assert r.status_code == 200
+    assert r.get_json() == {"path": "/data/grid.xiidm"}
+
+
+def test_pick_grid_file_degrades_without_display(monkeypatch):
+    # Sans afficheur / tkinter (Space headless) : le sous-processus échoue ;
+    # l'endpoint renvoie une erreur exploitable (jamais de 500).
+    monkeypatch.setattr(ihm.platform, "system", lambda: "Linux")
+    monkeypatch.setattr(ihm.subprocess, "run",
+                        lambda *a, **k: _FakeProc(1, stderr="No module named tkinter"))
+    d = ihm.app.test_client().get("/api/pick_grid_file").get_json()
+    assert d["path"] == ""
+    assert "tkinter" in d["error"]
+
+
+def test_pick_grid_file_timeout_is_graceful(monkeypatch):
+    def _boom(*a, **k):
+        raise ihm.subprocess.TimeoutExpired(cmd="picker", timeout=300)
+    monkeypatch.setattr(ihm.platform, "system", lambda: "Linux")
+    monkeypatch.setattr(ihm.subprocess, "run", _boom)
+    d = ihm.app.test_client().get("/api/pick_grid_file").get_json()
+    assert d["path"] == ""
+    assert "expiré" in d["error"]

--- a/tests/manoeuvre/test_ihm_dataset.py
+++ b/tests/manoeuvre/test_ihm_dataset.py
@@ -160,6 +160,20 @@ def test_timestamps_uses_year_derived_repo(dataset_mode, monkeypatch):
     assert seen["repo"].endswith("D-GITT-RTE7000-2022")
 
 
+def test_load_uses_year_derived_repo(dataset_mode, monkeypatch):
+    seen = {}
+    net = pp.network.create_four_substations_node_breaker_network()
+
+    def fake(repo, date, cache, heure="12:00", token=None):
+        seen["repo"] = repo
+        return net, {"date": date, "ts": heure, "iso": date + "T" + heure,
+                     "path": "p", "local": "/tmp/p"}
+
+    monkeypatch.setattr(ihm.dataset_source, "charger_situation", fake)
+    dataset_mode.post("/api/dataset/load", json={"date": "2023-02-08", "time": "12:00"})
+    assert seen["repo"].endswith("D-GITT-RTE7000-2023")
+
+
 # --- hosted (IHM déportée → téléchargement local côté front) ----------------
 
 def test_config_reports_hosted_flag(monkeypatch):

--- a/tests/manoeuvre/test_ihm_dataset.py
+++ b/tests/manoeuvre/test_ihm_dataset.py
@@ -1,0 +1,136 @@
+"""
+tests/manoeuvre/test_ihm_dataset.py
+-----------------------------------
+Endpoints de la **source dataset** de l'IHM de manœuvre
+(``/api/dataset/config``, ``/api/dataset/timestamps``, ``/api/dataset/load``) et
+garde-fous « aucune situation chargée » (``SESSION is None``) du mode dataset.
+
+La frontière réseau (``manoeuvre.dataset.source``) est monkeypatchée : **aucun
+appel HuggingFace**. ``/api/dataset/load`` est servi sur le réseau de test
+pypowsybl.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import pathlib
+
+import pytest
+
+pytest.importorskip("flask")
+pytest.importorskip("pypowsybl")
+
+import pypowsybl as pp  # noqa: E402
+
+_IHM_PATH = (pathlib.Path(__file__).resolve().parents[2]
+             / "scripts" / "manoeuvre_ihm.py")
+
+
+def _load_ihm():
+    spec = importlib.util.spec_from_file_location("manoeuvre_ihm_dataset_mod",
+                                                  _IHM_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+ihm = _load_ihm()
+
+
+@pytest.fixture()
+def dataset_mode(monkeypatch):
+    """Mode dataset activé, aucune situation chargée."""
+    monkeypatch.setattr(ihm, "SESSION", None)
+    monkeypatch.setitem(ihm.DATASET, "enabled", True)
+    monkeypatch.setitem(ihm.DATASET, "repo", "OpenSynth/D-GITT-RTE7000-2021")
+    monkeypatch.setitem(ihm.DATASET, "default_date", "2021-01-03")
+    monkeypatch.setitem(ihm.DATASET, "default_time", "12:00")
+    monkeypatch.setitem(ihm.DATASET, "sample_dates", ["2021-01-03", "2021-01-05"])
+    return ihm.app.test_client()
+
+
+# --- /api/dataset/config ---------------------------------------------------
+
+def test_config_enabled(dataset_mode):
+    d = dataset_mode.get("/api/dataset/config").get_json()
+    assert d["enabled"] is True
+    assert d["repo"].endswith("D-GITT-RTE7000-2021")
+    assert d["default_date"] == "2021-01-03"
+    assert d["default_time"] == "12:00"
+    assert d["sample_dates"] == ["2021-01-03", "2021-01-05"]
+
+
+def test_config_disabled(monkeypatch):
+    monkeypatch.setitem(ihm.DATASET, "enabled", False)
+    d = ihm.app.test_client().get("/api/dataset/config").get_json()
+    assert d["enabled"] is False
+
+
+# --- garde-fous SESSION is None --------------------------------------------
+
+def test_postes_needs_date(dataset_mode):
+    d = dataset_mode.get("/api/postes").get_json()
+    assert d["needs_date"] is True
+    assert d["postes"] == [] and d["all"] == [] and d["catalog"] == []
+
+
+def test_algos_defaults_sans_session(dataset_mode):
+    d = dataset_mode.get("/api/algos").get_json()
+    assert set(d["selection"]) == {"identificateur", "sequenceur", "planificateur"}
+    assert d["selection"]["sequenceur"] == "libtopo"
+    assert "libtopo" in d["disponibles"]["sequenceur"]
+
+
+def test_scenarios_vide_sans_session(dataset_mode):
+    assert dataset_mode.get("/api/scenarios").get_json()["scenarios"] == []
+
+
+# --- /api/dataset/timestamps -----------------------------------------------
+
+def test_timestamps_ok(dataset_mode, monkeypatch):
+    monkeypatch.setattr(ihm.dataset_source, "lister_instantanes",
+                        lambda repo, date, token=None: [
+                            {"ts": "00:00", "iso": date + "T00:00", "path": "a"},
+                            {"ts": "12:00", "iso": date + "T12:00", "path": "b"},
+                            {"ts": "23:55", "iso": date + "T23:55", "path": "c"}])
+    d = dataset_mode.get("/api/dataset/timestamps?date=2021-01-03").get_json()
+    assert d["ok"] is True
+    assert [t["ts"] for t in d["timestamps"]] == ["00:00", "12:00", "23:55"]
+    assert d["default"] == "12:00"
+
+
+def test_timestamps_date_invalide(dataset_mode):
+    # prefixe_jour (réel) lève ValueError AVANT tout accès réseau => 400.
+    r = dataset_mode.get("/api/dataset/timestamps?date=notadate")
+    assert r.status_code == 400
+    assert r.get_json()["ok"] is False
+
+
+# --- /api/dataset/load -----------------------------------------------------
+
+def test_load_situation(dataset_mode, monkeypatch):
+    net = pp.network.create_four_substations_node_breaker_network()
+    monkeypatch.setattr(
+        ihm.dataset_source, "charger_situation",
+        lambda repo, date, cache, heure="12:00", token=None: (
+            net, {"date": date, "ts": heure, "iso": date + "T" + heure,
+                  "path": "p", "local": "/tmp/p"}))
+    d = dataset_mode.post("/api/dataset/load",
+                          json={"date": "2021-01-03", "time": "12:00"}).get_json()
+    assert d["ok"] is True
+    assert d["date"] == "2021-01-03" and d["time"] == "12:00"
+    assert "S1VL2" in d["all"]                       # VL du réseau de test
+    assert ihm.SESSION is not None                   # session reconstruite
+    # La topologie d'un poste s'extrait ensuite via l'endpoint existant /api/load.
+    v = dataset_mode.post("/api/load", json={"vl": "S1VL2"}).get_json()
+    assert {"svg", "switches", "nb_noeuds", "nodale_depart"} <= set(v)
+
+
+def test_load_situation_absente(dataset_mode, monkeypatch):
+    def boom(*a, **k):
+        raise FileNotFoundError("Aucun instantané pour 2099-01-01")
+    monkeypatch.setattr(ihm.dataset_source, "charger_situation", boom)
+    r = dataset_mode.post("/api/dataset/load",
+                          json={"date": "2099-01-01", "time": "12:00"})
+    assert r.status_code == 400
+    assert r.get_json()["ok"] is False

--- a/tests/manoeuvre/test_ihm_dataset.py
+++ b/tests/manoeuvre/test_ihm_dataset.py
@@ -134,3 +134,27 @@ def test_load_situation_absente(dataset_mode, monkeypatch):
                           json={"date": "2099-01-01", "time": "12:00"})
     assert r.status_code == 400
     assert r.get_json()["ok"] is False
+
+
+# --- repo_pour_date : sélection du dataset par année (2021/2022/2023) -------
+
+def test_repo_pour_date_swaps_year():
+    f = ihm.dataset_source.repo_pour_date
+    base = "OpenSynth/D-GITT-RTE7000-2021"
+    assert f(base, "2022-06-15") == "OpenSynth/D-GITT-RTE7000-2022"
+    assert f(base, "2023-02-08") == "OpenSynth/D-GITT-RTE7000-2023"
+    assert f(base, "2021-01-03") == "OpenSynth/D-GITT-RTE7000-2021"
+    assert f("me/custom-grid", "2022-06-15") == "me/custom-grid"   # pas d'année
+    assert f(base, "notadate") == base                              # date invalide
+
+
+def test_timestamps_uses_year_derived_repo(dataset_mode, monkeypatch):
+    seen = {}
+
+    def fake(repo, date, token=None):
+        seen["repo"] = repo
+        return [{"ts": "12:00", "iso": date + "T12:00", "path": "p"}]
+
+    monkeypatch.setattr(ihm.dataset_source, "lister_instantanes", fake)
+    dataset_mode.get("/api/dataset/timestamps?date=2022-06-15")
+    assert seen["repo"].endswith("D-GITT-RTE7000-2022")

--- a/tests/manoeuvre/test_ihm_dataset.py
+++ b/tests/manoeuvre/test_ihm_dataset.py
@@ -158,3 +158,12 @@ def test_timestamps_uses_year_derived_repo(dataset_mode, monkeypatch):
     monkeypatch.setattr(ihm.dataset_source, "lister_instantanes", fake)
     dataset_mode.get("/api/dataset/timestamps?date=2022-06-15")
     assert seen["repo"].endswith("D-GITT-RTE7000-2022")
+
+
+# --- hosted (IHM déportée → téléchargement local côté front) ----------------
+
+def test_config_reports_hosted_flag(monkeypatch):
+    monkeypatch.setitem(ihm.DATASET, "enabled", True)
+    monkeypatch.setitem(ihm.DATASET, "hosted", True)
+    d = ihm.app.test_client().get("/api/dataset/config").get_json()
+    assert d["hosted"] is True

--- a/tests/manoeuvre/test_ihm_frontend_asset.py
+++ b/tests/manoeuvre/test_ihm_frontend_asset.py
@@ -63,3 +63,74 @@ def test_python_source_no_longer_embeds_full_page():
     src = _IHM_PATH.read_text(encoding="utf-8")
     assert 'PAGE = r"""' not in src
     assert "manoeuvre_ihm_assets" in src
+
+
+# ---------------------------------------------------------------------------
+# Garde-fou de **structure** : verrouille la présence des éléments / handlers
+# de la refonte IHM (onglets, poste unifié, Scénario Topologique, promote,
+# Recharger, Valider/Sauvegarder, sections nodales repliables…) et l'**absence**
+# des éléments retirés/renommés. Un retrait accidentel casse la CI tout de suite.
+# ---------------------------------------------------------------------------
+
+#: marqueurs qui DOIVENT être présents dans l'asset servi
+REQUIRED_MARKERS = [
+    # Situation réseau : onglets + bouton unique + sélecteur de fichier
+    'id="tabLocal"', 'id="tabRte"', 'id="panelLocal"', 'id="panelRte"',
+    'id="btnCharger"', 'onclick="chargerSituation()"', 'onclick="pickGridFile()"',
+    'function selectTab', '/api/pick_grid_file',
+    # Champ poste unifié + titre + liste browsable + pas d'auto-chargement
+    'id="posteSearch"', 'id="posteList"', 'id="posteListTitle"',
+    "Pré-sélection de postes typiques", 'function renderPosteList',
+    'function awaitPosteChoice',
+    # Scénario Topologique en 3 étapes
+    "🗺 Scénario Topologique", "1 · Poste", "2 · Topologie cible",
+    "3 · Séquence de manœuvres",
+    # Recharger (modale)
+    'onclick="openReload()"', 'id="reloadModal"', 'id="scenSel"',
+    'function validateReload',
+    # Valider / Sauvegarder séparés + téléchargement local
+    'onclick="validateCible()"', "💾 Sauvegarder", 'function maybeDownload',
+    # Boutons en en-tête de schéma : reset + promote cible→départ
+    "↺ État d'origine", "⇧ Nouvelle Topologie Départ", 'onclick="promoteCible()"',
+    '/api/promote_cible',
+    # Volet nodal : sections repliables + Réinitialiser + isolés (conteneurs)
+    'onclick="toggleNsec(this)"', 'function toggleNsec', "↺ Réinitialiser",
+    "＋ Nœud", 'id="ndDepartIso"', 'id="ndCibleIso"',
+    # Dates d'accès rapide 2021-2023
+    "'2022-06-15'", "'2023-02-08'",
+]
+
+#: marqueurs qui ne DOIVENT PLUS apparaître (éléments retirés / renommés)
+FORBIDDEN_MARKERS = [
+    'id="dsBox"',                 # ancien encart dataset → onglets
+    'id="poste"',                 # ancien menu épinglé → recherche unifiée
+    'id="posteCat"',              # ancien sélecteur par typologie → posteList
+    "<datalist",                  # ancienne datalist → posteList
+    ">= départ<",                 # reset nodal renommé « ↺ Réinitialiser »
+    "Scénarios sauvegardés",      # section → modale Recharger
+    "Nœuds électriques",          # section redondante retirée
+    "loadScen('as_depart')",      # bouton recâblé sur promoteCible()
+    "Valider &amp; sauvegarder",  # scindé en Valider + Sauvegarder
+    "load(r.postes[0])",          # auto-chargement de poste supprimé
+]
+
+
+def test_frontend_structure_required_markers():
+    txt = _ASSET.read_text(encoding="utf-8")
+    missing = [m for m in REQUIRED_MARKERS if m not in txt]
+    assert not missing, f"marqueurs IHM attendus absents : {missing}"
+
+
+def test_frontend_structure_removed_markers_absent():
+    txt = _ASSET.read_text(encoding="utf-8")
+    present = [m for m in FORBIDDEN_MARKERS if m in txt]
+    assert not present, f"marqueurs retirés encore présents : {present}"
+
+
+def test_frontend_script_block_balanced():
+    # Un seul bloc <script> non vide (garde-fou contre une troncature de l'asset).
+    txt = _ASSET.read_text(encoding="utf-8")
+    assert txt.count("<script>") == 1 and txt.count("</script>") == 1
+    body = txt.split("<script>", 1)[1].split("</script>", 1)[0]
+    assert len(body) > 10_000          # le JS de l'IHM est substantiel
+    assert body.count("{") == body.count("}")   # accolades équilibrées


### PR DESCRIPTION
## Summary

Adds a **dataset-sourced mode** to the maneuver IHM (`scripts/manoeuvre_ihm.py`), enabling it to load network situations on-demand from the RTE 7000 dataset on HuggingFace, and provides a complete **Docker Space deployment** scaffold.

The IHM can now run in two modes:
1. **Local mode** (`--grid <path>`): existing behavior, loads a single `.xiidm` file
2. **Dataset mode** (default if `--grid` omitted): sources situations from HuggingFace by date/time, with on-demand download + local cache + md5 verification

## Key Changes

### New Module: `manoeuvre/dataset/source.py`
- **Date/time resolution**: `lister_instantanes(repo, date)` lists available snapshots (HH:MM) for a given day via HuggingFace API tree endpoint
- **Snapshot selection**: `choisir_instantane(insts, heure)` picks the closest snapshot to a target time (defaults to noon)
- **Download & cache**: `telecharger_instantane()` / `charger_situation()` fetch snapshots with exponential backoff retries, verify md5 against published digests, and cache locally to avoid re-downloads
- **Pure stdlib**: HTTP layer uses only `urllib`, no `huggingface_hub` dependency; helpers intentionally duplicate those in `scripts/download_dgitt_subset.py` to keep both autonomous
- **Optional HF_TOKEN**: Jeton support to relax CDN rate-limiting on anonymous requests

### IHM Endpoints & Logic (`scripts/manoeuvre_ihm.py`)
- **`GET /api/dataset/config`**: Returns dataset configuration (enabled flag, repo, default date/time, sample dates)
- **`GET /api/dataset/timestamps?date=YYYY-MM-DD`**: Lists available snapshots for a date with preselector defaulting to noon
- **`POST /api/dataset/load`**: Resolves date/time → downloads snapshot → loads network → rebuilds session; returns postes list
- **Guard-rails**: `/api/postes`, `/api/algos`, `/api/scenarios` handle `SESSION is None` gracefully (dataset mode before any load)
- **CLI options**: `--dataset`, `--dataset-repo`, `--cache-dir`, `--default-date`; `--host` / `--port` now configurable; env vars `DGITT_REPO`, `DGITT_CACHE_DIR`, `DGITT_DEFAULT_DATE`, `HF_TOKEN`, `PORT`

### Frontend (`scripts/manoeuvre_ihm_assets/index.html`)
- **Dataset panel** (`#dsBox`): date picker, quick-access sample dates, time selector, load button
- **Dynamic UI**: panel hidden if dataset disabled; timestamps fetched and populated on date change
- **State tracking**: `DS` object tracks dataset config; `S.currentVL` preserves poste selection across date changes

### Deployment (`Dockerfile`, `.dockerignore`, `deploy/huggingface/`)
- **Single-stage Docker image**: Python 3.11 slim + `flask`, `pypowsybl`, `networkx`, `pandas` (no heavy recommender deps)
- **HuggingFace Space ready**: Runs as uid 1000 ("user"), listens on `:7860`, caches downloads in `.cache/dgitt`
- **README with frontmatter**: Space metadata (sdk: docker, app_port: 7860) + user-facing documentation
- **GitHub Action** (`.github/workflows/deploy-huggingface.yml`): Auto-redeploys on `main` merge; requires `HF_TOKEN` (write) + `HF_SPACE` secrets

### Tests
- **`tests/manoeuvre/test_dataset_source.py`**: Unit tests for date parsing, time selection, snapshot listing, download resumption, md5 validation (all HTTP mocked)
- **`tests/manoeuvre/test_ihm_dataset.py`**: Integration tests for endpoints (`/api/dataset/{config

https://claude.ai/code/session_01CcBw4vWWgGWZo1MJ3qcFTB