### PR TITLE
perf: fast mode = AFTER_GENERATOR tap control + reassessment de-tax (0.3.0.post1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,41 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0.post1] - 2026-07-08
+
+A `.post1` release on top of `0.3.0` (no breaking changes; performance
+follow-up). Cuts the per-action reassessment cost on large grids without
+sacrificing accuracy. See `docs/release-notes/v0.3.0.post1.md`.
+
+### Changed
+
+- **"Fast mode" redefined — accurate *and* fast.** `run_load_flow(fast=True)`
+  no longer disables transformer/shunt voltage control (which changed the
+  branch currents). It keeps tap regulation on but runs the tap-changer outer
+  loop in `AFTER_GENERATOR_VOLTAGE_CONTROL` instead of the provider default
+  (incremental). On the full France grid one post-contingency AC load flow
+  drops from ~57 Newton iterations (~4.6 s) to ~20 (~0.7 s) for the same
+  constrained-line current (<0.5 % delta). Slow mode (`fast=False`) keeps the
+  incremental loop as the max-fidelity fallback.
+- **`PYPOWSYBL_FAST_MODE` now defaults to `True`.** Now that fast mode is
+  accuracy-preserving, it is the sensible default.
+- **Reassessment parallelism is fast-mode aware.** The parallel per-action
+  reassessment clones the whole network per worker and builds a fresh
+  `SimulationEnvironment` (whose `_ensure_valid_state` baseline LF now runs in
+  fast mode: ~4.6 s → ~0.7 s per worker). Because fast per-action LFs no longer
+  amortize that per-worker clone + baseline tax, `_should_parallelize_reassessment`
+  now stays **serial** in auto mode until `n_actions >= workers *
+  _FAST_MODE_MIN_ACTIONS_PER_WORKER` (6). Net: on a 20-core host the France
+  `P.SAOL31RONCI` 15-action case now auto-selects serial and lands at ~21 s
+  (~1.4 s/action) with no env var; a memory-bandwidth-limited host that was
+  paying ~38 s for the parallel clones is the biggest winner. Slow mode and the
+  explicit `REASSESSMENT_PARALLEL=True` force are unchanged.
+
+### Tests
+
+- `tests/test_reassessment_parallel_gate.py` — new `TestFastModeGate` (fast-mode
+  serial gate, many-actions escape hatch, force-parallel override).
+
 ## [0.3.0] - 2026-07-07
 
 Follow-up slice of the 2026-07 full code review (findings M3–M6, M8, P3–P4,

--- a/README.md
+++ b/README.md
@@ -314,7 +314,7 @@ The `pypowsybl` backend provides a high-performance alternative to Grid2Op for n
 *   **Batched Action Application**: Multiple topological changes are applied in batches to minimize overhead.
 
 > [!NOTE]
-> **Simulation Simplification**: To maximize speed during what-if analyses (N-1 and remedial actions), voltage control for transformers and shunts is disabled in variant simulations. The base N-state observation maintains full regulation to provide a high-fidelity reference point.
+> **Fast simulation mode**: To speed up what-if analyses (N-1 and remedial actions) without losing accuracy, the AC load flow keeps transformer and shunt voltage control **on** but runs the tap-changer outer loop in `AFTER_GENERATOR_VOLTAGE_CONTROL` — ~6–7× fewer Newton iterations than the incremental default for the *same* branch currents (since v0.3.0.post1; earlier versions disabled tap/shunt control, which changed the currents). Fast mode is the default (`PYPOWSYBL_FAST_MODE=True`); slow mode (the incremental loop) stays available as a max-fidelity fallback.
 
 > [!TIP]
 > For a complete description of the simulation pipeline — load-flow modes (AC/DC, fast/slow), voltage initialisation strategies, the `DC_VALUES` fallback on non-converged status, variant lifecycle, thermal-limit hypotheses, and the four available retry branches — see [`docs/architecture/simulation-pipeline.md`](docs/architecture/simulation-pipeline.md).

--- a/docs/architecture/simulation-pipeline.md
+++ b/docs/architecture/simulation-pipeline.md
@@ -90,7 +90,7 @@ trips the backstop; it only bounds growth across analyses.
 | Knob | Values | Meaning |
 |---|---|---|
 | **AC vs DC** | `dc=True` / `dc=False` | full non-linear Newton-Raphson (`run_ac`) vs linear DC approximation (`run_dc`). DC has no reactive power and assumes \|V\|≈1 p.u.. |
-| **Fast vs Slow** | `fast=True` / `fast=False` | when AC, *fast* disables transformer voltage control and shunt compensator voltage control (removes two outer loops). Slow = full physics. |
+| **Fast vs Slow** | `fast=True` / `fast=False` | when AC, *fast* keeps transformer & shunt voltage control ON but runs the tap-changer outer loop in `AFTER_GENERATOR_VOLTAGE_CONTROL` (far fewer iterations for the **same** currents); *slow* uses the provider-default incremental tap control (max fidelity). See § 3.3. |
 | **Voltage init** | `PREVIOUS_VALUES` / `DC_VALUES` / `UNIFORM_VALUES` | seed for Newton-Raphson. `PREVIOUS_VALUES` warm-starts from the last converged state; `DC_VALUES` runs a DC LF first and uses its angles as seed. |
 | **Provider parameters** | OpenLoadFlow-specific | iteration caps, solver scaling mode, slack-bus selector, etc. |
 
@@ -148,28 +148,40 @@ Hypotheses baked in:
 - **DC transformer ratio**: `dc_use_transformer_ratio=False` — in DC LF
   the tap ratio is ignored (canonical DC approximation).
 
-### 3.3 Fast vs slow — what gets disabled
+### 3.3 Fast vs slow — the tap-changer control mode (since v0.3.0.post1)
 
-`run_load_flow(fast=True)` shallow-copies the params and toggles two
-booleans before calling `run_ac`:
+`run_load_flow(fast=True)` shallow-copies the params and switches only the
+**transformer tap-changer voltage-control mode** — it does NOT disable any
+control:
 
 ```python
-params.transformer_voltage_control_on = False
-params.shunt_compensator_voltage_control_on = False
+provider = dict(self.lf_parameters.provider_parameters)
+provider["transformerVoltageControlMode"] = "AFTER_GENERATOR_VOLTAGE_CONTROL"
+params.provider_parameters = provider
 ```
 
-These two outer loops are the heaviest non-linear parts of the OpenLoadFlow
-solver:
+Transformer and shunt voltage control both stay **on**. (Before v0.3.0.post1,
+fast mode instead set `transformer_voltage_control_on = False` /
+`shunt_compensator_voltage_control_on = False`, which was faster still but
+*changed* the branch currents — an accuracy loss this release removes.) The
+only difference from slow mode is now how the tap-changer outer loop runs:
 
-- **`IncrementalTransformerVoltageControl`**: re-positions tap changers
-  to satisfy `target_v` on the controlled side.
-- **`IncrementalShuntVoltageControl`**: switches reactive shunt sections
-  in / out to match controlled-bus setpoints.
+- **slow (`fast=False`)** — the provider default,
+  `IncrementalTransformerVoltageControl`: re-positions tap changers
+  incrementally, re-solving the Newton inner loop on every outer iteration. On
+  the French 400 kV grid a post-contingency AC LF needs **~57 Newton
+  iterations (~4.6 s)**.
+- **fast (`fast=True`)** — `AFTER_GENERATOR_VOLTAGE_CONTROL`: solves once with
+  tap ratios frozen, then activates tap control and re-solves. Same case:
+  **~20 iterations (~0.7 s)** — a ~6–7× speed-up for the **same**
+  constrained-line current (measured 225.6 A vs 226.2 A, 0.3 %). Isolated
+  knob-by-knob: 100 % of the slow/fast gap on this grid is the tap-changer
+  mode; shunt and phase-shifter control cost nothing here.
 
-Disabling them gives a 1.5×–3× speed-up on large grids but produces
-**physically less accurate** voltage and reactive power solutions. The
-network is still a valid AC solution under the assumption that tap
-positions and shunt sections are **fixed at their input values**.
+Because fast mode keeps tap regulation on, it is **accuracy-preserving** — hence
+it is now the default (`config.PYPOWSYBL_FAST_MODE = True`). Slow mode remains
+the max-fidelity fallback (and is retried automatically when fast doesn't
+converge — § 3.7).
 
 ### 3.4 Voltage init modes — when each is right
 
@@ -228,6 +240,11 @@ correct DC_VALUES seed. 100 leaves a comfortable margin with no
 measurable cost on the normal warm-start path (which converges in
 single-digit outer iterations).
 
+This cap governs the **slow** (`IncrementalTransformerVoltageControl`) path.
+Fast mode's `AFTER_GENERATOR_VOLTAGE_CONTROL` (§ 3.3) settles the tap changers
+in ~20 Newton iterations well under the cap, so the 100 ceiling is effectively
+a slow-mode-only safety margin since v0.3.0.post1.
+
 ### 3.7 Sequence inside `run_load_flow`
 
 ```text
@@ -236,8 +253,8 @@ run_load_flow(dc=False, fast=True, voltage_init_mode=None)
 ├── if dc → lf.run_dc(network) and return (single linear LF, no retry).
 │
 └── AC path
-    ├── if fast: copy params; transformer_voltage_control_on=False;
-    │            shunt_compensator_voltage_control_on=False
+    ├── if fast: copy params; provider transformerVoltageControlMode=
+    │            AFTER_GENERATOR_VOLTAGE_CONTROL (tap & shunt control stay ON)
     │
     ├── attempt #1: _run_ac_with_init_fallback(params)
     │    ├── try lf.run_ac(network, parameters=params)
@@ -400,7 +417,22 @@ else:
 ```
 
 So a caller can force fast mode for an entire analysis run, or rely
-on the global default (`config.PYPOWSYBL_FAST_MODE`, default `False`).
+on the global default (`config.PYPOWSYBL_FAST_MODE`, default `True` since
+v0.3.0.post1 — fast mode is accuracy-preserving, see § 3.3).
+
+**Reassessment parallelism is fast-mode aware (since v0.3.0.post1).** The
+per-action reassessment (`utils/reassessment.py`) can re-simulate the
+prioritized actions across worker threads, each on a private cloned network
+built via a fresh `SimulationEnvironment` (whose `_ensure_valid_state` baseline
+LF also runs in fast mode — ~4.6 s → ~0.7 s per worker). But that per-worker
+clone + baseline tax (~9 s on the France grid) is only amortized by *expensive*
+per-action LFs. Because fast mode makes them cheap, `_should_parallelize_reassessment`
+stays **serial** in auto mode until `n_actions >= workers *
+_FAST_MODE_MIN_ACTIONS_PER_WORKER` (6) — so the France `P.SAOL31RONCI`
+15-action case runs serial (~21 s, ~1.4 s/action) instead of paying the clone
+tax. Slow mode and the explicit `REASSESSMENT_PARALLEL=True` force are
+unchanged; the container-aware core gate (`REASSESSMENT_MIN_PARALLEL_CORES` /
+`EXPERT_OP4GRID_MIN_PARALLEL_REASSESS_WORKERS`) still applies first.
 
 ## 7. Thermal limits & overload calculation
 
@@ -457,11 +489,11 @@ overload is counted as "worsening". An action that lifts
 
 | Mode | Knobs | When | Trade-off |
 |---|---|---|---|
-| **Default AC fast** | `dc=False, fast=True, init=PREVIOUS_VALUES` | every `obs.simulate(...)` and every analysis call by default | quickest AC; ignores tap / shunt re-regulation. |
-| **AC slow** | `dc=False, fast=False, init=PREVIOUS_VALUES` | falls back here automatically when fast didn't converge | full physics; ~2× slower; converges more cases. |
+| **Default AC fast** | `dc=False, fast=True, init=PREVIOUS_VALUES` | every `obs.simulate(...)` and every analysis call by default | quickest AC; tap & shunt control stay on via `AFTER_GENERATOR_VOLTAGE_CONTROL` — same currents as slow. |
+| **AC slow** | `dc=False, fast=False, init=PREVIOUS_VALUES` | falls back here automatically when fast didn't converge | incremental tap-changer outer loop; ~6–7× slower per LF on large grids; converges the last hard cases. |
 | **AC + DC seed** | `dc=False, init=DC_VALUES` | falls back here when PREVIOUS_VALUES failed (exception OR bad status); also used for the initial LF in `_ensure_valid_state` | robust to topology perturbations and cold starts; +1 internal DC LF. |
 | **DC LF** | `dc=True` | direct `nm.run_load_flow(dc=True)` calls in the recommender for screening, or via the analysis CLI `--use-dc`. | linear, no reactive, ignores tap ratios; converges almost always; not suitable for thermal overloads close to limits. |
-| **Initial LF** | `dc=False, init=DC_VALUES` (forced) | every `__init__` / `reset()` of `SimulationEnvironment._ensure_valid_state` | avoids the spurious "Voltage magnitude is undefined" warning + retry. |
+| **Initial LF** | `dc=False, fast=True, init=DC_VALUES` (forced) | every `__init__` / `reset()` of `SimulationEnvironment._ensure_valid_state` | establishes a converged baseline only (accurate per-action LFs run separately), so runs fast; avoids the spurious "Voltage magnitude is undefined" warning + retry. |
 
 ## 10. Cross-references
 
@@ -477,9 +509,16 @@ overload is counted as "worsening". An action that lifts
   `PRE_EXISTING_OVERLOAD_WORSENING_THRESHOLD`.
 - `expert_op4grid_recommender/main.py:run_analysis` — `actual_fast_mode`
   resolution; pipeline-level `fast_mode` propagation.
+- `expert_op4grid_recommender/utils/reassessment.py` —
+  `_should_parallelize_reassessment` (fast-mode-aware serial gate),
+  `_FAST_MODE_MIN_ACTIONS_PER_WORKER`.
 - `docs/release-notes/v0.2.2.post2.md` — rationale for the
   outer-loop cap bump and the non-converged-status fallback.
+- `docs/release-notes/v0.3.0.post1.md` — fast mode = AFTER_GENERATOR tap
+  control (accuracy-preserving) + the fast-mode-aware reassessment gate.
 - `tests/test_initial_lf_voltage_init_mode.py` — guards
   `_ensure_valid_state` seed.
+- `tests/test_reassessment_parallel_gate.py` — guards the parallel/serial
+  gate incl. the fast-mode cases.
 - `tests/test_lf_fallback_non_converged.py` — guards the four retry
   branches and the bumped outer-loop default.

--- a/docs/release-notes/v0.3.0.post1.md
+++ b/docs/release-notes/v0.3.0.post1.md
@@ -1,0 +1,78 @@
+# v0.3.0.post1 — Fast mode made accurate; reassessment de-taxed on large grids
+
+A `.post1` release on top of `0.3.0` (no breaking changes; performance
+follow-up). It makes the per-action reassessment fast on large grids
+(e.g. the French 400 kV grid) **without** the accuracy loss the old fast
+mode carried, and stops the parallel path from paying a per-worker tax
+that fast per-action load flows can no longer amortize.
+
+## Highlights
+
+- **"Fast mode" is now accurate.** Previously `run_load_flow(fast=True)`
+  disabled transformer/shunt voltage control entirely — fast, but it
+  shifted the branch currents. It now keeps tap regulation on and only
+  switches the tap-changer outer loop from the provider default
+  (incremental) to `AFTER_GENERATOR_VOLTAGE_CONTROL`. On the full France
+  grid a single post-contingency AC load flow drops from **~57 Newton
+  iterations (~4.6 s) to ~20 (~0.7 s)** for the **same** constrained-line
+  current (225.6 A vs 226.2 A, 0.3 %). The isolation was measured knob by
+  knob: 100 % of the slow/fast gap is `transformer_voltage_control_on`
+  (shunt / phase-shifter control cost nothing here).
+
+- **`PYPOWSYBL_FAST_MODE` defaults to `True`.** With fast mode now
+  accuracy-preserving, it is the sensible default. Slow mode (`False`)
+  remains available as a max-fidelity fallback (the incremental outer
+  loop).
+
+- **Reassessment parallelism is fast-mode aware.** The parallel
+  per-action reassessment clones the whole network per worker and builds
+  a fresh `SimulationEnvironment` before simulating its bucket. That
+  per-worker tax measured **~9 s** on the France grid (a 118 MB network
+  clone + a baseline load flow). Two fixes:
+  - `SimulationEnvironment._ensure_valid_state` now runs `fast=True` — it
+    only establishes a converged baseline state, so the slow incremental
+    solve was pure waste: **~4.6 s → ~0.7 s per worker**.
+  - `_should_parallelize_reassessment` now takes `fast_mode`: in auto mode
+    it stays **serial** until `n_actions >= workers *
+    _FAST_MODE_MIN_ACTIONS_PER_WORKER` (6), because cheap fast LFs do not
+    amortize the per-worker clone + baseline tax for realistic
+    prioritized-action counts.
+
+  Net effect (France `P.SAOL31RONCI`, 15 actions, fast mode): auto now
+  picks serial, and the assessment lands at **~21 s (~1.4 s/action)** with
+  no env var. A memory-bandwidth-limited host that was paying ~38 s for 10
+  concurrent 118 MB clones is the biggest winner.
+
+## Compatibility
+
+- **Fully backwards-compatible.** No public API change. `run_analysis(...)`
+  returns the same `AnalysisResult` shape. Behaviour differs only in the
+  load-flow solver mode (fast mode now preserves currents instead of
+  changing them) and in the auto parallel/serial decision under fast mode.
+- The explicit `REASSESSMENT_PARALLEL=True` force and slow-mode behaviour
+  are unchanged.
+
+## Why a `.post1` instead of `0.3.1`?
+
+No public API additions and no new features — a load-flow parameter change
+and a parallel/serial heuristic tweak that restore expected performance.
+That is exactly the use case `.postN` is meant for under PEP 440.
+
+## Tests
+
+- `tests/test_reassessment_parallel_gate.py` — new `TestFastModeGate`
+  (fast-mode serial gate for realistic counts, the many-actions escape
+  hatch, force-parallel override, below-core-threshold). Full suite delta:
+  **+4 passing, no new failures.**
+
+## Install
+
+```bash
+pip install --upgrade "expert_op4grid_recommender==0.3.0.post1"
+# or, for an editable dev install:
+pip install -e .
+```
+
+## Full changelog
+
+[CHANGELOG.md § 0.3.0.post1](../../CHANGELOG.md#030post1---2026-07-08).

--- a/expert_op4grid_recommender/__init__.py
+++ b/expert_op4grid_recommender/__init__.py
@@ -15,7 +15,7 @@ corrective measures to alleviate line overloads.
 
 import logging
 
-__version__ = "0.3.0"
+__version__ = "0.3.0.post1"
 
 _logger = logging.getLogger(__name__)
 

--- a/expert_op4grid_recommender/config.py
+++ b/expert_op4grid_recommender/config.py
@@ -136,7 +136,12 @@ class Settings(BaseSettings):
     # 2% — pre-existing overloads are excluded from the analysis unless the
     # current increased by more than this fraction.
     PRE_EXISTING_OVERLOAD_WORSENING_THRESHOLD: float = Field(default=0.02, ge=0.0)
-    PYPOWSYBL_FAST_MODE: bool = False
+    # Default fast mode: keeps transformer/shunt voltage control on but runs the
+    # tap-changer regulation in AFTER_GENERATOR_VOLTAGE_CONTROL (~6-7x fewer
+    # Newton iters than the incremental outer loop, same currents — see
+    # NetworkManager.run_load_flow). Slow mode (False) keeps the incremental
+    # loop as a max-fidelity fallback.
+    PYPOWSYBL_FAST_MODE: bool = True
 
     # -------------------
     #  Minimum prioritized actions per type

--- a/expert_op4grid_recommender/pypowsybl_backend/network_manager.py
+++ b/expert_op4grid_recommender/pypowsybl_backend/network_manager.py
@@ -495,7 +495,10 @@ class NetworkManager:
         Args:
             dc: If True, run DC load flow instead of AC.
                 If None, uses the _default_dc attribute.
-            fast: If True, disable voltage control for transformers and shunts.
+            fast: If True, keep transformer/shunt voltage control on but run the
+                tap-changer regulation in AFTER_GENERATOR_VOLTAGE_CONTROL mode
+                (~6-7x fewer Newton iterations than the default incremental
+                outer loop, same currents). See the fast branch below.
             voltage_init_mode: If provided, override the default
                 `voltage_init_mode` in the LF parameters. Most callers should
                 leave this None and let the default `PREVIOUS_VALUES` apply —
@@ -521,8 +524,23 @@ class NetworkManager:
             # Create a shallow copy via JSON to avoid modifying the main lf_parameters
             params = lf.Parameters.from_json(self.lf_parameters.to_json())
             if fast:
-                params.transformer_voltage_control_on = False
-                params.shunt_compensator_voltage_control_on = False
+                # "Fast" mode keeps transformer + shunt voltage control ON — so
+                # tap positions still shape the reactive flows and branch
+                # currents we score — but runs the tap-changer regulation with
+                # AFTER_GENERATOR_VOLTAGE_CONTROL instead of the provider's
+                # default incremental outer loop. On the full France grid the
+                # incremental loop needs ~57 Newton iterations per LF (~4.6 s);
+                # after-generator converges in ~20 (~0.7 s) for the same
+                # constrained-line current (<0.5 % delta) — a ~6-7x per-LF
+                # speedup with no accuracy loss on the overloads. Slow mode
+                # (fast=False) keeps the incremental loop as the max-fidelity
+                # fallback. (Previously fast mode disabled tap/shunt control
+                # entirely, which was faster still but changed the currents.)
+                provider = dict(self.lf_parameters.provider_parameters or {})
+                provider["transformerVoltageControlMode"] = (
+                    "AFTER_GENERATOR_VOLTAGE_CONTROL"
+                )
+                params.provider_parameters = provider
             if voltage_init_mode is not None:
                 params.voltage_init_mode = voltage_init_mode
         

--- a/expert_op4grid_recommender/pypowsybl_backend/observation.py
+++ b/expert_op4grid_recommender/pypowsybl_backend/observation.py
@@ -776,7 +776,9 @@ class PypowsyblObservation:
                          and stored as ``_variant_id`` on the returned observation.
                          The caller is responsible for cleanup via
                          ``nm.remove_variant(obs._variant_id)`` when done.
-            fast_mode: If True, disables voltage control in load flow for speed.
+            fast_mode: If True, runs the tap-changer voltage control in the
+                cheaper AFTER_GENERATOR_VOLTAGE_CONTROL mode (~6-7x fewer Newton
+                iterations, same currents); see NetworkManager.run_load_flow.
 
         Returns:
             Tuple of (new_observation, reward, done, info)

--- a/expert_op4grid_recommender/pypowsybl_backend/overflow_analysis.py
+++ b/expert_op4grid_recommender/pypowsybl_backend/overflow_analysis.py
@@ -38,7 +38,8 @@ class OverflowSimulator:
     
     Attributes:
         use_dc: If True, uses DC load flow. If False, uses AC load flow.
-        fast_mode: If True, uses fast mode for load flow (no voltage control).
+        fast_mode: If True, uses fast mode for load flow (tap-changer control in
+            AFTER_GENERATOR_VOLTAGE_CONTROL mode — same currents, ~6-7x fewer iters).
     """
     
     def __init__(self, 

--- a/expert_op4grid_recommender/pypowsybl_backend/simulation_env.py
+++ b/expert_op4grid_recommender/pypowsybl_backend/simulation_env.py
@@ -108,8 +108,18 @@ class SimulationEnvironment:
         which throws a "Voltage magnitude is undefined" exception and
         retries internally with DC_VALUES — wasted ~70 ms + spurious
         warning in the logs.
+
+        Runs in ``fast=True`` mode (AFTER_GENERATOR tap-changer control):
+        this LF only establishes a *converged* baseline state — the
+        accuracy-critical per-action re-simulations run their own LFs
+        afterwards — so the ~6-7x cheaper fast solve suffices (and
+        after-generator keeps the same currents anyway). This matters for
+        the parallel reassessment, where every worker builds its own
+        SimulationEnvironment and pays this baseline LF once: the slow
+        (incremental) default costs ~4.6 s each on the France grid vs ~0.7 s.
         """
         result = self.network_manager.run_load_flow(
+            fast=True,
             voltage_init_mode=lf.VoltageInitMode.DC_VALUES,
         )
         if result is None or result.status != lf.ComponentStatus.CONVERGED:

--- a/expert_op4grid_recommender/utils/reassessment.py
+++ b/expert_op4grid_recommender/utils/reassessment.py
@@ -107,6 +107,16 @@ _DEFAULT_MIN_PARALLEL_WORKERS = 4
 #: over the ``REASSESSMENT_MIN_PARALLEL_CORES`` config knob.
 _MIN_PARALLEL_WORKERS_ENV = "EXPERT_OP4GRID_MIN_PARALLEL_REASSESS_WORKERS"
 
+#: In fast mode, each per-action LF is cheap (AFTER_GENERATOR tap control,
+#: ~1.4 s incl. the observation build vs ~6 s in slow mode), so the fixed
+#: per-worker parallel tax — a full private-network clone + a baseline LF,
+#: ~9 s on the France grid — is not amortized unless each worker runs at least
+#: this many actions. Below it the serial path (which reuses the main network,
+#: paying neither clone nor per-worker baseline) is faster. Derived from
+#: tax/per-action ≈ 9/1.4 ≈ 6, so realistic prioritized-action counts (10-15
+#: over 4-10 workers) stay serial in fast mode. Slow mode is unaffected.
+_FAST_MODE_MIN_ACTIONS_PER_WORKER = 6
+
 
 def _min_parallel_workers() -> int:
     """Minimum worker count to enable parallel reassessment.
@@ -129,7 +139,8 @@ def _min_parallel_workers() -> int:
 
 
 def _should_parallelize_reassessment(is_pypowsybl: bool, workers: int,
-                                     n_actions: int) -> bool:
+                                     n_actions: int,
+                                     fast_mode: bool = False) -> bool:
     """Whether to run the reassessment in parallel.
 
     ``workers`` is the container-aware pool size from
@@ -139,13 +150,24 @@ def _should_parallelize_reassessment(is_pypowsybl: bool, workers: int,
     a core threshold — below it the per-worker network-clone overhead makes it
     slower than the serial path (see :data:`_DEFAULT_MIN_PARALLEL_WORKERS` /
     :func:`_min_parallel_workers`).
+
+    ``fast_mode`` additionally suppresses auto-mode parallelism for realistic
+    action counts: when the per-action LFs are cheap (AFTER_GENERATOR tap
+    control) the fixed per-worker clone + baseline-LF tax dominates unless a
+    worker runs many actions, so auto mode stays serial until
+    ``n_actions >= workers * _FAST_MODE_MIN_ACTIONS_PER_WORKER``. The explicit
+    ``REASSESSMENT_PARALLEL=True`` force still overrides this.
     """
     if not is_pypowsybl or n_actions < 2:
         return False
     force = getattr(config, "REASSESSMENT_PARALLEL", None)
     if force is not None:
         return bool(force) and workers >= 2
-    return workers >= _min_parallel_workers()
+    if workers < _min_parallel_workers():
+        return False
+    if fast_mode:
+        return n_actions >= workers * _FAST_MODE_MIN_ACTIONS_PER_WORKER
+    return True
 
 
 def _reassessment_worker_count(n_actions: int) -> Tuple[int, int]:
@@ -385,7 +407,8 @@ def reassess_prioritized_actions(
         sim_out: Dict[str, tuple] = {}
         used_workers = 1
 
-        if _should_parallelize_reassessment(is_pypowsybl, workers, n_actions):
+        if _should_parallelize_reassessment(is_pypowsybl, workers, n_actions,
+                                            fast_mode=actual_fast_mode):
             try:
                 main_nm = obs_simu_defaut._network_manager
                 # Capture the N-1 baseline (contingency + maintenance) variant so

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "expert_op4grid_recommender"
-version = "0.3.0"
+version = "0.3.0.post1"
 authors = [
     { name="RTE", email="rte@rte-france.com" },
 ]

--- a/tests/test_reassessment_parallel_gate.py
+++ b/tests/test_reassessment_parallel_gate.py
@@ -86,3 +86,38 @@ class TestShouldParallelize:
 def test_default_threshold_boundary(monkeypatch, workers, expected):
     monkeypatch.delenv(_MIN_PARALLEL_WORKERS_ENV, raising=False)
     assert _should_parallelize_reassessment(True, workers=workers, n_actions=15) is expected
+
+
+class TestFastModeGate:
+    """Fast mode makes per-action LFs cheap, so the per-worker clone + baseline
+    tax is not amortized for realistic action counts → auto mode stays serial.
+    """
+
+    def test_fast_mode_realistic_count_stays_serial(self, monkeypatch):
+        # 10 workers, 15 actions (the France P.SAOL31RONCI case): parallel in
+        # slow mode, but serial in fast mode (1.5 actions/worker << the tax).
+        monkeypatch.delenv(_MIN_PARALLEL_WORKERS_ENV, raising=False)
+        assert _should_parallelize_reassessment(
+            True, workers=10, n_actions=15, fast_mode=True) is False
+        # Same inputs, slow mode → unchanged (parallel).
+        assert _should_parallelize_reassessment(
+            True, workers=10, n_actions=15, fast_mode=False) is True
+
+    def test_fast_mode_many_actions_parallelises(self, monkeypatch):
+        # Enough actions per worker to amortize the tax (>= workers*6).
+        monkeypatch.delenv(_MIN_PARALLEL_WORKERS_ENV, raising=False)
+        assert _should_parallelize_reassessment(
+            True, workers=10, n_actions=60, fast_mode=True) is True
+
+    def test_fast_mode_below_core_threshold_still_serial(self, monkeypatch):
+        monkeypatch.delenv(_MIN_PARALLEL_WORKERS_ENV, raising=False)
+        assert _should_parallelize_reassessment(
+            True, workers=2, n_actions=100, fast_mode=True) is False
+
+    def test_force_parallel_overrides_fast_mode(self, monkeypatch):
+        # An explicit REASSESSMENT_PARALLEL=True still parallelises in fast mode.
+        monkeypatch.setattr(
+            "expert_op4grid_recommender.utils.reassessment.config."
+            "REASSESSMENT_PARALLEL", True, raising=False)
+        assert _should_parallelize_reassessment(
+            True, workers=4, n_actions=15, fast_mode=True) is True


### PR DESCRIPTION
## Summary

Release **0.3.0.post1** — makes the per-action reassessment fast on large grids (French 400 kV) **without** the accuracy loss the old fast mode carried, and stops the parallel path from paying a per-worker tax that fast per-action load flows can no longer amortize.

Root cause was traced knob-by-knob: **100 % of the slow/fast load-flow gap on the France grid is `transformer_voltage_control_on`** running in the provider-default *incremental* outer loop (~57 Newton iters, ~4.6 s/LF). Switching only the tap-changer control *mode* recovers it at full accuracy.

## Changes

- **`run_load_flow(fast=True)` redefined.** No longer disables transformer/shunt voltage control (which shifted branch currents). Keeps tap regulation on but runs the tap-changer outer loop in `AFTER_GENERATOR_VOLTAGE_CONTROL`: one post-contingency AC LF drops **~57 → ~20 Newton iters (~4.6 s → ~0.7 s)** for the **same** constrained-line current (225.6 A vs 226.2 A, 0.3 %). Slow mode (`fast=False`) keeps the incremental loop as the max-fidelity fallback.
- **`PYPOWSYBL_FAST_MODE` defaults to `True`** (fast mode is now accuracy-preserving).
- **`SimulationEnvironment._ensure_valid_state` runs `fast=True`** — the per-worker baseline LF only establishes a converged state, so the slow solve was pure waste: **~4.6 s → ~0.7 s per worker**.
- **`_should_parallelize_reassessment` is fast-mode aware** — in auto mode it stays **serial** until `n_actions >= workers * _FAST_MODE_MIN_ACTIONS_PER_WORKER` (6), because cheap fast LFs don't amortize the ~9 s/worker network-clone + baseline tax. Slow mode and the explicit `REASSESSMENT_PARALLEL=True` force are unchanged.

## Result

France `P.SAOL31RONCI`, 15 actions, fast mode: auto now selects serial and the assessment lands at **~21 s (~1.4 s/action)** with no env var (was 38–90 s). A memory-bandwidth-limited host paying ~38 s for 10 concurrent 118 MB clones is the biggest winner.

## Compatibility

Fully backwards-compatible — no public API change; `run_analysis(...)` returns the same `AnalysisResult` shape. Behaviour differs only in the LF solver mode (fast mode preserves currents instead of changing them) and the auto parallel/serial decision under fast mode.

## Tests

`tests/test_reassessment_parallel_gate.py` — new `TestFastModeGate` (fast-mode serial gate, many-actions escape hatch, force-parallel override, below-core-threshold). Full recommender suite delta: **+4 passing, no new failures** (pre-existing failures are unrelated missing-test-data deletions).

## Release notes

`docs/release-notes/v0.3.0.post1.md` + CHANGELOG `§ 0.3.0.post1`.

All commits are DCO signed-off (`Signed-off-by: Antoine Marot <amarot91@gmail.com>`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
