### PR TITLE
IHM improvements: hosted mode, config modal, isolated devices, nodal order

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ system shipped as the default. See
 - [Documentation](#documentation)
 - [Features](#features)
 - [Installation](#installation)
+- [Getting Started](#getting-started)
 - [Usage Example](#usage-example)
 - [Pypowsybl Backend](#pypowsybl-backend)
 - [Pluggable Recommendation Models](#pluggable-recommendation-models)
@@ -207,6 +208,79 @@ module & web IHM, the RTE-7000 dataset, release notes, and the archive.
         ```bash
         pip install -e .[test]
         ```
+    * **Install the maneuver IHM extra (optional, adds Flask):**
+        ```bash
+        pip install -e ".[ihm]"   # quotes required on zsh
+        ```
+
+---
+
+## Getting Started
+
+The project has **two entry points**, both launched from the **project root**
+after installation. Pick the one that matches your task.
+
+### A · Expert system recommender (CLI)
+
+Analyse an N-1 contingency and print a **ranked list of corrective actions**:
+
+```bash
+pip install -e .                          # core install
+
+# 1) Default scenario (parameters taken from expert_op4grid_recommender/config.py)
+python expert_op4grid_recommender/main.py
+
+# 2) Custom contingency — date / timestep / faulted line(s)
+python expert_op4grid_recommender/main.py \
+    --date 2024-08-28 --timestep 36 --lines-defaut P.SAOL31RONCI
+
+# 3) Pure pypowsybl backend (no grid2op), with the fast simulation mode
+python expert_op4grid_recommender/main.py --backend pypowsybl --fast-mode
+```
+
+It sets up the environment, simulates the contingency, builds the overflow graph
+(saved under `Overflow_Graph/`), applies the expert rules, and prints the
+prioritized actions. See [Usage Example](#usage-example) for the full pipeline,
+[Pypowsybl Backend](#pypowsybl-backend) for backend options, and
+[Configuration](#configuration) for all tunable parameters.
+
+### B · Maneuver IHM (web)
+
+Turn a chosen **nodal** action into a safe, animated **switching sequence**
+through a lightweight web interface. It needs the optional **Flask** extra
+(`pypowsybl` / `networkx` / `pandas` are already core dependencies):
+
+```bash
+pip install -e ".[ihm]"                   # quotes required on zsh
+```
+
+**Local mode** — open the IHM on your own `.xiidm` network situation:
+
+```bash
+python scripts/manoeuvre_ihm.py --grid /path/to/grid.xiidm
+# then open http://localhost:8000
+```
+
+**Dataset mode** — source France situations **on demand** from the RTE-7000
+HuggingFace dataset by date/hour (omit `--grid`; this is what the hosted Space
+runs):
+
+```bash
+python scripts/manoeuvre_ihm.py --dataset
+# then open http://localhost:8000  → pick a date/hour, or "🗺 Explorer la journée"
+```
+
+In the IHM you pick a substation, edit the **target topology** (detailed clicks
+or the nodal bus view), compute and **animate the switching sequence**, then save
+scenarios/sequences. The **⚙ Config** modal exposes the available algorithms (per
+phase, default `libtopo`) and the scenario/sequence save paths; the **✍ login**
+field (left of ⚙ Config) tags saved scenarios with their author. Full guide:
+[`docs/manoeuvre/ihm.md`](docs/manoeuvre/ihm.md).
+
+> [!NOTE]
+> On a **hosted** instance (HuggingFace Space, auto-detected via `SPACE_ID`) local
+> file import is **disabled** for confidentiality — install the package and run
+> the IHM locally to load your own situations.
 
 ---
 
@@ -563,8 +637,33 @@ compute and **animate the switching sequence**, and save scenarios/sequences.
 It also backs the hosted **TopologyManoeuver4Grid** HuggingFace Space (network
 situations sourced on demand from the RTE-7000 dataset by date/hour).
 
+**Launch it** (after `pip install -e ".[ihm]"`):
+
+```bash
+# Local mode — your own .xiidm network situation
+python scripts/manoeuvre_ihm.py --grid /path/to/grid.xiidm   # http://localhost:8000
+
+# Dataset mode — RTE-7000 France situations sourced by date/hour (no --grid)
+python scripts/manoeuvre_ihm.py --dataset                    # http://localhost:8000
+```
+
+Highlights:
+
+- **Topology editing** — toggle breakers/disconnectors on the detailed schema, or
+  edit the **nodal bus view** (drag a feeder to re-route, a busbar onto another to
+  merge, **+ Nœud**), then **⚙ Calculer la topologie détaillée d'intérêt**.
+- **Declare isolated devices** — the **⌀ Isoler** action (or drop onto the
+  *Ouvrages isolés* zone) marks a feeder as a disconnected device kept **out of the
+  partition** (no longer mistaken for a one-device node).
+- **Day exploration** — a France map of the RTE-7000 day; hover a substation to see
+  its name, double-click to open it.
+- **Config & authoring** — the **⚙ Config** modal lists the pluggable algorithms
+  per phase (default `libtopo`) and the scenario/sequence save paths; the **✍ login**
+  field tags saved scenarios with their author (and a creation date is recorded).
+
 See the **annotated walkthrough** in the [Quick Overview](#quick-overview) above
-for the numbered tour of the interface. Full guide:
+for the numbered tour of the interface, and the **launch recipes** in
+[Getting Started](#getting-started). Full guide:
 [`docs/manoeuvre/ihm.md`](docs/manoeuvre/ihm.md).
 
 ---

--- a/docs/README.md
+++ b/docs/README.md
@@ -50,7 +50,9 @@ documented under [`architecture/plugins.md`](architecture/plugins.md).)
 - [`manoeuvre/regles.md`](manoeuvre/regles.md) — business rules (R1–R16) with
   rule-to-code traceability.
 - [`manoeuvre/ihm.md`](manoeuvre/ihm.md) — the interactive web IHM (topology
-  editor + sequence animation) and the hosted HuggingFace Space.
+  editor + sequence animation, day-exploration map, ⚙ config modal, isolated-device
+  declaration, scenario author/date metadata) and the hosted HuggingFace Space.
+  Launch recipes are in the [README Getting Started](../README.md#getting-started).
 - [`manoeuvre/postes_n_jeux_de_barres.md`](manoeuvre/postes_n_jeux_de_barres.md) —
   extension from 2-busbar to N-busbar substations.
 - [`manoeuvre/optimisations.md`](manoeuvre/optimisations.md) — performance/quality

--- a/docs/manoeuvre/ihm.md
+++ b/docs/manoeuvre/ihm.md
@@ -80,6 +80,16 @@ La couche de sourcing est `manoeuvre/dataset/source.py` (`lister_instantanes`,
 se charge en quelques secondes au premier choix d'une date ; les changements de
 poste à date constante sont quasi instantanés.
 
+**Import local désactivé sur le Space.** Sur une IHM **déportée** (HuggingFace,
+détectée par `SPACE_ID` / `MANOEUVRE_IHM_HOSTED` / `--hosted`), l'**import de
+fichiers locaux** est **interdit** : un fichier réseau peut porter des
+informations confidentielles. L'onglet **📁 Local** et son sélecteur de fichier
+sont **masqués** (une invite propose d'**installer le package et de lancer l'IHM
+chez soi** pour charger ses propres situations) ; côté serveur,
+`/api/pick_grid_file` et `/api/load_grid` répondent **`403`** (`{hosted:true}`).
+Seule la source **RTE7000** (dataset public, téléchargé à la demande) reste
+disponible.
+
 **Déploiement HuggingFace Docker Space** : `Dockerfile` (mono-conteneur Flask sur
 `:7860`, mode dataset) + `deploy/huggingface/` (README du Space + `SETUP.md`
 détaillé) + `.github/workflows/deploy-huggingface.yml` (redéploiement auto sur
@@ -156,8 +166,12 @@ Coordonnées du **plan de masse RTE** (planaire). Un **sélecteur d'heure** (en-
 de la carte : 00 h / 12 h / 23 h) choisit
 l'heure de la topologie ouverte au double-clic. Carte **autonome** (SVG,
 sans tuiles ni librairie externe) avec **zoom molette** et **déplacement au
-glisser** (manipulation du `viewBox`, fluide jusqu'à ~6 000 postes). Interactions :
+glisser** (manipulation du `viewBox`, fluide jusqu'à ~6 000 postes). Le **curseur
+sur les disques est une croix** (pointeur précis) plutôt qu'une main, pour pointer
+exactement le poste visé. Interactions :
 
+- **survol** d'un disque → **étiquette** affichant le **nom du poste** qui suit la
+  souris (`#mapTip`) — repérage immédiat sans cliquer ;
 - **clic** sur un disque → **bulle d'information** (nom, tension, total d'OC
   changés + ventilation par type, détail par voltage level, rang) ;
 - **double-clic** (ou bouton de la bulle) → bascule en **vue topologique** du
@@ -286,7 +300,12 @@ le bandeau indique la cause (OSM injoignable, ou joignable mais 0 apparié avec 
   les journées « cas d'intérêt » documentées, chacune avec sa **bulle**
   d'explication) — et un **unique bouton ⏬ Charger** qui agit sur l'onglet actif.
   L'onglet **RTE7000 est mis en avant par défaut** sur le HuggingFace Space (mode
-  dataset) ; **Local** par défaut en usage local.
+  dataset) ; **Local** par défaut en usage local. Un bouton **⚙ Config** (en-tête
+  *Situation réseau*) ouvre une **modale de configuration** : **algorithmes
+  pluggables par phase** (identification / séquencement / planification, avec le
+  défaut **« libtopo »**) et **chemins de sauvegarde / rechargement** des
+  scénarios et séquences (en **lecture seule** sur une IHM déportée). Voir
+  `GET/POST /api/config`.
 - **Scénario Topologique** : la suite de travail en **trois étapes** —
   **1 · Poste** (champ de recherche **unique** sur tous les postes + liste
   browsable curée **par typologie** en dessous), **2 · Topologie cible** (éditer
@@ -430,6 +449,17 @@ d'espace en barre. Pour en **reconnecter** un, le **glisser sur une barre** (il
 rejoint ce nœud) ; côté serveur, les isolés restants sont **laissés déconnectés**
 (hors partition cible).
 Le compteur de nœuds exclut les isolés.
+
+**Déclarer un ouvrage à isoler** (champ dédié). Pour mettre un départ **hors
+service** dans la cible, on le **déclare isolé** plutôt que de le placer seul dans
+un nœud : sélectionner le(s) départ(s) puis **⌀ Isoler** (ou les **glisser sur la
+zone « Ouvrages isolés »** de la cible, qui reste visible comme cible de dépose
+même vide). Le départ rejoint alors la liste **Ouvrages isolés** (envoyée dans
+`isolated` à `/api/nodale_to_detaillee`) : le backend le **laisse hors partition**
+**et le déconnecte réellement** (nœud 0-barre — `Session._isoler_dans_etat` ouvre
+les organes fermés qui le raccordent à une barre). Cela évite l'ancien contournement
+(« nœud à un seul ouvrage ») que le backend interprétait à tort comme un **véritable
+nœud électrique**.
 - **⚙ Calculer la topologie détaillée d'intérêt** : envoie la partition nodale
   (`/api/nodale_to_detaillee`) ; l'IHM **charge l'état détaillé réalisant** cette
   cible dans le schéma du bas (devient la nouvelle cible détaillée, à **valider**
@@ -567,9 +597,12 @@ navigateur).
 | `POST /api/seq_delete` | `{index}` | idem `seq_insert` | Supprime la manœuvre n°`index` (1-based) |
 | `POST /api/seq_delete_many` | `{indices:[…]}` | idem `seq_insert` | Supprime en une fois plusieurs manœuvres (sélection / bloc) |
 | `POST /api/manual_start` | — | `{cible_svg, cible_nb, goto, manoeuvres[], n_steps, labels[], …}` | Démarre une séquence **manuelle vierge** (départ → cible affichée en référence) |
-| `GET /api/scenarios` | — | `{scenarios:[{name, vl, sub, nominal_v, nb_barres, nb_depart, nb_cible, n_dj, n_sa, n_int, n_nodal, dt, year, season, weekday, source}]}` | Liste des scénarios **avec métadonnées de recherche** |
+| `GET /api/config` | — | `{algos:{disponibles,selection}, scenarios_dir, sequences_dir, hosted}` | Config **runtime** (modale ⚙ Config) : algos pluggables par phase + sélection, chemins de sauvegarde/rechargement |
+| `POST /api/config` | `{algos?, scenarios_dir?, sequences_dir?}` | idem `GET /api/config` | Met à jour la sélection d'algos et les **dossiers** scénarios/séquences ; chemins **ignorés** si `hosted` (lecture seule) |
+| `GET /api/pick_grid_file`, `POST /api/load_grid` *(déporté)* | — | `403 {ok:false, error, hosted:true}` | **Import local refusé** sur une IHM hébergée (confidentialité des fichiers) |
+| `GET /api/scenarios` | — | `{scenarios:[{name, vl, sub, nominal_v, nb_barres, nb_depart, nb_cible, n_dj, n_sa, n_int, n_nodal, dt, year, season, weekday, cible_dt, source}]}` | Liste des scénarios **avec métadonnées de recherche** (dont `cible_dt`) |
 | `GET /api/scenarios_archive` | — | `application/zip` | **Archive ZIP** de toute la base de scénarios (`scenarios.zip`) |
-| `POST /api/save` | `{name, depart_dt?, source?}` | `{path, name, content, scenarios[]}` ou `{already_exists:true, name, path, scenarios[]}` | Sauvegarde **anti-doublon** (identique → non réécrit) avec **nom unique indexé** ; `meta` calculée + `dt/source` loggés ; `content` = JSON pour téléchargement local |
+| `POST /api/save` | `{name, depart_dt?, cible_dt?, source?}` | `{path, name, content, scenarios[]}` ou `{already_exists:true, name, path, scenarios[]}` | Sauvegarde **anti-doublon** (identique → non réécrit) avec **nom unique indexé** ; `meta` calculée + `dt`/`cible_dt`/`source` loggés (`cible_dt` = date/heure de la topo **cible** RTE7000 **non modifiée**) ; `content` = JSON pour téléchargement local |
 | `POST /api/load_scenario` | `{name, mode}` | `{initial_svg, nb_initial, svg, switches, nb_noeuds, vl, meta, nodale_depart, nodale_cible}` | Recharge (`mode="both"` ou `"as_depart"`) ; `meta` (date/heure, source) → re-synchro Date/Heure côté IHM |
 | `POST /api/save_sequence` | `{name, overwrite?}` | `{path, name, content}` ou `{exists:true, name, path}` | Sauvegarde la séquence **courante** ; `content` = JSON écrit |
 
@@ -600,14 +633,18 @@ Topologie cible validée, réutilisable comme cible (rejeu) ou comme départ.
     "vl": "CARRIP3", "sub": "CARRI", "nominal_v": 63.0,
     "nb_barres": 2, "nb_depart": 1, "nb_cible": 2,
     "n_dj": 3, "n_sa": 0, "n_int": 0, "n_nodal": 1,
-    "dt": "2021-01-03T12:00", "year": 2021, "season": "hiver",
-    "weekday": 6, "source": "rte"
+    "dt": "2021-01-03T08:00", "year": 2021, "season": "hiver",
+    "weekday": 6, "cible_dt": "2021-01-03T12:00", "source": "rte"
   }
 }
 ```
 Le bloc `meta` (ajouté v0.2.x) alimente la **recherche** dans la base partagée
 (tension, barres, OC par type, ouvrages déplacés, date/heure de départ →
-année/saison/jour). Absent des fichiers antérieurs (champs `null`).
+année/saison/jour). `dt` = date/heure de la **topologie de départ** (RTE7000 :
+date/heure choisies ; local : `case_date` du fichier) ; `cible_dt` = date/heure de
+la **topologie cible**, conservée pour un fichier RTE7000 dont la cible **n'a pas
+été modifiée** (topologie observée à cette heure ; `null` sinon). Absent des
+fichiers antérieurs (champs `null`).
 
 ### Séquence (`--sequences-dir/<nom>.json`)
 Séquence **courante** (telle qu'éventuellement éditée par l'expert) + topologies
@@ -706,6 +743,11 @@ assert res.ecarts == []
 | **Replier** indépendamment les sections nodales **Départ** / **Cible** | Bouton **▾ / ▸** dans le `.stitle` → `toggleNsec()` (replie tout sauf le titre ; l'autre section prend l'espace) |
 | **Re-éditer la cible détaillée** après calcul de séquence + signaler l'obsolescence | Bouton **✎ Modifier la cible** (`/api/cible`) ; bandeau « la séquence n'atteint plus cet état cible » |
 | Demander un **calcul de topologie détaillée d'intérêt** depuis la cible nodale | `/api/nodale_to_detaillee` → façade `identifier_topologie_detaillee` (phase A, algo sélectionné), cible détaillée chargée |
+| **Désactiver l'import de fichier local** sur une IHM déportée (confidentialité) | Onglet **📁 Local** masqué + invite à l'IHM locale (`#hostedNote`) ; `/api/pick_grid_file` & `/api/load_grid` → `403` si `hosted` |
+| Voir le **nom des postes au survol** sur la carte + **curseur pointeur précis** | `#mapTip` (étiquette suivant la souris) + `.pdisk{cursor:crosshair}` |
+| **Modale de configuration** : algos disponibles (+ défaut) et chemins de sauvegarde/rechargement | Bouton **⚙ Config** → modale `#configModal` ; `GET/POST /api/config` |
+| **Conserver date/heure** de la topo de départ **et** de la topo cible (RTE7000 non modifiée) | `meta.dt` (départ) + `meta.cible_dt` (cible) ; `save()` envoie `depart_dt`/`cible_dt` |
+| **Déclarer des ouvrages à isoler** (hors partition, vraiment déconnectés) | Bouton **⌀ Isoler** / dépose sur la zone *Ouvrages isolés* → `isolated` ; `Session._isoler_dans_etat` ouvre les organes (nœud 0-barre) |
 
 ---
 

--- a/docs/manoeuvre/ihm.md
+++ b/docs/manoeuvre/ihm.md
@@ -305,7 +305,9 @@ le bandeau indique la cause (OSM injoignable, ou joignable mais 0 apparié avec 
   pluggables par phase** (identification / séquencement / planification, avec le
   défaut **« libtopo »**) et **chemins de sauvegarde / rechargement** des
   scénarios et séquences (en **lecture seule** sur une IHM déportée). Voir
-  `GET/POST /api/config`.
+  `GET/POST /api/config`. À **gauche** de ce bouton, un champ **✍ votre nom**
+  porte l'**auteur** des scénarios (mémorisé localement, modifiable à tout
+  moment ; demandé une fois à la première sauvegarde).
 - **Scénario Topologique** : la suite de travail en **trois étapes** —
   **1 · Poste** (champ de recherche **unique** sur tous les postes + liste
   browsable curée **par typologie** en dessous), **2 · Topologie cible** (éditer
@@ -611,9 +613,9 @@ navigateur).
 | `GET /api/config` | — | `{algos:{disponibles,selection}, scenarios_dir, sequences_dir, hosted}` | Config **runtime** (modale ⚙ Config) : algos pluggables par phase + sélection, chemins de sauvegarde/rechargement |
 | `POST /api/config` | `{algos?, scenarios_dir?, sequences_dir?}` | idem `GET /api/config` | Met à jour la sélection d'algos et les **dossiers** scénarios/séquences ; chemins **ignorés** si `hosted` (lecture seule) |
 | `GET /api/pick_grid_file`, `POST /api/load_grid` *(déporté)* | — | `403 {ok:false, error, hosted:true}` | **Import local refusé** sur une IHM hébergée (confidentialité des fichiers) |
-| `GET /api/scenarios` | — | `{scenarios:[{name, vl, sub, nominal_v, nb_barres, nb_depart, nb_cible, n_dj, n_sa, n_int, n_nodal, dt, year, season, weekday, cible_dt, source}]}` | Liste des scénarios **avec métadonnées de recherche** (dont `cible_dt`) |
+| `GET /api/scenarios` | — | `{scenarios:[{name, vl, sub, nominal_v, nb_barres, nb_depart, nb_cible, n_dj, n_sa, n_int, n_nodal, dt, year, season, weekday, cible_dt, source, created_at, author}]}` | Liste des scénarios **avec métadonnées de recherche** (dont `cible_dt`, `created_at`, `author`) |
 | `GET /api/scenarios_archive` | — | `application/zip` | **Archive ZIP** de toute la base de scénarios (`scenarios.zip`) |
-| `POST /api/save` | `{name, depart_dt?, cible_dt?, source?}` | `{path, name, content, scenarios[]}` ou `{already_exists:true, name, path, scenarios[]}` | Sauvegarde **anti-doublon** (identique → non réécrit) avec **nom unique indexé** ; `meta` calculée + `dt`/`cible_dt`/`source` loggés (`cible_dt` = date/heure de la topo **cible** RTE7000 **non modifiée**) ; `content` = JSON pour téléchargement local |
+| `POST /api/save` | `{name, depart_dt?, cible_dt?, source?, author?}` | `{path, name, content, scenarios[]}` ou `{already_exists:true, name, path, scenarios[]}` | Sauvegarde **anti-doublon** (identique → non réécrit) avec **nom unique indexé** ; `meta` calculée + `dt`/`cible_dt`/`source`/`author` loggés + `created_at` (horloge serveur) ; `content` = JSON pour téléchargement local |
 | `POST /api/load_scenario` | `{name, mode}` | `{initial_svg, nb_initial, svg, switches, nb_noeuds, vl, meta, nodale_depart, nodale_cible}` | Recharge (`mode="both"` ou `"as_depart"`) ; `meta` (date/heure, source) → re-synchro Date/Heure côté IHM |
 | `POST /api/save_sequence` | `{name, overwrite?}` | `{path, name, content}` ou `{exists:true, name, path}` | Sauvegarde la séquence **courante** ; `content` = JSON écrit |
 
@@ -645,7 +647,8 @@ Topologie cible validée, réutilisable comme cible (rejeu) ou comme départ.
     "nb_barres": 2, "nb_depart": 1, "nb_cible": 2,
     "n_dj": 3, "n_sa": 0, "n_int": 0, "n_nodal": 1,
     "dt": "2021-01-03T08:00", "year": 2021, "season": "hiver",
-    "weekday": 6, "cible_dt": "2021-01-03T12:00", "source": "rte"
+    "weekday": 6, "cible_dt": "2021-01-03T12:00", "source": "rte",
+    "created_at": "2025-02-14T09:30", "author": "Alice"
   }
 }
 ```
@@ -654,8 +657,14 @@ Le bloc `meta` (ajouté v0.2.x) alimente la **recherche** dans la base partagée
 année/saison/jour). `dt` = date/heure de la **topologie de départ** (RTE7000 :
 date/heure choisies ; local : `case_date` du fichier) ; `cible_dt` = date/heure de
 la **topologie cible**, conservée pour un fichier RTE7000 dont la cible **n'a pas
-été modifiée** (topologie observée à cette heure ; `null` sinon). Absent des
-fichiers antérieurs (champs `null`).
+été modifiée** (topologie observée à cette heure ; `null` sinon). `created_at` =
+**date de création** du fichier (horloge serveur) ; `author` = **auteur**
+(facultatif, saisi dans l'IHM). Absent des fichiers antérieurs (champs `null`).
+
+> **Auteur** : un champ **✍ votre nom** (à gauche du bouton **⚙ Config**) porte
+> l'auteur des scénarios — **mémorisé localement** (navigateur) et **modifiable à
+> tout moment**. À la **première sauvegarde** sans nom déclaré, l'IHM le **demande
+> une fois** via une petite modale offrant une coche **« ne plus me redemander »**.
 
 ### Séquence (`--sequences-dir/<nom>.json`)
 Séquence **courante** (telle qu'éventuellement éditée par l'expert) + topologies
@@ -758,6 +767,7 @@ assert res.ecarts == []
 | Voir le **nom des postes au survol** sur la carte + **curseur pointeur précis** | `#mapTip` (étiquette suivant la souris) + `.pdisk{cursor:crosshair}` |
 | **Modale de configuration** : algos disponibles (+ défaut) et chemins de sauvegarde/rechargement | Bouton **⚙ Config** → modale `#configModal` ; `GET/POST /api/config` |
 | **Conserver date/heure** de la topo de départ **et** de la topo cible (RTE7000 non modifiée) | `meta.dt` (départ) + `meta.cible_dt` (cible) ; `save()` envoie `depart_dt`/`cible_dt` |
+| **Date de création** + **auteur** dans les métadonnées des scénarios | `meta.created_at` (horloge serveur) + `meta.author` ; champ **✍ votre nom** (gauche de ⚙ Config), demandé une fois (coche « ne plus me redemander ») |
 | **Déclarer des ouvrages à isoler** (hors partition, vraiment déconnectés) | Bouton **⌀ Isoler** / dépose sur la zone *Ouvrages isolés* → `isolated` ; `Session._isoler_dans_etat` ouvre les organes (nœud 0-barre) |
 
 ---

--- a/docs/manoeuvre/ihm.md
+++ b/docs/manoeuvre/ihm.md
@@ -305,7 +305,7 @@ le bandeau indique la cause (OSM injoignable, ou joignable mais 0 apparié avec 
   pluggables par phase** (identification / séquencement / planification, avec le
   défaut **« libtopo »**) et **chemins de sauvegarde / rechargement** des
   scénarios et séquences (en **lecture seule** sur une IHM déportée). Voir
-  `GET/POST /api/config`. À **gauche** de ce bouton, un champ **✍ votre nom**
+  `GET/POST /api/config`. À **gauche** de ce bouton, un champ **✍ votre login**
   porte l'**auteur** des scénarios (mémorisé localement, modifiable à tout
   moment ; demandé une fois à la première sauvegarde).
 - **Scénario Topologique** : la suite de travail en **trois étapes** —
@@ -661,7 +661,7 @@ la **topologie cible**, conservée pour un fichier RTE7000 dont la cible **n'a p
 **date de création** du fichier (horloge serveur) ; `author` = **auteur**
 (facultatif, saisi dans l'IHM). Absent des fichiers antérieurs (champs `null`).
 
-> **Auteur** : un champ **✍ votre nom** (à gauche du bouton **⚙ Config**) porte
+> **Auteur** : un champ **✍ votre login** (à gauche du bouton **⚙ Config**) porte
 > l'auteur des scénarios — **mémorisé localement** (navigateur) et **modifiable à
 > tout moment**. À la **première sauvegarde** sans nom déclaré, l'IHM le **demande
 > une fois** via une petite modale offrant une coche **« ne plus me redemander »**.
@@ -767,7 +767,7 @@ assert res.ecarts == []
 | Voir le **nom des postes au survol** sur la carte + **curseur pointeur précis** | `#mapTip` (étiquette suivant la souris) + `.pdisk{cursor:crosshair}` |
 | **Modale de configuration** : algos disponibles (+ défaut) et chemins de sauvegarde/rechargement | Bouton **⚙ Config** → modale `#configModal` ; `GET/POST /api/config` |
 | **Conserver date/heure** de la topo de départ **et** de la topo cible (RTE7000 non modifiée) | `meta.dt` (départ) + `meta.cible_dt` (cible) ; `save()` envoie `depart_dt`/`cible_dt` |
-| **Date de création** + **auteur** dans les métadonnées des scénarios | `meta.created_at` (horloge serveur) + `meta.author` ; champ **✍ votre nom** (gauche de ⚙ Config), demandé une fois (coche « ne plus me redemander ») |
+| **Date de création** + **auteur** dans les métadonnées des scénarios | `meta.created_at` (horloge serveur) + `meta.author` ; champ **✍ votre login** (gauche de ⚙ Config), demandé une fois (coche « ne plus me redemander ») |
 | **Déclarer des ouvrages à isoler** (hors partition, vraiment déconnectés) | Bouton **⌀ Isoler** / dépose sur la zone *Ouvrages isolés* → `isolated` ; `Session._isoler_dans_etat` ouvre les organes (nœud 0-barre) |
 
 ---

--- a/docs/manoeuvre/ihm.md
+++ b/docs/manoeuvre/ihm.md
@@ -467,9 +467,16 @@ nœud électrique**.
 - **⚙ Calculer la topologie détaillée d'intérêt** : envoie la partition nodale
   (`/api/nodale_to_detaillee`) ; l'IHM **charge l'état détaillé réalisant** cette
   cible dans le schéma du bas (devient la nouvelle cible détaillée, à **valider**
-  avant calcul de séquence). Le statut indique **✓** si la cible nodale est
+  avant calcul de séquence). Le schéma détaillé obtenu met aussi en évidence les
+  **organes qui diffèrent du départ** (vert = fermé à la cible, orange = ouvert),
+  comme une édition manuelle (le diff `changes` est renvoyé par
+  `/api/nodale_to_detaillee`). Le statut indique **✓** si la cible nodale est
   intégralement réalisable, ou un message de **réalisation partielle** (nœuds non
-  réalisables, écarts) en cas de dégradation gracieuse de l'algorithme.
+  réalisables, écarts) en cas de dégradation gracieuse de l'algorithme. Les
+  **ouvrages isolés** sont **comptés à part**, jamais comme des nœuds : le statut
+  affiche « **N nœud(s) + M ouvrage(s) isolé(s)** » (`nb_obtenu` = nœuds réels,
+  `nb_isoles` = isolés) et **non** un total gonflé (plus de « obtenu 4 » pour
+  2 nœuds + 2 isolés).
   Le volet nodal cible est alors **resynchronisé sur la topologie réalisée**
   (partition, **couleurs** topological_coloring et ouvrages isolés renvoyés dans
   `nodale` par `/api/nodale_to_detaillee`) : il prend les mêmes nœuds et couleurs
@@ -594,7 +601,7 @@ navigateur).
 | `POST /api/promote_cible` | — | `{initial_svg, nb_initial, svg, switches, nb_noeuds, vl, nodale_depart, nodale_cible}` | **Promeut la cible courante en nouvel état de départ** (chaînage sans scénario sauvegardé) ; met à jour les deux schémas + vues nodales |
 | `POST /api/cible` | — | `{svg, switches, nb_noeuds, nodale}` | Vue de la cible détaillée **courante** (sans la modifier) — pour revenir l'éditer alors qu'une séquence est calculée |
 | `POST /api/nodale` | — | `{nodale_depart, nodale_cible}` | Partitions nodales (cible initialisée = départ) ; `nodale_*` = `{groups[[…]], labels{id:nom}, types{id:type}, flows{id:MW}, dirs{id:TOP\|BOTTOM}, order{id:x}, colors{id:#hex}, isolated[…]}`. `labels`/`dirs`/`order`/`colors` sont **extraits du SLD** (libellés, côté, ordre horizontal et **couleur du nœud `topological_coloring`** identiques à la vue détaillée) ; `flows` provient d'une charge de réseau ; `isolated` liste les départs **déconnectés** (composante sans barre) |
-| `POST /api/nodale_to_detaillee` | `{groups, isolated?}` | `{svg, switches, nb_noeuds, is_verified, message, ecarts[], noeuds_non_realisables[[…]], nb_obtenu, nb_vise, nodale}` | Calcule la **topologie détaillée d'intérêt** réalisant la cible nodale `groups` (les `isolated` sont laissés hors partition) et la charge comme cible détaillée ; `nodale` = `{groups, colors, isolated}` de la topologie **réalisée** (resynchronise le volet nodal) |
+| `POST /api/nodale_to_detaillee` | `{groups, isolated?}` | `{svg, switches, nb_noeuds, is_verified, message, ecarts[], noeuds_non_realisables[[…]], nb_obtenu, nb_isoles, nb_vise, changes[], nodale}` | Calcule la **topologie détaillée d'intérêt** réalisant la cible nodale `groups` ; les `isolated` sont laissés **hors partition** et **réellement déconnectés** (nœud 0-barre). `nb_obtenu` = nœuds **réels** (isolés exclus), `nb_isoles` = ouvrages isolés (comptés à part), `changes` = diff départ→cible (surlignage vert/orange), `nodale` = `{groups, colors, isolated}` de la topologie **réalisée** (resynchronise le volet nodal) |
 | `POST /api/sequence` | `{mode?}` | `{verified, verified_detaillee, ecarts[], alertes[], message, nb_manoeuvres, manoeuvres[], n_steps, labels[], nb_final, matches_cible, edited, mode}` | Calcule la séquence (cible **détaillée**) ; `mode` = `"smooth"` (défaut) ou `"aggressive"` ; `alertes` = **bonne pratique non bloquante** (R10ter : > 1 ouvrage ré-aiguillé hors tension à la fois, mode smooth), affichée en badge ⚠ |
 | `GET /api/step?i=k` | — | `{svg, switches[], nb_noeuds, i, reached, nodale}` | Image d'animation de l'étape *k* (surlignée) **+ organes cliquables** ; `reached` = l'état affiché est la topologie cible ; `nodale` = **partition nodale de l'état détaillé de l'étape** (`{groups, colors, isolated}`) → le volet nodal **suit l'étape** (départ → … → cible) ; `null` si aucune séquence |
 | `POST /api/seq_insert` | `{step, id}` | `{goto, manoeuvres[], n_steps, labels[], nb_final, matches_cible, edited}` | Insère une manœuvre basculant `id` **après** l'étape `step` (conserve la suite) |

--- a/docs/manoeuvre/ihm.md
+++ b/docs/manoeuvre/ihm.md
@@ -418,7 +418,11 @@ défaut (qui délègue à `determiner_topo_complete_cible(poste, topo_cible)`).
   SLD : même nœud électrique ⇒ même couleur), repérée par un badge `N0`, `N1`… Ses
   branches sont des **départs verticaux** — *du haut* au-dessus de la barre, *du
   bas* en dessous, comme dans la vue détaillée — **triés de gauche à droite** par
-  leur abscisse SLD. Chaque branche porte son **libellé** (extrait du SLD, donc
+  leur abscisse SLD. Les départs *du haut* et *du bas* **partagent le même axe
+  horizontal** (une **colonne par rang d'abscisse SLD**, haut et bas confondus) :
+  chaque départ conserve donc **à la fois son côté (haut/bas) et sa position
+  gauche → droite** exactement comme dans la vue détaillée. Chaque branche porte
+  son **libellé** (extrait du SLD, donc
   **strictement identique** au schéma détaillé : `C.REG1`, `AT762`, `TR634`…) et sa
   **valeur de flux** (P en MW, état de départ). Les nœuds sont **empilés
   verticalement**. Le volet montre la topologie nodale de **départ** (lecture

--- a/scripts/manoeuvre_ihm.py
+++ b/scripts/manoeuvre_ihm.py
@@ -1103,7 +1103,7 @@ class Session:
                 **self._date_tags(depart_dt)}
 
     def save_scenario(self, name: str, depart_dt=None, source=None,
-                      cible_dt=None) -> dict:
+                      cible_dt=None, author=None) -> dict:
         """Sauvegarde le scénario courant (départ + cible) en **évitant les
         doublons** :
 
@@ -1151,6 +1151,11 @@ class Session:
         # quand la cible n'a **pas** été modifiée (topologie observée à cette heure).
         # ``None`` sinon (cible éditée par l'expert : plus rattachée à un instantané).
         meta["cible_dt"] = cible_dt or None
+        # **Date de création** du fichier (horloge serveur) + **auteur** (facultatif,
+        # renseigné par l'IHM) — traçabilité des scénarios sauvegardés.
+        from datetime import datetime
+        meta["created_at"] = datetime.now().strftime("%Y-%m-%dT%H:%M")
+        meta["author"] = (author or "").strip() or None
         data = {
             "voltage_level_id": self.vl, "name": final,
             "depart": cur_dep, "cible": cur_cib,
@@ -1186,7 +1191,8 @@ class Session:
                         "n_int": m.get("n_int"), "n_nodal": m.get("n_nodal"),
                         "dt": m.get("dt"), "year": m.get("year"),
                         "season": m.get("season"), "weekday": m.get("weekday"),
-                        "cible_dt": m.get("cible_dt"), "source": m.get("source")})
+                        "cible_dt": m.get("cible_dt"), "source": m.get("source"),
+                        "created_at": m.get("created_at"), "author": m.get("author")})
         return out
 
     def load_scenario(self, name: str, mode: str = "both") -> str:
@@ -1967,7 +1973,8 @@ def api_save():
     name = _safe_name(request.json.get("name", ""), SESSION.vl)
     res = SESSION.save_scenario(name, depart_dt=request.json.get("depart_dt"),
                                 source=request.json.get("source"),
-                                cible_dt=request.json.get("cible_dt"))
+                                cible_dt=request.json.get("cible_dt"),
+                                author=request.json.get("author"))
     if res["status"] == "exists":
         # scénario déjà présent (départ + cible identiques) → non écrasé.
         return jsonify(already_exists=True, name=res["name"], path=res["path"],

--- a/scripts/manoeuvre_ihm.py
+++ b/scripts/manoeuvre_ihm.py
@@ -908,6 +908,36 @@ class Session:
             colors = self._branch_colors([eq for g in groups for eq in g])
         return {"groups": groups, "colors": colors, "isolated": isolated}
 
+    def _isoler_dans_etat(self, state: dict[str, bool], equipements) -> dict[str, bool]:
+        """Force les ``equipements`` **déclarés isolés** à être réellement
+        déconnectés dans ``state`` : ouvre les organes **fermés** reliant chaque
+        équipement encore **en service** à une barre, de sorte qu'il devienne un
+        **nœud 0-barre** (ouvrage isolé) et non un véritable nœud électrique.
+
+        Les équipements **déjà déconnectés** au départ sont laissés tels quels.
+        Renvoie une **copie** de ``state`` (jamais muté en place)."""
+        cibles = {str(e) for e in (equipements or [])}
+        if not cibles:
+            return dict(state)
+        out = dict(state)
+        with self.applied(out):
+            G = self._graph(out)
+        deja_iso = set(_isolated_assets(G))
+        eq_to_nodes: dict[str, list] = {}
+        for n, data in G.nodes(data=True):
+            eq = data.get("equipment_id")
+            if eq in cibles:
+                eq_to_nodes.setdefault(eq, []).append(n)
+        for eq, nodes in eq_to_nodes.items():
+            if eq in deja_iso:
+                continue   # déjà déconnecté → aucun organe à manœuvrer
+            for node in nodes:
+                for _u, _v, d in G.edges(node, data=True):
+                    sid = d.get("switch_id")
+                    if sid is not None and not d.get("open", False) and sid in out:
+                        out[sid] = True   # ouvrir l'organe → détache l'ouvrage
+        return out
+
     def nodale_to_detaillee(self, groups, isolated=None) -> dict:
         """Pont **nodal → détaillé** : calcule une topologie détaillée d'intérêt
         réalisant la partition nodale cible ``groups`` (éditée par l'expert) et la
@@ -942,6 +972,12 @@ class Session:
                             for k, v in self.initial.items()}
         else:
             self.current = dict(self.initial)
+        # Ouvrages **explicitement déclarés isolés** par l'expert : forcer leur
+        # déconnexion réelle (nœud 0-barre) au lieu de les laisser sur une barre —
+        # l'algo ne manœuvre que les départs de la partition, donc un ouvrage en
+        # service déclaré isolé resterait sinon connecté.
+        if iso:
+            self.current = self._isoler_dans_etat(self.current, iso)
         self.scenario_name = None   # cible à revalider avant calcul de séquence
 
         svg, switches, nb = self.view(self.current)
@@ -1042,7 +1078,8 @@ class Session:
                 "n_int": cnt["LOAD_BREAK_SWITCH"], "n_nodal": nodal,
                 **self._date_tags(depart_dt)}
 
-    def save_scenario(self, name: str, depart_dt=None, source=None) -> dict:
+    def save_scenario(self, name: str, depart_dt=None, source=None,
+                      cible_dt=None) -> dict:
         """Sauvegarde le scénario courant (départ + cible) en **évitant les
         doublons** :
 
@@ -1086,6 +1123,10 @@ class Session:
         meta = self.scenario_meta(depart_dt)
         if source:
             meta["source"] = source   # 'rte' | 'local' (pour re-synchroniser l'IHM)
+        # Date/heure de la topologie **cible** : conservée pour les fichiers RTE7000
+        # quand la cible n'a **pas** été modifiée (topologie observée à cette heure).
+        # ``None`` sinon (cible éditée par l'expert : plus rattachée à un instantané).
+        meta["cible_dt"] = cible_dt or None
         data = {
             "voltage_level_id": self.vl, "name": final,
             "depart": cur_dep, "cible": cur_cib,
@@ -1121,7 +1162,7 @@ class Session:
                         "n_int": m.get("n_int"), "n_nodal": m.get("n_nodal"),
                         "dt": m.get("dt"), "year": m.get("year"),
                         "season": m.get("season"), "weekday": m.get("weekday"),
-                        "source": m.get("source")})
+                        "cible_dt": m.get("cible_dt"), "source": m.get("source")})
         return out
 
     def load_scenario(self, name: str, mode: str = "both") -> str:
@@ -1659,8 +1700,13 @@ def api_explore_coords_file():
 def api_load_grid():
     """Charge une **situation réseau** quelconque (chemin ``.xiidm`` côté serveur)
     et réinitialise la session. Permet d'inspecter/tester n'importe quel poste
-    d'une situation arbitraire sans relancer le serveur."""
+    d'une situation arbitraire sans relancer le serveur.
+
+    **Refusé sur une IHM déportée** (Space) : charger un ``.xiidm`` arbitraire
+    côté serveur est désactivé (confidentialité). Utiliser l'IHM en local."""
     global SESSION
+    if DATASET["hosted"]:
+        return jsonify(ok=False, error=_HOSTED_IMPORT_MSG, hosted=True), 403
     path = ((request.json or {}).get("path") or "").strip()
     if not path or not pathlib.Path(path).expanduser().exists():
         return jsonify(ok=False, error=f"Fichier introuvable : {path}"), 400
@@ -1710,12 +1756,26 @@ def _pick_grid_file_tkinter() -> dict:
     return {"path": proc.stdout.strip()}
 
 
+#: message renvoyé quand l'import local est refusé (IHM déportée / Space).
+_HOSTED_IMPORT_MSG = (
+    "Import de fichier local désactivé sur cette instance hébergée : un fichier "
+    "réseau peut contenir des informations confidentielles. Installez le package "
+    "et lancez l'IHM en local pour charger vos propres situations : "
+    'pip install -e ".[ihm]" puis '
+    "python scripts/manoeuvre_ihm.py --grid /chemin/grid.xiidm")
+
+
 @app.get("/api/pick_grid_file")
 def api_pick_grid_file():
     """Ouvre un sélecteur de fichier **natif** (usage local) pour choisir une
     situation réseau ``.xiidm`` et renvoie ``{path, error?}`` — ``path`` vide si
     l'utilisateur annule. Sur un serveur sans afficheur (Space), renvoie une
-    ``error`` (l'IHM invite alors à coller le chemin à la main)."""
+    ``error`` (l'IHM invite alors à coller le chemin à la main).
+
+    **Refusé sur une IHM déportée** (Space) : l'import local est désactivé (les
+    fichiers peuvent porter des données confidentielles)."""
+    if DATASET["hosted"]:
+        return jsonify(path="", error=_HOSTED_IMPORT_MSG, hosted=True), 403
     try:
         if platform.system() == "Darwin":
             return jsonify(_pick_grid_file_macos())
@@ -1805,6 +1865,40 @@ def api_algos_set():
     return jsonify(disponibles=algos_disponibles(), selection=selection)
 
 
+@app.get("/api/config")
+def api_config():
+    """Configuration **runtime** de l'IHM (modale ⚙ Config) : algorithmes
+    pluggables disponibles + sélection courante (par phase), et **chemins de
+    sauvegarde / rechargement** des scénarios et séquences. ``hosted`` => les
+    chemins sont en **lecture seule** (FS éphémère du Space)."""
+    return jsonify(
+        algos={"disponibles": algos_disponibles(), "selection": _algos_courants()},
+        scenarios_dir=str(SCEN_DIR), sequences_dir=str(SEQ_DIR),
+        hosted=DATASET["hosted"])
+
+
+@app.post("/api/config")
+def api_config_set():
+    """Met à jour la config runtime : sélection d'algorithmes (par phase) et
+    **dossiers** de scénarios / séquences. Sur une IHM déportée (Space), les
+    chemins sont **ignorés** (lecture seule). Renvoie la config effective."""
+    global SCEN_DIR, SEQ_DIR
+    body = request.json or {}
+    if SESSION is not None and isinstance(body.get("algos"), dict):
+        SESSION.set_algos(body["algos"])
+    if not DATASET["hosted"]:
+        sd = (body.get("scenarios_dir") or "").strip()
+        qd = (body.get("sequences_dir") or "").strip()
+        if sd:
+            SCEN_DIR = pathlib.Path(sd).expanduser()
+        if qd:
+            SEQ_DIR = pathlib.Path(qd).expanduser()
+    return jsonify(
+        algos={"disponibles": algos_disponibles(), "selection": _algos_courants()},
+        scenarios_dir=str(SCEN_DIR), sequences_dir=str(SEQ_DIR),
+        hosted=DATASET["hosted"])
+
+
 @app.post("/api/nodale_to_detaillee")
 def api_nodale_to_detaillee():
     """Calcule la topologie détaillée d'intérêt réalisant la cible nodale éditée
@@ -1848,7 +1942,8 @@ def _safe_name(name, default):
 def api_save():
     name = _safe_name(request.json.get("name", ""), SESSION.vl)
     res = SESSION.save_scenario(name, depart_dt=request.json.get("depart_dt"),
-                                source=request.json.get("source"))
+                                source=request.json.get("source"),
+                                cible_dt=request.json.get("cible_dt"))
     if res["status"] == "exists":
         # scénario déjà présent (départ + cible identiques) → non écrasé.
         return jsonify(already_exists=True, name=res["name"], path=res["path"],

--- a/scripts/manoeuvre_ihm.py
+++ b/scripts/manoeuvre_ihm.py
@@ -981,19 +981,43 @@ class Session:
         self.scenario_name = None   # cible à revalider avant calcul de séquence
 
         svg, switches, nb = self.view(self.current)
+        realized = self.nodale_state(self.current)
+        iso_real = set(realized["isolated"])
+        nb_isoles = len(iso_real)
         seq = ident.sequence   # sous-produit éventuel (écarts détaillés)
+
+        if iso:
+            # Verdict **recalculé sur l'état final** (post-isolation) : on ne
+            # compte que les nœuds RÉELS — les ouvrages isolés sont présentés à
+            # part, **jamais** comptés comme des nœuds (sinon le verdict de l'algo,
+            # calculé avant l'isolation, gonfle le compte : « obtenu 4 » au lieu de
+            # « 2 nœuds + 2 ouvrages isolés »).
+            real_part = {frozenset(e for e in g if e not in iso_real)
+                         for g in realized["groups"]}
+            real_part.discard(frozenset())
+            target_part = {frozenset(g) for g in groups}
+            is_ok = (real_part == target_part) and iso <= iso_real
+            message, ecarts, non_real = "", [], []
+        else:
+            is_ok = ident.is_realisable
+            message = ident.message
+            ecarts = seq.ecarts if seq is not None else []
+            non_real = ident.noeuds_non_realisables
         return {
             "svg": svg, "switches": switches, "nb_noeuds": nb,
-            "is_verified": ident.is_realisable,
-            "message": ident.message,
-            "ecarts": seq.ecarts if seq is not None else [],
-            "noeuds_non_realisables": ident.noeuds_non_realisables,
-            "nb_obtenu": nb,
+            "is_verified": is_ok,
+            "message": message,
+            "ecarts": ecarts,
+            "noeuds_non_realisables": non_real,
+            "nb_obtenu": nb,            # nœuds **réels** (isolés exclus)
+            "nb_isoles": nb_isoles,     # ouvrages isolés (présentés à part)
             "nb_vise": topo_cible.nb_noeuds,
             "algo": self.algos["identificateur"],
+            # Diff départ → cible (organes verts/oranges) pour le surlignage.
+            "changes": self.diff_states(),
             # Vue nodale **réalisée** (partition + couleurs + isolés) pour
             # resynchroniser le volet nodal cible avec le détail obtenu.
-            "nodale": self.nodale_state(self.current),
+            "nodale": realized,
         }
 
     def _vl_info(self) -> tuple[float, str]:

--- a/scripts/manoeuvre_ihm_assets/index.html
+++ b/scripts/manoeuvre_ihm_assets/index.html
@@ -97,6 +97,8 @@
  .isochip{font-family:monospace;font-size:10px;padding:2px 7px;border:1px dashed #f59e0b;border-radius:10px;background:#fffbeb;color:#92400e;cursor:grab;user-select:none}
  .nodiso.ro .isochip{cursor:default;border-color:#cbd5e1;background:#f1f5f9;color:#475569}
  .isochip.sel{background:#6366f1;color:#fff;border-color:#4f46e5;border-style:solid}
+ /* Survol de la zone isolés pendant un glisser = cible de dépose « isoler ». */
+ .nodiso.droptarget{outline:2px dashed #6366f1;outline-offset:-2px;background:#eef2ff}
  #nodstatus{font-size:11px;padding:4px 8px;white-space:normal}
  #nodstatus.okv{color:#065f46;background:#ecfdf5}
  #nodstatus.kov{color:#92400e;background:#fffbeb}
@@ -165,8 +167,13 @@
  .conn{stroke-width:0.9;vector-effect:non-scaling-stroke;stroke-opacity:.32;
    stroke-linecap:round;pointer-events:none}
  .dept{fill:#fcfcfa;stroke:#d9d2c0;stroke-width:0.8;stroke-linejoin:round;pointer-events:none}
- .pdisk{cursor:pointer;stroke:#ffffff;stroke-width:0.5}
+ /* Curseur en croix (pointeur précis) plutôt qu'une main : pointe pile le poste. */
+ .pdisk{cursor:crosshair;stroke:#ffffff;stroke-width:0.5}
  .pdisk:hover{stroke:#1e293b;stroke-width:2}
+ /* Étiquette de survol (nom du poste) qui suit la souris sur la carte. */
+ #mapTip{position:absolute;display:none;pointer-events:none;z-index:25;background:#0f172a;
+   color:#fff;font-size:11px;font-weight:bold;padding:2px 7px;border-radius:5px;
+   box-shadow:0 2px 8px rgba(0,0,0,.3);white-space:nowrap}
  .ptop{stroke:#111;stroke-width:1.5}
  .phalo{fill:none;stroke:#facc15;stroke-width:3.5;pointer-events:none}
  #mapHours{display:inline-flex;gap:2px;align-items:center}
@@ -219,12 +226,24 @@
  #btnExplore{width:100%;margin-top:4px;background:#0e7490;color:#fff;border-color:#0e7490}
 </style></head><body>
 <div id="side">
-  <h2 style="margin-top:0">Situation réseau</h2>
+  <h2 style="margin-top:0">Situation réseau
+    <button onclick="openConfig()" title="Configuration : algorithmes par phase + chemins de sauvegarde/rechargement des scénarios et séquences"
+            style="float:right;padding:1px 8px;font-size:11px;margin:0;font-weight:normal">⚙ Config</button>
+  </h2>
   <div class="tabs" role="tablist">
     <button id="tabLocal" class="tab" onclick="selectTab('local')"
             title="Charger une situation réseau depuis un fichier .xiidm local">📁 Local</button>
     <button id="tabRte" class="tab" onclick="selectTab('rte')"
             title="Charger une situation du dataset RTE 7000 (France) par date / heure">📅 RTE7000</button>
+  </div>
+
+  <div id="hostedNote" style="display:none;font-size:11px;color:#92400e;background:#fffbeb;
+       border:1px dashed #f59e0b;border-radius:6px;padding:7px 9px;margin-top:5px;line-height:1.4">
+    📁 <b>Import de fichier local désactivé</b> sur cette instance hébergée : un fichier réseau
+    peut contenir des informations confidentielles. Pour charger vos propres situations,
+    installez le package et lancez l'IHM chez vous :
+    <code style="display:block;margin-top:4px;font-size:10px;background:#fff7ed;padding:3px 5px;border-radius:4px">pip install -e ".[ihm]"
+python scripts/manoeuvre_ihm.py --grid /chemin/grid.xiidm</code>
   </div>
 
   <div id="panelLocal" class="tabpanel">
@@ -324,6 +343,7 @@
       <div id="mapSvgWrap">
         <div id="mapSpin" style="display:none">Chargement de la journée…</div>
         <div id="mapBubble"></div>
+        <div id="mapTip"></div>
         <div id="mapLegend"></div>
       </div>
       <div id="mapSide">
@@ -392,6 +412,7 @@
       <div class="nodiso ed" id="ndCibleIso" style="display:none"></div>
       <div class="ntools">
         <button onclick="nodNewNode()" title="Créer un nœud vide (puis y glisser des départs ; ou avec la sélection courante)">＋ Nœud</button>
+        <button onclick="nodIsolateSel()" title="Déclarer les départs sélectionnés comme ouvrages ISOLÉS (déconnectés / hors partition) — au lieu d'un nœud à un seul ouvrage. Glisser aussi un départ sur la zone « Ouvrages isolés » l'isole.">⌀ Isoler</button>
         <button onclick="nodReset()" title="Réinitialiser la cible (nodale + détaillée) à la topologie d'origine du poste (départ)">↺ Réinitialiser</button>
         <button onclick="nodClearSel()" title="Vider la sélection">∅ Désélectionner</button>
       </div>
@@ -428,6 +449,29 @@
       <span style="flex:1"></span>
       <button onclick="closeReload()">Annuler</button>
       <button class="primary" onclick="validateReload()">Valider</button>
+    </div>
+  </div>
+</div>
+<div id="configModal" class="modal" style="display:none" onclick="if(event.target===this)closeConfig()">
+  <div class="modalbox" style="max-width:540px">
+    <h3>⚙ Configuration</h3>
+    <div style="font-size:12px;font-weight:bold;color:#334155;margin:6px 0 3px">Algorithmes (par phase)</div>
+    <div style="font-size:11px;color:#64748b;margin-bottom:6px">« libtopo » = algorithme par défaut natif ; les plugins enregistrés apparaissent ici. Les verdicts affichés sont recalculés indépendamment de l'algorithme branché.</div>
+    <div style="display:grid;grid-template-columns:1fr auto;gap:6px 10px;align-items:center;font-size:12px">
+      <label for="cfgAlgoIdent">Identification (nodale → détaillée)</label><select id="cfgAlgoIdent" style="padding:3px"></select>
+      <label for="cfgAlgoSeq">Séquencement (détaillée → manœuvres)</label><select id="cfgAlgoSeq" style="padding:3px"></select>
+      <label for="cfgAlgoPlan">Planification (bout-en-bout)</label><select id="cfgAlgoPlan" style="padding:3px"></select>
+    </div>
+    <div style="font-size:12px;font-weight:bold;color:#334155;margin:13px 0 3px">Chemins de sauvegarde / rechargement</div>
+    <div style="display:grid;grid-template-columns:auto 1fr;gap:6px 10px;align-items:center;font-size:12px">
+      <label for="cfgScenDir">Scénarios</label><input id="cfgScenDir" style="padding:4px" placeholder="dossier des scénarios">
+      <label for="cfgSeqDir">Séquences</label><input id="cfgSeqDir" style="padding:4px" placeholder="dossier des séquences">
+    </div>
+    <div id="cfgHosted" style="display:none;font-size:11px;color:#92400e;background:#fffbeb;border:1px dashed #f59e0b;border-radius:6px;padding:6px 8px;margin-top:7px">IHM hébergée : les chemins sont en lecture seule (système de fichiers éphémère).</div>
+    <div style="display:flex;gap:6px;align-items:center;margin-top:13px">
+      <span id="cfgMsg" style="font-size:11px;color:#1a7f37;flex:1"></span>
+      <button onclick="closeConfig()">Fermer</button>
+      <button class="primary" onclick="saveConfig()">Appliquer</button>
     </div>
   </div>
 </div>
@@ -602,7 +646,14 @@ async function initDataset(){
       b.innerHTML=xesc(d)+(meta.tag?'<span class="stag">'+xesc(meta.tag)+'</span>':'');
       b.onclick=()=>{di.value=d;loadDatasetTimestamps(d);};sm.appendChild(b);});
     await loadDatasetTimestamps(di.value);}
-  selectTab(DS.enabled?'rte':'local');   // RTE7000 « en avant » sur le Space
+  // IHM déportée (Space) : l'import local est interdit (confidentialité) — on
+  // masque l'onglet/panneau Local et on affiche une invitation à l'IHM locale.
+  if(DS.hosted){
+    document.getElementById('tabLocal').style.display='none';
+    document.getElementById('panelLocal').style.display='none';
+    const hn=document.getElementById('hostedNote');if(hn)hn.style.display='block';
+    selectTab('rte');
+  }else selectTab(DS.enabled?'rte':'local');   // RTE7000 « en avant » sur le Space
   if(DS.enabled&&!S.currentVL){const t=document.getElementById('diagTop');
     if(t)t.textContent='Choisissez une date puis « Charger la situation »…';}}
 async function loadDatasetTimestamps(date){
@@ -766,6 +817,8 @@ function renderScenList(){const root=document.getElementById('scenList');if(!roo
     if(s.dt){const jour=(s.weekday!=null?JOURS[s.weekday]:''),sai=s.season||'';
       chips+='<span class="scc scdt">📅 '+xesc(s.dt.replace('T',' '))
         +(jour?' · '+jour:'')+(sai?' · '+sai:'')+'</span>';}
+    if(s.cible_dt&&s.cible_dt!==s.dt)
+      chips+='<span class="scc scdt" title="date/heure de la topologie cible">🎯 '+xesc(s.cible_dt.replace('T',' '))+'</span>';
     if(s.nb_barres!=null)chips+='<span class="scc">'+s.nb_barres+' barre'+(s.nb_barres>1?'s':'')+'</span>';
     if(s.nb_depart!=null&&s.nb_cible!=null)chips+='<span class="scc">'+s.nb_depart+'→'+s.nb_cible+' nœud</span>';
     if(s.n_dj!=null)chips+='<span class="scc">DJ '+(s.n_dj||0)+' · SA '+(s.n_sa||0)+' · INT '+(s.n_int||0)+'</span>';
@@ -784,6 +837,39 @@ function downloadAllScenarios(){const a=document.createElement('a');
   a.href='/api/scenarios_archive';a.download='scenarios.zip';
   document.body.appendChild(a);a.click();a.remove();}
 function closeReload(){document.getElementById('reloadModal').style.display='none';}
+// Modale « ⚙ Configuration » : algorithmes pluggables par phase (avec le défaut)
+// + chemins de sauvegarde/rechargement des scénarios et séquences.
+async function openConfig(){
+  let r;try{r=await (await fetch('/api/config')).json();}catch(e){r=null;}
+  if(!r)return;
+  fillCfgAlgo('cfgAlgoIdent','identificateur',r.algos);
+  fillCfgAlgo('cfgAlgoSeq','sequenceur',r.algos);
+  fillCfgAlgo('cfgAlgoPlan','planificateur',r.algos);
+  const sd=document.getElementById('cfgScenDir'),qd=document.getElementById('cfgSeqDir');
+  sd.value=r.scenarios_dir||'';qd.value=r.sequences_dir||'';
+  sd.disabled=qd.disabled=!!r.hosted;
+  document.getElementById('cfgHosted').style.display=r.hosted?'block':'none';
+  document.getElementById('cfgMsg').textContent='';
+  document.getElementById('configModal').style.display='flex';}
+function fillCfgAlgo(id,phase,algos){const sel=document.getElementById(id);if(!sel)return;
+  sel.innerHTML='';((algos.disponibles||{})[phase]||[]).forEach(n=>{
+    const o=document.createElement('option');o.value=n;o.text=n+(n==='libtopo'?' (défaut)':'');sel.add(o);});
+  sel.value=(algos.selection||{})[phase]||'libtopo';
+  sel.disabled=sel.options.length<2;}
+function closeConfig(){document.getElementById('configModal').style.display='none';}
+async function saveConfig(){
+  const body={algos:{
+      identificateur:document.getElementById('cfgAlgoIdent').value,
+      sequenceur:document.getElementById('cfgAlgoSeq').value,
+      planificateur:document.getElementById('cfgAlgoPlan').value},
+    scenarios_dir:document.getElementById('cfgScenDir').value,
+    sequences_dir:document.getElementById('cfgSeqDir').value};
+  let r;try{r=await api('/api/config',body);}catch(e){
+    document.getElementById('cfgMsg').textContent='échec';return;}
+  await refreshAlgos();await refreshScenarios();   // resync sélecteurs inline + base
+  document.getElementById('cfgScenDir').value=r.scenarios_dir||'';
+  document.getElementById('cfgSeqDir').value=r.sequences_dir||'';
+  document.getElementById('cfgMsg').textContent='✓ Configuration appliquée.';}
 async function validateReload(){const name=document.getElementById('scenSel').value;
   if(name)await loadScen('both');closeReload();}
 async function saveWithConfirm(url,name,msgEl){
@@ -803,12 +889,17 @@ async function save(){const name=document.getElementById('scenName').value;
   const msg=document.getElementById('savemsg');
   // Date/heure de DÉPART à logger : en RTE7000, la date du dataset + l'heure de
   // départ choisie ; en local, le backend lit l'horodatage du fichier (case_date).
-  let depart_dt=null;
+  let depart_dt=null,cible_dt=null;
   if(S.tab==='rte'){
     const date=(MAP.data&&MAP.data.date)||document.getElementById('dsDate').value;
     const hour=MAP.topoHour||document.getElementById('dsTime').value;
-    if(date&&hour)depart_dt=date+'T'+hour;}
-  const r=await api('/api/save',{name,depart_dt,source:S.tab});
+    if(date&&hour)depart_dt=date+'T'+hour;
+    // Date/heure de la topologie CIBLE : conservée seulement si la cible n'a PAS
+    // été modifiée (topologie observée à l'heure cible d'un instantané RTE7000).
+    if(date&&!S.cibleModifiee){
+      const hc=MAP.cibleHour||MAP.topoHour||document.getElementById('dsTime').value;
+      if(hc)cible_dt=date+'T'+hc;}}
+  const r=await api('/api/save',{name,depart_dt,cible_dt,source:S.tab});
   if(r&&r.already_exists){   // départ + cible identiques à un scénario existant
     setValidated(true);await refreshScenarios();
     msg.textContent='⚠ Scénario déjà existant (« '+r.name+' », départ + cible identiques) — non écrasé.';
@@ -1132,7 +1223,13 @@ function renderNodaleCible(){
 // sur un nœud pour reconnecter (clic = (dé)sélection pour glisser un lot).
 function renderIso(rootId,list,editable){
   const root=document.getElementById(rootId);
-  if(!list||!list.length){root.style.display='none';root.innerHTML='';return;}
+  if(!list||!list.length){
+    if(!editable){root.style.display='none';root.innerHTML='';return;}
+    // Zone CIBLE éditable : reste visible (même vide) comme cible de dépose
+    // « isoler » — glisser-y un départ le déclare ouvrage isolé.
+    root.style.display='block';
+    root.innerHTML='<div class="isohd">⌀ Ouvrages isolés (0) — glisser un départ ici pour l\'isoler</div>';
+    return;}
   root.style.display='block';
   let h=`<div class="isohd">⚠ Ouvrages isolés (${list.length})`
     +(editable?' — glisser sur un nœud pour reconnecter':' — déconnectés')+`</div><div class="isochips">`;
@@ -1156,21 +1253,31 @@ function ndStart(e,info){e.preventDefault();
 function ndNodeUnder(e){const el=document.elementFromPoint(e.clientX,e.clientY);
   const g=el&&el.closest?el.closest('#ndCible .nbus'):null;
   return g?+g.getAttribute('data-node'):null;}
+// Survol de la zone « Ouvrages isolés » cible (cible de dépose pour isoler).
+function ndOverIso(e){const el=document.elementFromPoint(e.clientX,e.clientY);
+  return !!(el&&el.closest&&el.closest('#ndCibleIso'));}
 function ndMove(e){const d=NOD.dnd;if(!d)return;
   if(!d.moved&&Math.hypot(e.clientX-d.x0,e.clientY-d.y0)<5)return;
   d.moved=true;document.body.classList.add('ndndrag');
   const tgt=ndNodeUnder(e);
   document.querySelectorAll('#ndCible .nbus').forEach(g=>
     g.classList.toggle('droptarget',tgt!=null&&+g.getAttribute('data-node')===tgt));
+  const iso=document.getElementById('ndCibleIso');
+  if(iso)iso.classList.toggle('droptarget',d.type==='feeder'&&ndOverIso(e));
 }
 function ndUp(e){const d=NOD.dnd;NOD.dnd=null;
   document.body.classList.remove('ndndrag');
   document.querySelectorAll('.nbus.droptarget').forEach(g=>g.classList.remove('droptarget'));
+  const isoZ=document.getElementById('ndCibleIso');if(isoZ)isoZ.classList.remove('droptarget');
   if(!d)return;
   if(!d.moved){   // simple clic = (dé)sélection d'un départ
     if(d.type==='feeder'){if(NOD.selBranches.has(d.eq))NOD.selBranches.delete(d.eq);
       else NOD.selBranches.add(d.eq);renderNodaleCible();}
     return;}
+  // Déposer un (ou des) départ(s) sur la zone « Ouvrages isolés » = isoler.
+  if(d.type==='feeder'&&ndOverIso(e)){
+    const items=NOD.selBranches.has(d.eq)?[...NOD.selBranches]:[d.eq];
+    nodIsolate(items);return;}
   const tgt=ndNodeUnder(e);
   if(tgt==null)return;
   if(d.type==='node'){if(tgt!==d.node)nodMergeNodes(d.node,tgt);}
@@ -1196,6 +1303,20 @@ function nodMergeNodes(src,dst){
 // glisser-y ensuite des départs. Un nœud resté vide est ignoré au calcul.
 function nodNewNode(){NOD.groups.push([]);const idx=NOD.groups.length-1;
   if(NOD.selBranches.size)nodMoveSelTo(idx);else renderNodaleCible();}
+// Déclarer des départs comme **ouvrages isolés** (déconnectés / hors partition) :
+// les retire des nœuds et les ajoute à NOD.isolated (envoyé à /api/nodale_to_detaillee,
+// qui les laisse hors partition et les déconnecte réellement). Évite le « nœud à un
+// seul ouvrage » que le backend prenait pour un véritable nœud électrique.
+function nodIsolate(items){
+  if(!items||!items.length)return;
+  NOD.groups=NOD.groups.map(g=>g.filter(eq=>items.indexOf(eq)<0));
+  items.forEach(eq=>{if(NOD.isolated.indexOf(eq)<0)NOD.isolated.push(eq);});
+  NOD.selBranches=new Set();nodNormalize();renderNodaleCible();}
+function nodIsolateSel(){
+  const items=[...NOD.selBranches];
+  if(!items.length){const st=document.getElementById('nodstatus');
+    st.className='';st.textContent='Sélectionnez d\'abord un ou des départs (clic), puis « ⌀ Isoler ».';return;}
+  nodIsolate(items);}
 function nodClearSel(){NOD.selBranches=new Set();renderNodaleCible();}
 async function nodCompute(){
   const st=document.getElementById('nodstatus');st.className='';st.textContent='Calcul en cours…';
@@ -1427,6 +1548,18 @@ function initMap(){
   wrap.addEventListener('dblclick',e=>{const el=e.target.closest('.pdisk');if(!el)return;
     if(MAP.clickTimer){clearTimeout(MAP.clickTimer);MAP.clickTimer=null;}
     hideBubble();mapOpenPoste(el.getAttribute('data-sub'));});
+  // Survol : étiquette « nom du poste » qui suit la souris (pointeur précis).
+  const tip=document.getElementById('mapTip');
+  wrap.addEventListener('mousemove',e=>{
+    if(pan){tip.style.display='none';return;}
+    const el=e.target.closest('.pdisk'),p=el&&MAP.bySub[el.getAttribute('data-sub')];
+    if(!p){tip.style.display='none';return;}
+    const wr=wrap.getBoundingClientRect();
+    tip.textContent=p.name||p.sub;tip.style.display='block';
+    let x=e.clientX-wr.left+14,y=e.clientY-wr.top+14;
+    if(x+tip.offsetWidth>wr.width)x=e.clientX-wr.left-tip.offsetWidth-8;
+    tip.style.left=Math.max(2,x)+'px';tip.style.top=Math.max(2,y)+'px';});
+  wrap.addEventListener('mouseleave',()=>{tip.style.display='none';});
 }
 function mapZoom(f){const w=document.getElementById('mapSvgWrap').getBoundingClientRect();
   if(MAP._zoomAt)MAP._zoomAt({clientX:w.left+w.width/2,clientY:w.top+w.height/2},f);}

--- a/scripts/manoeuvre_ihm_assets/index.html
+++ b/scripts/manoeuvre_ihm_assets/index.html
@@ -1338,14 +1338,16 @@ async function nodCompute(){
   // Charger la topologie détaillée d'intérêt comme cible (volet du bas).
   document.getElementById('diagBottom').innerHTML=d.svg;
   document.getElementById('nbB').textContent=d.nb_noeuds;
-  bind(d.switches);hideSeq();setValidated(false);
+  bind(d.switches);highlightChanges(d.changes);hideSeq();setValidated(false);   // diff départ→cible (vert/orange)
   S.cibleModifiee=true;setDefaultScenName();   // cible issue d'une édition nodale
   // Resynchroniser la cible nodale sur la topologie détaillée RÉALISÉE
   // (partition + couleurs + isolés des nœuds obtenus).
   syncNodalCible(d.nodale);
+  // Les ouvrages isolés sont présentés à part, jamais comptés comme des nœuds.
+  const iso=d.nb_isoles||0, isoTxt=iso?(' + '+iso+' ouvrage(s) isolé(s)'):'';
   let msg='';
-  if(d.is_verified){st.className='okv';msg='✓ Topologie détaillée d\'intérêt chargée comme cible ('+d.nb_obtenu+' nœud(s)'+(d.algo?', algo '+d.algo:'')+'). Validez puis calculez la séquence.';}
-  else{st.className='kov';msg='⚠ Cible partiellement réalisable (obtenu '+d.nb_obtenu+' / visé '+d.nb_vise+' nœud(s)). '+(d.message||'');
+  if(d.is_verified){st.className='okv';msg='✓ Topologie détaillée d\'intérêt chargée comme cible ('+d.nb_obtenu+' nœud(s)'+isoTxt+(d.algo?', algo '+d.algo:'')+'). Validez puis calculez la séquence.';}
+  else{st.className='kov';msg='⚠ Cible partiellement réalisable (obtenu '+d.nb_obtenu+' nœud(s)'+isoTxt+' / visé '+d.nb_vise+' nœud(s)). '+(d.message||'');
     if(d.noeuds_non_realisables&&d.noeuds_non_realisables.length)msg+=' Nœuds non réalisables : '+d.noeuds_non_realisables.map(g=>g.join(',')).join(' | ')+'.';}
   if(d.ecarts&&d.ecarts.length)msg+=' Écarts : '+d.ecarts.join(' ; ')+'.';
   st.textContent=msg;}

--- a/scripts/manoeuvre_ihm_assets/index.html
+++ b/scripts/manoeuvre_ihm_assets/index.html
@@ -228,7 +228,7 @@
 <div id="side">
   <h2 style="margin-top:0;display:flex;align-items:center;gap:6px">
     <span style="flex:1">Situation réseau</span>
-    <input id="authorName" placeholder="✍ votre nom" autocomplete="off"
+    <input id="authorName" placeholder="✍ votre login" autocomplete="off"
            title="Auteur des scénarios sauvegardés — modifiable à tout moment ; enregistré dans les métadonnées des fichiers."
            style="width:104px;padding:2px 6px;font-size:11px;font-weight:normal">
     <button onclick="openConfig()" title="Configuration : algorithmes par phase + chemins de sauvegarde/rechargement des scénarios et séquences"
@@ -483,9 +483,9 @@ python scripts/manoeuvre_ihm.py --grid /chemin/grid.xiidm</code>
 </div>
 <div id="authorModal" class="modal" style="display:none" onclick="if(event.target===this)closeAuthor(null)">
   <div class="modalbox" style="max-width:380px">
-    <h3>✍ Votre nom (auteur)</h3>
-    <div style="font-size:12px;color:#475569;margin-bottom:8px">Indiquez votre nom : il sera enregistré dans les métadonnées des scénarios (facultatif).</div>
-    <input id="authorInput" placeholder="nom de l'auteur" autocomplete="off" style="width:100%;padding:6px"
+    <h3>✍ Votre login (auteur)</h3>
+    <div style="font-size:12px;color:#475569;margin-bottom:8px">Indiquez votre login : il sera enregistré dans les métadonnées des scénarios (facultatif).</div>
+    <input id="authorInput" placeholder="login de l'auteur" autocomplete="off" style="width:100%;padding:6px"
            onkeydown="if(event.key==='Enter')confirmAuthor()">
     <label style="display:flex;align-items:center;gap:6px;font-size:12px;margin-top:9px">
       <input type="checkbox" id="authorNoask"> Ne plus me redemander
@@ -903,7 +903,7 @@ function currentAuthor(){return (document.getElementById('authorName').value||''
 function initAuthor(){const el=document.getElementById('authorName');if(!el)return;
   el.value=localStorage.getItem('manoeuvre_author')||'';
   el.addEventListener('input',()=>localStorage.setItem('manoeuvre_author',currentAuthor()));}
-// Modale « ✍ Votre nom » : demandée une seule fois si aucun auteur déclaré, avec
+// Modale « ✍ Votre login » : demandée une seule fois si aucun auteur déclaré, avec
 // une coche « ne plus me redemander ». Renvoie une Promesse {name, noask} ou null.
 let _authorResolve=null;
 function askAuthor(){return new Promise(res=>{_authorResolve=res;

--- a/scripts/manoeuvre_ihm_assets/index.html
+++ b/scripts/manoeuvre_ihm_assets/index.html
@@ -1162,13 +1162,19 @@ function allByDir(top){const out=[];
 function buildNodaleSVG(groups, editable, colors){
   const BW=30, BUSH=6, STUB=24, PADX=14, PADY=10, GAPY=22, CW=6.1, BADGE=22;
   const topH=labLen(allByDir(true))*CW+6, botH=labLen(allByDir(false))*CW+6;
-  const place=(x0,len,j,cnt)=>cnt>1?x0+(j*(len-BW)/(cnt-1))+BW/2:x0+len/2;
   let y=PADY, maxX=0; const segs=[];
   groups.forEach((g,ni)=>{
-    const top=g.filter(isTop).sort(byOrder);
-    const bot=g.filter(eq=>!isTop(eq)).sort(byOrder);
-    const cols=Math.max(top.length,bot.length,1), busLen=Math.max(46,cols*BW);
+    // **Ordre gauche → droite identique au schéma détaillé** : on classe TOUS les
+    // départs du nœud par leur abscisse SLD (NOD.order) et on attribue une colonne
+    // par rang. Le haut (départs « top ») et le bas (« bottom ») **partagent ce
+    // même axe horizontal** — un départ garde donc sa position relative et son côté
+    // (haut/bas) exactement comme dans la vue détaillée.
+    const all=g.slice().sort(byOrder);
+    const colOf={}; all.forEach((eq,i)=>{colOf[eq]=i;});
+    const top=g.filter(isTop), bot=g.filter(eq=>!isTop(eq));
+    const cols=Math.max(all.length,1), busLen=Math.max(46,cols*BW);
     const x0=PADX+BADGE+6, x1=x0+busLen, busY=y+topH+STUB+BUSH/2;
+    const colX=col=>x0+(col+0.5)*busLen/cols;   // centre de la colonne (rang global)
     const blockH=topH+STUB+BUSH+STUB+botH;
     const col=nodeFill(g,ni,colors), tcol=textOn(col);
     let blk=`<g class="nbus${editable?' ed':''}" data-node="${ni}">`;
@@ -1180,9 +1186,9 @@ function buildNodaleSVG(groups, editable, colors){
        +`width="${BADGE}" height="${BADGE}" fill="${col}"/>`
        +`<text x="${(PADX+BADGE/2).toFixed(1)}" y="${(busY+3.8).toFixed(1)}" fill="${tcol}">N${ni}</text></g>`;
     blk+=`<title>N${ni} · ${g.length} branche(s)</title>`;
-    top.forEach((eq,j)=>blk+=branchSeg(eq,place(x0,busLen,j,top.length),
+    top.forEach(eq=>blk+=branchSeg(eq,colX(colOf[eq]),
       busY-BUSH/2,busY-BUSH/2-STUB,true,editable));
-    bot.forEach((eq,j)=>blk+=branchSeg(eq,place(x0,busLen,j,bot.length),
+    bot.forEach(eq=>blk+=branchSeg(eq,colX(colOf[eq]),
       busY+BUSH/2,busY+BUSH/2+STUB,false,editable));
     blk+=`</g>`;
     segs.push(blk); maxX=Math.max(maxX,x1); y+=blockH+GAPY;});

--- a/scripts/manoeuvre_ihm_assets/index.html
+++ b/scripts/manoeuvre_ihm_assets/index.html
@@ -226,9 +226,13 @@
  #btnExplore{width:100%;margin-top:4px;background:#0e7490;color:#fff;border-color:#0e7490}
 </style></head><body>
 <div id="side">
-  <h2 style="margin-top:0">Situation réseau
+  <h2 style="margin-top:0;display:flex;align-items:center;gap:6px">
+    <span style="flex:1">Situation réseau</span>
+    <input id="authorName" placeholder="✍ votre nom" autocomplete="off"
+           title="Auteur des scénarios sauvegardés — modifiable à tout moment ; enregistré dans les métadonnées des fichiers."
+           style="width:104px;padding:2px 6px;font-size:11px;font-weight:normal">
     <button onclick="openConfig()" title="Configuration : algorithmes par phase + chemins de sauvegarde/rechargement des scénarios et séquences"
-            style="float:right;padding:1px 8px;font-size:11px;margin:0;font-weight:normal">⚙ Config</button>
+            style="padding:1px 8px;font-size:11px;margin:0;font-weight:normal">⚙ Config</button>
   </h2>
   <div class="tabs" role="tablist">
     <button id="tabLocal" class="tab" onclick="selectTab('local')"
@@ -477,6 +481,22 @@ python scripts/manoeuvre_ihm.py --grid /chemin/grid.xiidm</code>
     </div>
   </div>
 </div>
+<div id="authorModal" class="modal" style="display:none" onclick="if(event.target===this)closeAuthor(null)">
+  <div class="modalbox" style="max-width:380px">
+    <h3>✍ Votre nom (auteur)</h3>
+    <div style="font-size:12px;color:#475569;margin-bottom:8px">Indiquez votre nom : il sera enregistré dans les métadonnées des scénarios (facultatif).</div>
+    <input id="authorInput" placeholder="nom de l'auteur" autocomplete="off" style="width:100%;padding:6px"
+           onkeydown="if(event.key==='Enter')confirmAuthor()">
+    <label style="display:flex;align-items:center;gap:6px;font-size:12px;margin-top:9px">
+      <input type="checkbox" id="authorNoask"> Ne plus me redemander
+    </label>
+    <div style="display:flex;gap:6px;align-items:center;margin-top:12px">
+      <span style="flex:1"></span>
+      <button onclick="closeAuthor(null)">Annuler</button>
+      <button class="primary" onclick="confirmAuthor()">Enregistrer</button>
+    </div>
+  </div>
+</div>
 <script>
 let S={n:0,idx:0,timer:null,labels:[],algo:{},sel:new Set(),lastSel:null,manual:false,
   editTarget:false,stale:false,currentVL:null,tab:'local'};
@@ -619,6 +639,7 @@ async function init(){const r=await (await fetch('/api/postes')).json();
   if(sn)sn.addEventListener('input',()=>{S.scenNameDirty=true;});
   search.addEventListener('keydown',e=>{if(e.key==='Enter'){
     const v=search.value.trim();if(v&&ALL_POSTES.includes(v))selectPoste(v);}});
+  initAuthor();
   initNodalResize(); initNodalDnD(); initMap(); await refreshScenarios(); await initDataset();
   // Pas d'auto-chargement de poste : on attend que l'utilisateur en choisisse un
   // (le schéma reste sur « Choisissez un poste… » tant qu'aucun n'est sélectionné).
@@ -806,7 +827,7 @@ function renderScenList(){const root=document.getElementById('scenList');if(!roo
     fy=g('scfYear').value,fse=g('scfSeason').value,fday=g('scfDay').value;
   const ge=(v,m)=>isNaN(m)||((v||0)>=m);
   const hits=SCENARIOS.filter(s=>{
-    if(q&&!((s.name+' '+(s.vl||'')+' '+(s.sub||'')).toLowerCase().includes(q)))return false;
+    if(q&&!((s.name+' '+(s.vl||'')+' '+(s.sub||'')+' '+(s.author||'')).toLowerCase().includes(q)))return false;
     if(fv&&Math.round(s.nominal_v||0)!==Math.round(+fv))return false;
     if(fy&&String(s.year)!==fy)return false;
     if(fse&&s.season!==fse)return false;
@@ -828,6 +849,8 @@ function renderScenList(){const root=document.getElementById('scenList');if(!roo
     if(s.nb_depart!=null&&s.nb_cible!=null)chips+='<span class="scc">'+s.nb_depart+'→'+s.nb_cible+' nœud</span>';
     if(s.n_dj!=null)chips+='<span class="scc">DJ '+(s.n_dj||0)+' · SA '+(s.n_sa||0)+' · INT '+(s.n_int||0)+'</span>';
     if(s.n_nodal)chips+='<span class="scc">⚇ '+s.n_nodal+'</span>';
+    if(s.author)chips+='<span class="scc" title="auteur">✍ '+xesc(s.author)+'</span>';
+    if(s.created_at)chips+='<span class="scc" title="date de création">🕒 '+xesc(s.created_at.replace('T',' '))+'</span>';
     d.innerHTML='<div class="scnm">'+xesc(s.name)+'</div><div class="scmeta">'+chips+'</div>';
     d.onclick=()=>{g('scenSel').value=s.name;renderScenList();};
     d.ondblclick=()=>{g('scenSel').value=s.name;validateReload();};
@@ -875,6 +898,35 @@ async function saveConfig(){
   document.getElementById('cfgScenDir').value=r.scenarios_dir||'';
   document.getElementById('cfgSeqDir').value=r.sequences_dir||'';
   document.getElementById('cfgMsg').textContent='✓ Configuration appliquée.';}
+// --- Auteur des scénarios (mémorisé localement, modifiable à tout moment) ----
+function currentAuthor(){return (document.getElementById('authorName').value||'').trim();}
+function initAuthor(){const el=document.getElementById('authorName');if(!el)return;
+  el.value=localStorage.getItem('manoeuvre_author')||'';
+  el.addEventListener('input',()=>localStorage.setItem('manoeuvre_author',currentAuthor()));}
+// Modale « ✍ Votre nom » : demandée une seule fois si aucun auteur déclaré, avec
+// une coche « ne plus me redemander ». Renvoie une Promesse {name, noask} ou null.
+let _authorResolve=null;
+function askAuthor(){return new Promise(res=>{_authorResolve=res;
+  document.getElementById('authorInput').value=localStorage.getItem('manoeuvre_author')||'';
+  document.getElementById('authorNoask').checked=false;
+  document.getElementById('authorModal').style.display='flex';
+  document.getElementById('authorInput').focus();});}
+function closeAuthor(val){document.getElementById('authorModal').style.display='none';
+  const r=_authorResolve;_authorResolve=null;if(r)r(val);}
+function confirmAuthor(){closeAuthor({name:(document.getElementById('authorInput').value||'').trim(),
+  noask:document.getElementById('authorNoask').checked});}
+// Auteur à enregistrer pour une sauvegarde : si aucun nom déclaré et que
+// l'utilisateur n'a pas coché « ne plus me redemander », on le demande une fois.
+async function resolveAuthor(){
+  let author=currentAuthor();
+  if(author||localStorage.getItem('manoeuvre_author_noask')==='1')return author;
+  const a=await askAuthor();
+  if(a){
+    if(a.noask)localStorage.setItem('manoeuvre_author_noask','1');
+    author=a.name;
+    if(author){localStorage.setItem('manoeuvre_author',author);
+      document.getElementById('authorName').value=author;}}
+  return author;}
 async function validateReload(){const name=document.getElementById('scenSel').value;
   if(name)await loadScen('both');closeReload();}
 async function saveWithConfirm(url,name,msgEl){
@@ -904,7 +956,8 @@ async function save(){const name=document.getElementById('scenName').value;
     if(date&&!S.cibleModifiee){
       const hc=MAP.cibleHour||MAP.topoHour||document.getElementById('dsTime').value;
       if(hc)cible_dt=date+'T'+hc;}}
-  const r=await api('/api/save',{name,depart_dt,cible_dt,source:S.tab});
+  const author=await resolveAuthor();   // demande le nom une fois si non déclaré
+  const r=await api('/api/save',{name,depart_dt,cible_dt,source:S.tab,author});
   if(r&&r.already_exists){   // départ + cible identiques à un scénario existant
     setValidated(true);await refreshScenarios();
     msg.textContent='⚠ Scénario déjà existant (« '+r.name+' », départ + cible identiques) — non écrasé.';

--- a/scripts/manoeuvre_ihm_assets/index.html
+++ b/scripts/manoeuvre_ihm_assets/index.html
@@ -237,8 +237,10 @@
             title="Charger une situation du dataset RTE 7000 (France) par date / heure">📅 RTE7000</button>
   </div>
 
-  <div id="hostedNote" style="display:none;font-size:11px;color:#92400e;background:#fffbeb;
-       border:1px dashed #f59e0b;border-radius:6px;padding:7px 9px;margin-top:5px;line-height:1.4">
+  <div id="hostedNote" style="display:none;position:relative;font-size:11px;color:#92400e;background:#fffbeb;
+       border:1px dashed #f59e0b;border-radius:6px;padding:7px 22px 7px 9px;margin-top:5px;line-height:1.4">
+    <span onclick="dismissHostedNote()" title="Masquer ce message"
+          style="position:absolute;top:3px;right:6px;cursor:pointer;color:#b45309;font-weight:bold;font-size:13px">✕</span>
     📁 <b>Import de fichier local désactivé</b> sur cette instance hébergée : un fichier réseau
     peut contenir des informations confidentielles. Pour charger vos propres situations,
     installez le package et lancez l'IHM chez vous :
@@ -509,6 +511,9 @@ const DATE_INFO={
   '2022-06-15':{tag:'mer. · été',desc:"Mercredi, été — 6 400 blocs, 2 037 postes actifs, 181 reconfigurations structurelles : autre année (dataset 2022)."},
   '2023-02-08':{tag:'mer. · hiver',desc:"Mercredi, hiver — 6 442 blocs, 1 984 postes actifs, 185 reconfigurations structurelles, jusqu'à 38 organes manœuvrés (le plus profond) : autre année (dataset 2023)."},
 };
+// Masquer le bandeau d'information « import local désactivé » (IHM hébergée).
+function dismissHostedNote(){const hn=document.getElementById('hostedNote');
+  if(hn)hn.style.display='none';}
 // --- Onglets « Situation réseau » (Local ⇄ RTE7000) -----------------------
 function selectTab(which){
   const local=(which==='local');S.tab=local?'local':'rte';

--- a/tests/manoeuvre/test_ihm_frontend_asset.py
+++ b/tests/manoeuvre/test_ihm_frontend_asset.py
@@ -104,6 +104,9 @@ REQUIRED_MARKERS = [
     'cursor:crosshair', 'onclick="openConfig()"', 'id="configModal"',
     'function saveConfig', 'function nodIsolate', 'onclick="nodIsolateSel()"',
     'colX(colOf', 'highlightChanges(d.changes)',
+    # Auteur des scénarios : champ persistant + modale « demander une fois »
+    'id="authorName"', 'id="authorModal"', 'function resolveAuthor',
+    'function askAuthor', 'id="authorNoask"',
 ]
 
 #: marqueurs qui ne DOIVENT PLUS apparaître (éléments retirés / renommés)

--- a/tests/manoeuvre/test_ihm_frontend_asset.py
+++ b/tests/manoeuvre/test_ihm_frontend_asset.py
@@ -98,6 +98,12 @@ REQUIRED_MARKERS = [
     "＋ Nœud", 'id="ndDepartIso"', 'id="ndCibleIso"',
     # Dates d'accès rapide 2021-2023
     "'2022-06-15'", "'2023-02-08'",
+    # Améliorations IHM : import local hors-Space, carte (survol/curseur),
+    # config, ouvrages isolés, ordre nodal gauche→droite partagé haut/bas.
+    'id="hostedNote"', 'function dismissHostedNote', 'id="mapTip"',
+    'cursor:crosshair', 'onclick="openConfig()"', 'id="configModal"',
+    'function saveConfig', 'function nodIsolate', 'onclick="nodIsolateSel()"',
+    'colX(colOf', 'highlightChanges(d.changes)',
 ]
 
 #: marqueurs qui ne DOIVENT PLUS apparaître (éléments retirés / renommés)

--- a/tests/manoeuvre/test_ihm_ui_improvements.py
+++ b/tests/manoeuvre/test_ihm_ui_improvements.py
@@ -167,3 +167,68 @@ def test_isoler_dans_etat_opens_incident_switches(session):
     # L'opération ne mute pas l'entrée et déconnecte f.
     assert out is not state
     assert f in session.nodale_state(out)["isolated"]
+
+
+# --------------------------------------------------------------------------
+# 5. nodale_to_detaillee : diff vert/orange + compte de nœuds correct
+# --------------------------------------------------------------------------
+
+def test_to_detaillee_returns_changes_for_highlight(session):
+    # Le pont nodal → détaillé doit renvoyer le diff départ→cible pour le
+    # surlignage vert/orange (absent auparavant → pas de couleurs après calcul).
+    feeders = sorted(_feeders(session))
+    iso = [feeders[0]]
+    res = session.nodale_to_detaillee([feeders[1:]], iso)
+    assert "changes" in res and isinstance(res["changes"], list)
+    # l'ouvrage isolé était en service → son organe passe ouvert → diff "opened".
+    assert any(c["direction"] == "opened" for c in res["changes"])
+
+
+def test_to_detaillee_node_count_excludes_isolated(session):
+    # 2 isolés + reste sur 1 nœud : obtenu = nœuds RÉELS (sans les isolés), et le
+    # message ne gonfle pas le compte (« obtenu 4 » au lieu de « 1 + 2 isolés »).
+    feeders = sorted(_feeders(session))
+    iso = feeders[:2]
+    rest = feeders[2:]
+    res = session.nodale_to_detaillee([rest], iso)
+    assert res["nb_isoles"] == 2
+    assert res["nb_obtenu"] == res["nb_vise"] == 1     # 1 nœud réel visé/obtenu
+    assert res["is_verified"] is True
+    # côté isolés, le message reste vide (le front compose « N nœud(s) + M isolés »)
+    assert "obtenu" not in (res["message"] or "")
+    # et aucun nombre supérieur au compte réel n'apparaît dans le message.
+    assert "4" not in (res["message"] or "")
+
+
+def test_to_detaillee_without_iso_keeps_algo_verdict(session):
+    p = session.nodale_payload(session.initial)
+    res = session.nodale_to_detaillee(p["groups"], [])
+    assert res["nb_isoles"] == 0
+    assert "changes" in res
+    assert res["is_verified"] is True
+
+
+def test_api_nodale_to_detaillee_endpoint_shape(session, monkeypatch):
+    monkeypatch.setattr(ihm, "SESSION", session)
+    feeders = sorted(_feeders(session))
+    r = ihm.app.test_client().post("/api/nodale_to_detaillee",
+                                   json={"groups": [feeders[1:]], "isolated": [feeders[0]]})
+    d = r.get_json()
+    for k in ("changes", "nb_isoles", "nb_obtenu", "nb_vise", "nodale"):
+        assert k in d
+
+
+# --------------------------------------------------------------------------
+# 6. Données d'ordre de la vue nodale (axe gauche→droite = abscisse SLD)
+# --------------------------------------------------------------------------
+
+def test_nodale_order_data_present_for_all_feeders(session):
+    # La vue nodale trie de gauche à droite par ``order`` (abscisse SLD) et place
+    # le côté par ``dirs`` : ces deux champs doivent être fournis pour CHAQUE départ
+    # (sinon repli 0/BOTTOM → ordre alphabétique parasite).
+    p = session.nodale_payload(session.initial)
+    feeders = [e for g in p["groups"] for e in g]
+    assert feeders
+    for eq in feeders:
+        assert isinstance(p["order"].get(eq), (int, float))
+        assert p["dirs"].get(eq) in ("TOP", "BOTTOM")

--- a/tests/manoeuvre/test_ihm_ui_improvements.py
+++ b/tests/manoeuvre/test_ihm_ui_improvements.py
@@ -1,0 +1,169 @@
+"""
+tests/manoeuvre/test_ihm_ui_improvements.py
+--------------------------------------------
+Tests des améliorations d'IHM manœuvre :
+
+1. **Import local désactivé** sur une IHM déportée (Space) : ``/api/pick_grid_file``
+   et ``/api/load_grid`` renvoient ``403`` quand ``DATASET["hosted"]`` ;
+2. **Modale de config** : ``GET/POST /api/config`` (algos par phase + chemins de
+   sauvegarde/rechargement des scénarios/séquences) ;
+3. **Date/heure cible** conservée dans le scénario (``meta.cible_dt``) ;
+4. **Déclaration d'ouvrages isolés** : un départ en service déclaré isolé est
+   réellement **déconnecté** (nœud 0-barre) par ``nodale_to_detaillee``.
+
+Nécessitent ``flask`` et ``pypowsybl`` (sinon test ignoré).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import pathlib
+
+import pytest
+
+pytest.importorskip("flask")
+pytest.importorskip("pypowsybl")
+
+import pypowsybl as pp  # noqa: E402
+
+_IHM_PATH = (pathlib.Path(__file__).resolve().parents[2]
+             / "scripts" / "manoeuvre_ihm.py")
+VL = "S1VL2"
+
+
+def _load_ihm():
+    spec = importlib.util.spec_from_file_location("manoeuvre_ihm_ui_mod", _IHM_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+ihm = _load_ihm()
+
+
+@pytest.fixture()
+def session():
+    net = pp.network.create_four_substations_node_breaker_network()
+    s = ihm.Session(net)
+    s.load(VL)
+    return s
+
+
+def _feeders(s):
+    return {eq for g in s.groups_of(s.initial) for eq in g}
+
+
+# --------------------------------------------------------------------------
+# 1. Import local désactivé sur IHM déportée (Space)
+# --------------------------------------------------------------------------
+
+def test_pick_grid_file_refused_when_hosted(monkeypatch):
+    monkeypatch.setitem(ihm.DATASET, "hosted", True)
+    r = ihm.app.test_client().get("/api/pick_grid_file")
+    assert r.status_code == 403
+    assert r.get_json()["hosted"] is True
+
+
+def test_load_grid_refused_when_hosted(monkeypatch):
+    monkeypatch.setitem(ihm.DATASET, "hosted", True)
+    r = ihm.app.test_client().post("/api/load_grid", json={"path": "/x.xiidm"})
+    assert r.status_code == 403
+    assert r.get_json()["hosted"] is True
+
+
+def test_load_grid_allowed_when_not_hosted(monkeypatch):
+    # Non hébergée : l'erreur est « fichier introuvable » (400), pas un refus.
+    monkeypatch.setitem(ihm.DATASET, "hosted", False)
+    r = ihm.app.test_client().post("/api/load_grid", json={"path": "/nope.xiidm"})
+    assert r.status_code == 400
+    assert not r.get_json().get("hosted")
+
+
+# --------------------------------------------------------------------------
+# 2. Modale de configuration : /api/config
+# --------------------------------------------------------------------------
+
+def test_config_get(session, monkeypatch):
+    monkeypatch.setattr(ihm, "SESSION", session)
+    d = ihm.app.test_client().get("/api/config").get_json()
+    assert "disponibles" in d["algos"] and "selection" in d["algos"]
+    assert "libtopo" in d["algos"]["selection"]["sequenceur"]
+    assert d["scenarios_dir"] and d["sequences_dir"]
+    assert "hosted" in d
+
+
+def test_config_post_updates_dirs(session, monkeypatch, tmp_path):
+    monkeypatch.setattr(ihm, "SESSION", session)
+    monkeypatch.setitem(ihm.DATASET, "hosted", False)
+    sd, qd = tmp_path / "scen", tmp_path / "seq"
+    d = ihm.app.test_client().post("/api/config", json={
+        "scenarios_dir": str(sd), "sequences_dir": str(qd)}).get_json()
+    assert d["scenarios_dir"] == str(sd)
+    assert d["sequences_dir"] == str(qd)
+    assert ihm.SCEN_DIR == sd and ihm.SEQ_DIR == qd
+
+
+def test_config_post_dirs_readonly_when_hosted(session, monkeypatch, tmp_path):
+    monkeypatch.setattr(ihm, "SESSION", session)
+    monkeypatch.setitem(ihm.DATASET, "hosted", True)
+    before_scen, before_seq = ihm.SCEN_DIR, ihm.SEQ_DIR
+    ihm.app.test_client().post("/api/config", json={
+        "scenarios_dir": str(tmp_path / "x"), "sequences_dir": str(tmp_path / "y")})
+    assert ihm.SCEN_DIR == before_scen and ihm.SEQ_DIR == before_seq
+
+
+# --------------------------------------------------------------------------
+# 3. Date/heure de la topologie cible conservée dans le scénario
+# --------------------------------------------------------------------------
+
+def test_scenario_keeps_depart_and_cible_dt(session, monkeypatch, tmp_path):
+    monkeypatch.setattr(ihm, "SCEN_DIR", tmp_path)
+    res = session.save_scenario("sc", depart_dt="2021-01-03T08:00",
+                                source="rte", cible_dt="2021-01-03T12:00")
+    data = json.loads((tmp_path / f"{res['name']}.json").read_text())
+    assert data["meta"]["dt"] == "2021-01-03T08:00"        # topo de départ
+    assert data["meta"]["cible_dt"] == "2021-01-03T12:00"  # topo cible (RTE7000)
+    # exposée par la liste de scénarios (modale Recharger).
+    listed = {s["name"]: s for s in session.list_scenarios()}
+    assert listed[res["name"]]["cible_dt"] == "2021-01-03T12:00"
+
+
+def test_scenario_cible_dt_none_when_modified(session, monkeypatch, tmp_path):
+    monkeypatch.setattr(ihm, "SCEN_DIR", tmp_path)
+    res = session.save_scenario("sc2", depart_dt="2021-01-03T08:00", source="rte")
+    data = json.loads((tmp_path / f"{res['name']}.json").read_text())
+    assert data["meta"]["cible_dt"] is None
+
+
+# --------------------------------------------------------------------------
+# 4. Déclaration d'ouvrages isolés -> réellement déconnectés
+# --------------------------------------------------------------------------
+
+def test_declared_isolated_feeder_is_disconnected(session):
+    feeders = sorted(_feeders(session))
+    assert len(feeders) >= 2
+    iso = [feeders[0]]
+    rest = feeders[1:]
+    # Le départ déclaré isolé était en service (S1VL2 pristine = 1 nœud).
+    assert session.nodale_state(session.initial)["isolated"] == []
+    res = session.nodale_to_detaillee([rest], iso)
+    realised = res["nodale"]
+    assert iso[0] in realised["isolated"]                 # réellement déconnecté
+    # Côté affichage (dropIso du front : isolés retirés des nœuds) → plus un nœud.
+    iso_set = set(realised["isolated"])
+    flat = {eq for g in realised["groups"] for eq in g if eq not in iso_set}
+    assert iso[0] not in flat
+    # Et il n'est pas compté dans le nombre de nœuds réels.
+    assert res["nb_noeuds"] == len([g for g in realised["groups"]
+                                    if any(eq not in iso_set for eq in g)])
+
+
+def test_isoler_dans_etat_opens_incident_switches(session):
+    feeders = sorted(_feeders(session))
+    f = feeders[0]
+    state = dict(session.initial)
+    out = session._isoler_dans_etat(state, [f])
+    # L'opération ne mute pas l'entrée et déconnecte f.
+    assert out is not state
+    assert f in session.nodale_state(out)["isolated"]

--- a/tests/manoeuvre/test_ihm_ui_improvements.py
+++ b/tests/manoeuvre/test_ihm_ui_improvements.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 import importlib.util
 import json
 import pathlib
+import re
 
 import pytest
 
@@ -134,6 +135,36 @@ def test_scenario_cible_dt_none_when_modified(session, monkeypatch, tmp_path):
     res = session.save_scenario("sc2", depart_dt="2021-01-03T08:00", source="rte")
     data = json.loads((tmp_path / f"{res['name']}.json").read_text())
     assert data["meta"]["cible_dt"] is None
+
+
+def test_scenario_records_created_at_and_author(session, monkeypatch, tmp_path):
+    monkeypatch.setattr(ihm, "SCEN_DIR", tmp_path)
+    res = session.save_scenario("sc3", author="  Alice  ")
+    data = json.loads((tmp_path / f"{res['name']}.json").read_text())
+    # date de création (horloge serveur) au format ISO minute, + auteur nettoyé.
+    assert re.match(r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}", data["meta"]["created_at"])
+    assert data["meta"]["author"] == "Alice"
+    listed = {s["name"]: s for s in session.list_scenarios()}
+    assert listed[res["name"]]["author"] == "Alice"
+    assert listed[res["name"]]["created_at"] == data["meta"]["created_at"]
+
+
+def test_scenario_author_none_when_blank(session, monkeypatch, tmp_path):
+    monkeypatch.setattr(ihm, "SCEN_DIR", tmp_path)
+    res = session.save_scenario("sc4", author="   ")
+    data = json.loads((tmp_path / f"{res['name']}.json").read_text())
+    assert data["meta"]["author"] is None
+    assert data["meta"]["created_at"]            # toujours daté
+
+
+def test_api_save_passes_author(session, monkeypatch, tmp_path):
+    monkeypatch.setattr(ihm, "SCEN_DIR", tmp_path)
+    monkeypatch.setattr(ihm, "SESSION", session)
+    r = ihm.app.test_client().post("/api/save", json={"name": "sc5", "author": "Bob"})
+    d = r.get_json()
+    assert "Bob" in d["content"]
+    data = json.loads((tmp_path / f"{d['name']}.json").read_text())
+    assert data["meta"]["author"] == "Bob"
 
 
 # --------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

This PR adds four major improvements to the maneuver IHM (interactive web interface):

1. **Hosted mode security** — disable local file import on remote instances (HuggingFace Space) to prevent confidentiality leaks
2. **Configuration modal** — expose pluggable algorithms per phase and scenario/sequence save paths
3. **Isolated device handling** — properly disconnect devices declared as isolated (0-bar nodes) instead of leaving them connected
4. **Nodal view ordering** — share horizontal axis between top/bottom feeders so left-right position matches the detailed SLD exactly

## Key Changes

### Backend (`scripts/manoeuvre_ihm.py`)

- **Hosted mode detection & enforcement**:
  - `DATASET["hosted"]` flag (auto-detected via `SPACE_ID` env var or `--hosted` CLI flag)
  - `/api/pick_grid_file` and `/api/load_grid` return `403` when hosted
  - Added `_HOSTED_IMPORT_MSG` constant with installation instructions

- **Isolated device disconnection** (`_isoler_dans_etat` method):
  - New method that forces declared isolated devices to be truly disconnected (0-bar nodes)
  - Opens incident switches to detach devices from busbars
  - Called in `nodale_to_detaillee` before topology calculation
  - Recalculates verdict on real nodes only (excludes isolated devices from node count)

- **Scenario metadata enhancements**:
  - `save_scenario()` now accepts `cible_dt` (target topology date) and `author` parameters
  - Stores `created_at` (ISO format, server time) and `author` in scenario metadata
  - `list_scenarios()` exposes these fields for the reload modal

- **Configuration API** (`/api/config`):
  - `GET /api/config` returns available algorithms per phase + current save paths + hosted flag
  - `POST /api/config` updates scenario/sequence directories (read-only when hosted)

- **Enhanced `nodale_to_detaillee` response**:
  - Added `nb_isoles` (count of isolated devices)
  - Added `changes` field (diff between initial and target states for highlighting)
  - Recalculates verdict when isolated devices are present (counts only real nodes)

### Frontend (`scripts/manoeuvre_ihm_assets/index.html`)

- **Hosted mode UI**:
  - Hide "📁 Local" tab and panel when hosted
  - Show dismissible banner explaining local import is disabled with installation instructions
  - `dismissHostedNote()` function to hide the banner

- **Configuration modal** (`#configModal`):
  - Three algorithm selectors (identification, sequencing, planning) with available options
  - Scenario/sequence directory inputs (disabled when hosted)
  - `openConfig()`, `saveConfig()`, `closeConfig()` functions
  - Displays "hosted" notice when applicable

- **Author field**:
  - New input field in header (left of ⚙ Config button) for author name
  - Separate modal (`#authorModal`) for first-time author entry
  - `initAuthor()`, `confirmAuthor()`, `closeAuthor()` functions
  - Author name persisted in localStorage and passed to save API

- **Map improvements**:
  - Cursor changed from pointer to `crosshair` on substation disks for precise targeting
  - New `#mapTip` element displays substation name on hover, follows mouse
  - CSS styling for hover tooltip

- **Nodal view enhancements**:
  - New "⌀ Isoler" button to declare selected feeders as isolated devices
  - `nodIsolateSel()` function to move selected feeders to isolated zone
  - Isolated zone now styled as drop target (dashed outline) during drag operations
  - `.droptarget` CSS class for visual feedback

- **Scenario list display**:
  - Show `cible_dt` (target date) if different from departure date
  - Show `author` and `created_at` metadata as chips
  - Include author in search filter

### Tests (`tests/manoe

https://claude.ai/code/session_0144YJtJLNn3gaBHh2mF9dQk