### PR TITLE
Fix DC-escalation contamination in reused pypowsybl env (issue #6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.1.post1] - 2026-07-22
+
 ### Fixed
 
 - **Reused pypowsybl env no longer "contaminated" by a DC escalation (issue #6).**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Reused pypowsybl env no longer "contaminated" by a DC escalation (issue #6).**
+  When an overload-disconnection load flow diverges, `run_analysis_step2_graph`
+  calls `switch_to_dc_load_flow_pypowsybl`, which escalated the *shared* env to
+  DC by setting `NetworkManager._default_dc = True` and DC-solving the base
+  variant (leaving every bus `v_mag = NaN`, since a DC load flow computes no
+  voltage magnitudes). That escalation was never reset, so a subsequent analysis
+  reusing the same `SimulationEnvironment` (batch classifiers, long-lived
+  services, the Co-Study4Grid game backend) ran *every* load flow in DC — where
+  branch currents are not populated, so `rho ≈ 0` and real overloads **silently
+  vanished** (`run_analysis_step1` returned an empty "Overload breaks the grid
+  apart" short-circuit). The escalation is now recorded
+  (`SimulationEnvironment._dc_escalation_pending`) and undone at the next
+  analysis boundary: `run_analysis_step1`'s reused-env branch calls
+  `SimulationEnvironment.reset_loadflow_mode_to_baseline(config.USE_DC_LOAD_FLOW)`,
+  restoring the configured baseline load-flow mode and an AC-solved (energized)
+  base variant — exactly like a freshly built env. Behaviour-preserving on the
+  non-divergent path (the restore only fires after an actual DC escalation) and
+  it removes the need for the game-mode classifier's env-rebuild workaround. The
+  earlier "deep, unrecoverable pypowsybl network-global corruption" diagnosis in
+  `docs/reviews/2026-07_env_corruption_overflow_graph.md` was an artifact of the
+  leaked `_default_dc` flag (which silently turned every "recovery" AC solve back
+  into DC); the write-up is corrected there. Regression test:
+  `tests/test_env_reuse_dc_escalation.py` (IEEE-9 based — no France-grid fixture).
+
 ## [0.3.1] - 2026-07-21
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -503,8 +503,25 @@ pytest tests/test_ActionClassifier.py::test_specific  # Single test
 
 ## Current Development Status
 
-**Current version**: `0.3.1` (see `CHANGELOG.md` for full history)
+**Current version**: `0.3.1.post1` (see `CHANGELOG.md` for full history)
 
+> **v0.3.1.post1 highlights** (silent-correctness fix, issue #6): a reused
+> pypowsybl `SimulationEnvironment` is no longer contaminated by a transient DC
+> escalation. When an overload-disconnection load flow diverges,
+> `switch_to_dc_load_flow_pypowsybl` set `NetworkManager._default_dc=True` on the
+> **shared** env and DC-solved the base variant (every bus `v_mag=NaN`), and the
+> flag was never reset — so the *next* analysis reusing the env ran every load
+> flow in DC, where branch currents aren't populated (`rho≈0`) and real overloads
+> silently vanished. The escalation is now recorded
+> (`SimulationEnvironment._dc_escalation_pending`) and undone at the next analysis
+> boundary via `SimulationEnvironment.reset_loadflow_mode_to_baseline(...)`, which
+> `run_analysis_step1`'s reused-env branch calls to restore the configured
+> baseline LF mode + an AC-solved (energized) base. Byte-identical on the
+> non-divergent path; removes the game-mode classifier's env-rebuild workaround.
+> The "deep pypowsybl corruption" diagnosis in
+> `docs/reviews/2026-07_env_corruption_overflow_graph.md` was an artifact of the
+> leaked flag and is corrected there. See `docs/release-notes/v0.3.1.post1.md`.
+>
 > **v0.3.1 highlights**: opt-in `USE_DC_FOR_OVERFLOW_GRAPH` (default off — AC
 > graph observations preserved) runs the overflow-graph flow transfer in DC
 > with a power-derived rho (`|I| = |P|·1000/(√3·Vnom)`), ~10 s → ~0.2 s on a

--- a/docs/release-notes/v0.3.1.post1.md
+++ b/docs/release-notes/v0.3.1.post1.md
@@ -1,0 +1,86 @@
+# v0.3.1.post1 — Reused pypowsybl env no longer contaminated by a DC escalation
+
+A `.post1` release on top of `0.3.1` (no breaking API changes; silent-correctness
+fix). It stops a transient DC escalation from leaking across analyses that reuse
+one `SimulationEnvironment`, which could make a later analysis silently miss real
+overloads (issue #6).
+
+## Highlights
+
+- **Reused-env DC contamination fixed (issue #6).** When an
+  overload-disconnection load flow diverges (a stressed contingency whose kept
+  overloads island the grid), `run_analysis_step2_graph` calls
+  `switch_to_dc_load_flow_pypowsybl` to fall back to DC. That escalation set
+  `NetworkManager._default_dc = True` on the **shared** env and DC-solved the
+  base variant — and a DC load flow computes no voltage magnitudes, so every bus
+  `v_mag` became `NaN`. The flag was **never reset**, so a subsequent analysis
+  reusing the same env (batch classifiers, long-lived services, the
+  Co-Study4Grid game backend) ran *every* load flow in DC. `run_dc` does not
+  populate branch currents, so `rho ≈ 0` on every line and **real overloads
+  silently vanished** — `run_analysis_step1` returned an empty "Overload breaks
+  the grid apart" short-circuit where a freshly built env detected the overload.
+
+- **Root cause was a state leak, not deep pypowsybl corruption.** Instrumenting
+  the base variant's NaN-`v_mag` count after every load flow showed the divergent
+  AC solve runs on a *transient cloned variant* and leaves the base variant
+  untouched (still 35 NaN buses on the France THT `hiver_pic_2021` snapshot); the
+  jump to 1701 happens on the *DC solve of `base`* inside the escalation. The
+  earlier "only a full env reload recovers" conclusion was an artifact of the
+  same leaked `_default_dc` flag — it silently turned every attempted "cold AC
+  recovery" load flow back into DC. Clearing the flag and doing a genuine AC
+  solve recovers fully, no reload needed.
+
+- **The fix restores the env at the analysis boundary.** The escalation is now
+  recorded (`SimulationEnvironment._dc_escalation_pending`) and undone on reuse:
+  - `switch_to_dc_load_flow_pypowsybl` sets the flag alongside `_default_dc`.
+  - New `SimulationEnvironment.reset_loadflow_mode_to_baseline(dc)` restores the
+    load-flow mode (`_default_dc` / `_use_dc`) to the configured baseline
+    (`config.USE_DC_LOAD_FLOW`), re-solves the base variant in that mode, and
+    clears the flag.
+  - `run_analysis_step1`'s reused-env (`prebuilt_env_context`) branch calls it
+    when the flag is set; otherwise it keeps the previous plain `reset_to_base()`
+    fast path.
+
+  Net effect: a reused env self-heals at the start of the next
+  `run_analysis_step1`, so the RTE7000 game-mode classifier's
+  rebuild-the-env-after-every-graded-analysis workaround (~4 s each) is no longer
+  needed.
+
+## Compatibility
+
+- **Fully backwards-compatible.** No change to `run_analysis(...)` /
+  `AnalysisResult`. The overflow-graph flow numbers are **byte-identical on the
+  non-divergent path** — the restore only fires after an actual DC escalation
+  (`_dc_escalation_pending`), and a screening-only (`step1`) workload never
+  escalates, so it keeps the plain-`reset_to_base()` fast path.
+- New public surface is additive: `SimulationEnvironment.reset_loadflow_mode_to_baseline`
+  and the `_dc_escalation_pending` guard attribute.
+
+## Why a `.post1` instead of `0.3.2`?
+
+No new features and no change to the analysis output on any path that already
+worked — a correctness fix for env reuse plus the small env-lifecycle helper it
+needs. That matches how this project has used `.postN` for follow-up fixes.
+
+## Tests
+
+- `tests/test_env_reuse_dc_escalation.py` — new IEEE-9-based regression suite (no
+  France-grid fixture or the deprecated `pypowsybl2grid` required): fresh env is
+  AC + energized; `switch_to_dc` flags the escalation and de-energizes base;
+  `reset_loadflow_mode_to_baseline` re-energizes base (and honours a DC baseline);
+  and end-to-end, `run_analysis_step1` sanitizes a reused, escalated env while
+  leaving an un-escalated reused env on the fast path. All six fail on the
+  unmodified source and pass with the fix. Full suite: **+6 passing, no new
+  failures.**
+
+## Install
+
+```bash
+pip install --upgrade "expert_op4grid_recommender==0.3.1.post1"
+# or, for an editable dev install:
+pip install -e .
+```
+
+## Full changelog
+
+[CHANGELOG.md § 0.3.1.post1](../../CHANGELOG.md#031post1---2026-07-22).

--- a/docs/reviews/2026-07_env_corruption_overflow_graph.md
+++ b/docs/reviews/2026-07_env_corruption_overflow_graph.md
@@ -1,13 +1,16 @@
-# Bug: overflow-graph build corrupts a reused pypowsybl env (step2 → later step1 "vanishes" overloads)
+# Bug: overflow-graph build "contaminates" a reused pypowsybl env (step2 → later step1 "vanishes" overloads)
 
 **Severity:** correctness (silent) — affects any workflow that reuses one
 `SimulationEnvironment` across **multiple** analyses (batch classifiers,
 long-lived services, the Co-Study4Grid game backend serving several
 contingencies from one loaded network).
 
-**Status:** root-caused with a minimal reproduction; verified workaround below.
-No in-place code fix landed yet (needs care not to change the graph-build flow
-math — see "Fix directions").
+**Status:** root-caused and **fixed in-place** (issue #6). The original
+hypothesis below (a *deep, unrecoverable* pypowsybl network-global corruption)
+turned out to be **wrong** — it was an artifact of a hidden confounder (a leaked
+`_default_dc` flag that silently turned every "recovery" load flow back into DC).
+The true cause is an ordinary state leak on the reused env, and it is fully
+recoverable without any network reload. See "Root cause (corrected)".
 
 ## Symptom
 
@@ -18,34 +21,57 @@ detects on a freshly built env — it returns an `AnalysisResult` short-circuit
 ("Overload breaks the grid apart") with an empty overload set. The analysis
 silently reports *no actionable overload* where there is one.
 
-Only a **full env rebuild** (reload the network from file) restores correct
-detection. `reset_to_base()`, `sweep_kept_variants()`, removing every non-base
-variant, re-cloning `base` from the pristine `InitialState` variant, and a cold
-AC load flow on `base` **all fail to recover**.
+The trigger is contingency-specific: it only fires after an analysis whose
+overload-disconnection load flow **diverges** (`MAX_ITERATION_REACHED`), which
+happens when disconnecting the kept overloads islands part of a stressed grid.
+An "easy" contingency whose overload-disconnection stays solvable never trips it.
 
-## Root cause
+## Root cause (corrected)
 
-`run_analysis_step2_graph` builds the overflow graph via
-`pypowsybl_backend/overflow_analysis.py`. Its flow-change analysis clones a
-working variant, disconnects the overloaded lines, and runs a load flow (DC for
-the graph transfer). On a stressed operating point disconnecting the overloads
-can island part of the grid and that load flow does **not** converge
-(`MAX_ITERATION_REACHED`).
+The corruption is **not** produced by the divergent load flow, and it is **not**
+below the variant layer. It is a plain state leak on the *shared* env:
 
-After the graph build returns, the **base variant's AC voltage state is
-destroyed**: on the France THT `hiver_pic_2021` snapshot the base variant goes
-from 35 NaN `v_mag` buses to **1701** (≈1666 buses left de-energized), while line
-connection flags, switch open/closed states, load and generation totals, and the
-cached thermal limits are all **unchanged**. The next `step1` calls
-`reset_to_base()` (which only switches the working variant — it does not re-solve)
-and then `obs.simulate(contingency)`, which warm-starts (`PREVIOUS_VALUES`) from
-those NaN voltages, diverges, and yields a degenerate near-zero-flow observation
-→ every `rho < 1` → "no overload".
+1. In `run_analysis_step2_graph`, `check_simu_overloads` disconnects all kept
+   overloads on top of the contingency and runs an AC load flow. On a stressed
+   operating point that islands the grid and the solve **diverges**
+   (`MAX_ITERATION_REACHED`). This diverging solve runs on a *transient cloned
+   variant* and — verified by instrumentation — leaves the base variant
+   untouched (still 35 NaN `v_mag` buses on the `hiver_pic_2021` snapshot).
 
-The damage lives **below the variant layer** (in pypowsybl network-global solver
-state): it survives variant purge and a re-clone of `base` from `InitialState`,
-and is only cleared by reloading the network object. That is why the workaround
-must rebuild the whole env.
+2. Because the check reports non-convergence, step2 calls
+   **`switch_to_dc_load_flow_pypowsybl`**, which escalates the analysis to DC by
+   setting **`env.network_manager._default_dc = True`** on the *shared, reused*
+   NetworkManager and then calling `env.reset()`. `reset()` re-solves the **base
+   variant**, and because `_default_dc` is now `True` it runs a **DC** load flow
+   — which computes no voltage magnitudes, so every bus `v_mag` becomes `NaN`
+   (35 → 1701). That is the "de-energized base" that looked like deep corruption.
+
+3. `switch_to_dc` **never resets `_default_dc`**, so it leaks past the end of the
+   analysis. The next `step1` that reuses the env runs *all* its load flows in DC
+   (`run_load_flow(dc=None)` → `use_dc = _default_dc = True`). A DC load flow
+   does not populate branch currents (`i1/i2 = 0`), so `rho ≈ 0` on every line →
+   no line reads as overloaded → the short-circuit fires with an empty set.
+
+### Why the earlier investigation concluded "only a full reload recovers"
+
+The earlier write-up reported that `reset_to_base()`, variant purge, re-cloning
+`base` from `InitialState`, **and a cold AC load flow on `base`** all failed to
+recover, and inferred deep pypowsybl-global corruption. The confounder was
+`_default_dc`: with it still `True`, every "cold AC load flow" issued through
+`NetworkManager.run_load_flow(...)` was silently a **DC** solve, so of course it
+never re-energized the base. Clearing the flag first makes recovery trivial:
+
+```python
+nm._default_dc = False
+nm.reset_to_base()
+nm.run_load_flow(voltage_init_mode=DC_VALUES)   # a real AC solve
+# base NaN v_mag: 1701 -> 35 again; the next step1 detects the overload.
+```
+
+No network reload is needed. The divergent AC solve leaves no residual
+network-global damage — confirmed by instrumenting the base `v_mag` NaN count
+after every load flow: it stays at 35 through the divergent solve and only jumps
+to 1701 on the DC solve of `base` inside `switch_to_dc`.
 
 ## Minimal reproduction
 
@@ -61,40 +87,64 @@ def probe(cid):
 print(probe("AVALLL61VNOL"))                      # CONTEXT (overload detected)
 out = run_analysis_step1(..., current_lines_defaut=["AVALLL61J.VIL"],
                          dict_action=full, prebuilt_env_context=ctx0)
-run_analysis_step2_graph(out)                     # builds overflow graph
-print(probe("AVALLL61VNOL"))                      # no-context  <-- BUG
+run_analysis_step2_graph(out)                     # diverges -> switch_to_dc
 
-# base variant voltages are now NaN even though topology/loads are identical:
+# BEFORE the fix: _default_dc leaked True and base was DC-solved.
+print(nm._default_dc)                             # True  (leaked)
 nm.set_working_variant(nm.base_variant_id)
-np.isnan(net.get_buses()["v_mag"].values).sum()   # 35 fresh -> 1701 after
+np.isnan(net.get_buses()["v_mag"].values).sum()   # 35 fresh -> 1701 after (DC solve)
+print(probe("AVALLL61VNOL"))                      # no-context  <-- BUG (runs in DC)
+
+# AFTER the fix: run_analysis_step1 restores the env on reuse.
+print(probe("AVALLL61VNOL"))                      # CONTEXT again; nm._default_dc == False
 ```
 
-Contingency-specific: contingencies whose overload disconnection keeps the grid
-solvable (e.g. an "easy" case) do not trip it; a stressed one whose flow-change
-LF hits `MAX_ITERATION` does.
+## Fix (applied)
 
-## Workaround (used by the RTE7000 game-mode classifier)
+`switch_to_dc_load_flow_pypowsybl`'s DC escalation is *analysis-scoped* but was
+written onto *shared, long-lived* env state. The fix records the escalation and
+undoes it at the next analysis boundary, so a reused env always starts a new
+analysis in the configured baseline mode with a valid (energized) base — exactly
+like a freshly built env:
 
-Rebuild the env after every analysis that ran `step2` (env rebuild is only
-~4 s). Screening with `step1` alone never corrupts, so only grading needs it:
+- `switch_to_dc_load_flow_pypowsybl` sets `env._dc_escalation_pending = True`
+  alongside `_default_dc = True`.
+- `SimulationEnvironment.reset_loadflow_mode_to_baseline(dc)` restores the LF
+  mode flags (`_default_dc` / `_use_dc`) to the configured baseline
+  (`config.USE_DC_LOAD_FLOW`), re-solves the base variant in that mode
+  (`_ensure_valid_state`), and clears the escalation flag.
+- `run_analysis_step1`'s reused-env (`prebuilt_env_context`) branch calls
+  `reset_loadflow_mode_to_baseline(...)` when it finds `_dc_escalation_pending`,
+  and otherwise keeps the previous plain `reset_to_base()` fast path.
+
+This keeps the overflow-graph flow numbers **byte-identical on the non-divergent
+path** (the restore only runs when a prior analysis actually escalated to DC),
+costs a single baseline load flow instead of the ~4 s full env rebuild the
+work­around used, and removes the need for that workaround entirely.
+
+Regression test: `tests/test_env_reuse_dc_escalation.py` (built on the IEEE-9
+network — no France-grid fixture or `pypowsybl2grid` needed).
+
+## Historical workaround (no longer required)
+
+The RTE7000 game-mode classifier rebuilt the env after every analysis that ran
+`step2` (~4 s each). With the fix this is unnecessary — a reused env self-heals
+at the start of the next `run_analysis_step1`:
 
 ```python
 rec = process(cid, ctx0, dict_action)     # step1 (+ step2 for candidates)
-if rec["kind"] in ("candidate", "error"): # step2 ran or state is unknown
-    del env; env, ctx0, dict_action, net = build_env(lab)
+# (previously) del env; env, ctx0, dict_action, net = build_env(lab)
 ```
 
-## Fix directions (not yet applied)
+## Alternative fix directions (considered, not needed)
 
-1. **Isolate the flow-change load flow** on a network object that is not the one
-   reused across analyses (e.g. a dedicated clone loaded once), so a divergent
-   graph-transfer LF can never pollute the shared network's global solver state.
-2. **Restore a valid AC base state after `step2_graph`** — but note a plain
-   `run_ac(DC_VALUES)` on `base` did *not* recover here, so this must reload /
-   re-import the network, not just re-solve.
-3. **Guard the flow-change LF divergence**: when disconnecting the overloads
-   islands the grid, skip/flag it instead of leaving the shared network in a
-   half-solved state.
+For the record, the isolation / guard directions from the original write-up
+would also work but are heavier than needed given the corrected root cause:
 
-Any fix must keep the overflow-graph flow numbers byte-identical on the
-non-divergent path (the existing pipeline output contract).
+1. **Isolate the flow-change load flow** on a dedicated network object. Robust,
+   but adds a second network to memory and only matters if the divergent solve
+   actually corrupted shared state — which it does not.
+2. **Guard the divergence** (skip the LF when disconnecting the overloads
+   islands the grid). Reasonable defense-in-depth, but the divergence itself is
+   harmless; the leak is the DC-mode flag, which the applied fix addresses
+   directly.

--- a/docs/reviews/2026-07_env_corruption_overflow_graph.md
+++ b/docs/reviews/2026-07_env_corruption_overflow_graph.md
@@ -1,0 +1,100 @@
+# Bug: overflow-graph build corrupts a reused pypowsybl env (step2 → later step1 "vanishes" overloads)
+
+**Severity:** correctness (silent) — affects any workflow that reuses one
+`SimulationEnvironment` across **multiple** analyses (batch classifiers,
+long-lived services, the Co-Study4Grid game backend serving several
+contingencies from one loaded network).
+
+**Status:** root-caused with a minimal reproduction; verified workaround below.
+No in-place code fix landed yet (needs care not to change the graph-build flow
+math — see "Fix directions").
+
+## Symptom
+
+Run a full analysis (`step1` → `step2_graph` → `step2_discovery`) for one
+contingency on a pypowsybl env, then run `step1` for a **different** contingency
+on the **same** env: the second `step1` no longer detects the overloads it
+detects on a freshly built env — it returns an `AnalysisResult` short-circuit
+("Overload breaks the grid apart") with an empty overload set. The analysis
+silently reports *no actionable overload* where there is one.
+
+Only a **full env rebuild** (reload the network from file) restores correct
+detection. `reset_to_base()`, `sweep_kept_variants()`, removing every non-base
+variant, re-cloning `base` from the pristine `InitialState` variant, and a cold
+AC load flow on `base` **all fail to recover**.
+
+## Root cause
+
+`run_analysis_step2_graph` builds the overflow graph via
+`pypowsybl_backend/overflow_analysis.py`. Its flow-change analysis clones a
+working variant, disconnects the overloaded lines, and runs a load flow (DC for
+the graph transfer). On a stressed operating point disconnecting the overloads
+can island part of the grid and that load flow does **not** converge
+(`MAX_ITERATION_REACHED`).
+
+After the graph build returns, the **base variant's AC voltage state is
+destroyed**: on the France THT `hiver_pic_2021` snapshot the base variant goes
+from 35 NaN `v_mag` buses to **1701** (≈1666 buses left de-energized), while line
+connection flags, switch open/closed states, load and generation totals, and the
+cached thermal limits are all **unchanged**. The next `step1` calls
+`reset_to_base()` (which only switches the working variant — it does not re-solve)
+and then `obs.simulate(contingency)`, which warm-starts (`PREVIOUS_VALUES`) from
+those NaN voltages, diverges, and yields a degenerate near-zero-flow observation
+→ every `rho < 1` → "no overload".
+
+The damage lives **below the variant layer** (in pypowsybl network-global solver
+state): it survives variant purge and a re-clone of `base` from `InitialState`,
+and is only cleared by reloading the network object. That is why the workaround
+must rebuild the whole env.
+
+## Minimal reproduction
+
+```python
+# env built with the default config (IGNORE_LINES_MONITORING=True,
+# MONITORING_FACTOR_THERMAL_LIMITS=0.95); ctx0 = prebuilt_env_context
+def probe(cid):
+    out = run_analysis_step1(analysis_date=None, current_timestep=0,
+        current_lines_defaut=[cid], backend=Backend.PYPOWSYBL,
+        dict_action={}, prebuilt_env_context=ctx0)
+    return "CONTEXT" if isinstance(out, AnalysisContext) else "no-context"
+
+print(probe("AVALLL61VNOL"))                      # CONTEXT (overload detected)
+out = run_analysis_step1(..., current_lines_defaut=["AVALLL61J.VIL"],
+                         dict_action=full, prebuilt_env_context=ctx0)
+run_analysis_step2_graph(out)                     # builds overflow graph
+print(probe("AVALLL61VNOL"))                      # no-context  <-- BUG
+
+# base variant voltages are now NaN even though topology/loads are identical:
+nm.set_working_variant(nm.base_variant_id)
+np.isnan(net.get_buses()["v_mag"].values).sum()   # 35 fresh -> 1701 after
+```
+
+Contingency-specific: contingencies whose overload disconnection keeps the grid
+solvable (e.g. an "easy" case) do not trip it; a stressed one whose flow-change
+LF hits `MAX_ITERATION` does.
+
+## Workaround (used by the RTE7000 game-mode classifier)
+
+Rebuild the env after every analysis that ran `step2` (env rebuild is only
+~4 s). Screening with `step1` alone never corrupts, so only grading needs it:
+
+```python
+rec = process(cid, ctx0, dict_action)     # step1 (+ step2 for candidates)
+if rec["kind"] in ("candidate", "error"): # step2 ran or state is unknown
+    del env; env, ctx0, dict_action, net = build_env(lab)
+```
+
+## Fix directions (not yet applied)
+
+1. **Isolate the flow-change load flow** on a network object that is not the one
+   reused across analyses (e.g. a dedicated clone loaded once), so a divergent
+   graph-transfer LF can never pollute the shared network's global solver state.
+2. **Restore a valid AC base state after `step2_graph`** — but note a plain
+   `run_ac(DC_VALUES)` on `base` did *not* recover here, so this must reload /
+   re-import the network, not just re-solve.
+3. **Guard the flow-change LF divergence**: when disconnecting the overloads
+   islands the grid, skip/flag it instead of leaving the shared network in a
+   half-solved state.
+
+Any fix must keep the overflow-graph flow numbers byte-identical on the
+non-divergent path (the existing pipeline output contract).

--- a/expert_op4grid_recommender/__init__.py
+++ b/expert_op4grid_recommender/__init__.py
@@ -15,7 +15,7 @@ corrective measures to alleviate line overloads.
 
 import logging
 
-__version__ = "0.3.1"
+__version__ = "0.3.1.post1"
 
 _logger = logging.getLogger(__name__)
 

--- a/expert_op4grid_recommender/environment_pypowsybl.py
+++ b/expert_op4grid_recommender/environment_pypowsybl.py
@@ -325,7 +325,15 @@ def switch_to_dc_load_flow_pypowsybl(env: SimulationEnvironment,
     # Create new environment with DC mode
     # Note: In the pypowsybl backend, we can set DC mode on the network manager
     env.network_manager._default_dc = True
-    
+
+    # Mark this (possibly reused) env as transiently escalated to DC so a later
+    # analysis restores it (issue #6). This flag is checked at the top of
+    # run_analysis_step1's reused-env branch, which calls
+    # env.reset_loadflow_mode_to_baseline() to undo the escalation. Without it,
+    # DC mode + the DC-solved (de-energised) base variant leak across analyses
+    # and silently hide every subsequent overload.
+    env._dc_escalation_pending = True
+
     # Reset and get new observation
     obs = env.reset()
     

--- a/expert_op4grid_recommender/pipeline.py
+++ b/expert_op4grid_recommender/pipeline.py
@@ -259,7 +259,21 @@ def run_analysis_step1(analysis_date: Optional[datetime],
     with Timer("Environment Setup"):
         if prebuilt_env_context is not None and is_pypowsybl:
             env = prebuilt_env_context['env']
-            env.network_manager.reset_to_base()
+            # Sanitize a reused env before starting a new analysis. A prior
+            # analysis whose overload-disconnection load flow diverged calls
+            # switch_to_dc_load_flow_pypowsybl, which escalates this *shared* env
+            # to DC (NetworkManager._default_dc=True) and DC-solves the base
+            # variant (leaving every bus v_mag=NaN — DC computes no voltage
+            # magnitudes). Left in place, that escalation leaks across analyses:
+            # this analysis would run every load flow in DC, where branch
+            # currents are not populated, so rho≈0 and real overloads silently
+            # vanish (issue #6). When the env was escalated, restore the
+            # configured baseline LF mode + a valid (energised) base state;
+            # otherwise just reset the working variant, exactly as before.
+            if getattr(env, "_dc_escalation_pending", False):
+                env.reset_loadflow_mode_to_baseline(config.USE_DC_LOAD_FLOW)
+            else:
+                env.network_manager.reset_to_base()
             obs = env.get_obs()
             path_chronic = prebuilt_env_context['path_chronic']
             chronic_name = prebuilt_env_context['chronic_name']

--- a/expert_op4grid_recommender/pypowsybl_backend/simulation_env.py
+++ b/expert_op4grid_recommender/pypowsybl_backend/simulation_env.py
@@ -75,9 +75,24 @@ class SimulationEnvironment:
             thermal_limits_path, thermal_limits
         )
         
+        # DC load-flow mode (mirrors network_manager._default_dc for external,
+        # DC-aware callers). Always defined so the attribute exists before any
+        # DC escalation sets it. get_env_first_obs_pypowsybl flips it to True
+        # when the env is created in DC mode.
+        self._use_dc = False
+
+        # Transient-DC-escalation guard (issue #6). When an
+        # overload-disconnection load flow diverges, the analysis pipeline calls
+        # switch_to_dc_load_flow_pypowsybl, which escalates THIS env to DC for a
+        # single analysis. This flag records that escalation so a subsequent
+        # analysis that reuses the env can detect and undo it (see
+        # reset_loadflow_mode_to_baseline) instead of silently inheriting DC mode
+        # + a de-energised base variant.
+        self._dc_escalation_pending = False
+
         # Run initial load flow to ensure valid state
         self._ensure_valid_state()
-        
+
         # Create initial observation
         self._current_obs = None
     
@@ -149,7 +164,37 @@ class SimulationEnvironment:
         self.network_manager.reset_to_base()
         self._ensure_valid_state()
         return self.get_obs()
-    
+
+    def reset_loadflow_mode_to_baseline(self, dc: bool = False) -> None:
+        """Restore this env's load-flow mode to ``dc`` and re-energise the base
+        variant — the inverse of a transient ``switch_to_dc`` escalation.
+
+        ``switch_to_dc_load_flow_pypowsybl`` escalates a (possibly reused) env to
+        DC for a single analysis: it sets ``NetworkManager._default_dc = True``
+        and DC-solves the base variant, which leaves every bus ``v_mag = NaN``
+        because a DC load flow computes no voltage magnitudes. Since one env is
+        shared across analyses, that escalation would otherwise persist and force
+        every later analysis into DC — where branch currents are not populated,
+        so ``rho ≈ 0`` and real overloads silently vanish (issue #6).
+
+        Call this before reusing the env for a new analysis to put it back into
+        the configured baseline mode with an AC-solved (energised) base variant,
+        exactly as a freshly built env would be. Idempotent; its cost is a single
+        baseline load flow (far cheaper than the ~4 s full env rebuild the bug
+        otherwise forces). It clears :attr:`_dc_escalation_pending`.
+
+        Args:
+            dc: The baseline DC-mode to restore (normally ``config.USE_DC_LOAD_FLOW``).
+        """
+        self._use_dc = dc
+        self.network_manager._default_dc = dc
+        self.network_manager.reset_to_base()
+        # Re-solve the base variant in the restored mode so downstream
+        # observations read an energised grid (AC) instead of the de-energised
+        # DC snapshot the escalation left behind.
+        self._ensure_valid_state()
+        self._dc_escalation_pending = False
+
     def set_thermal_limit(self, thermal_limits: Union[List[float], np.ndarray]):
         """
         Set thermal limits for all lines.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "expert_op4grid_recommender"
-version = "0.3.1"
+version = "0.3.1.post1"
 authors = [
     { name="RTE", email="rte@rte-france.com" },
 ]

--- a/tests/test_env_reuse_dc_escalation.py
+++ b/tests/test_env_reuse_dc_escalation.py
@@ -1,0 +1,205 @@
+# Copyright (c) 2025-2026, RTE (https://www.rte-france.com)
+# See AUTHORS.txt
+# This Source Code Form is subject to the terms of the Mozilla Public License, version 2.0.
+# If a copy of the MPL was not distributed with this file,
+# you can obtain one at http://mozilla.org/MPL/2.0/.
+# SPDX-License-Identifier: MPL-2.0
+"""Regression tests for the reused-env DC-escalation contamination bug (issue #6).
+
+When an overload-disconnection load flow diverges, the analysis pipeline calls
+``switch_to_dc_load_flow_pypowsybl``, which escalates the *shared* pypowsybl env
+to DC for a single analysis: it flips ``NetworkManager._default_dc = True`` and
+DC-solves the base variant (leaving every bus ``v_mag = NaN`` — a DC load flow
+computes no voltage magnitudes). Because one ``SimulationEnvironment`` is reused
+across analyses (batch classifiers, long-lived services, the Co-Study4Grid game
+backend), that escalation used to persist: the next analysis ran every load flow
+in DC (branch currents not populated → ``rho ≈ 0``), so real overloads silently
+vanished — a silent-correctness bug.
+
+The fix marks the escalation (``env._dc_escalation_pending``) and has
+``run_analysis_step1`` restore the configured baseline load-flow mode and an
+AC-solved (energised) base variant when it reuses an escalated env, via
+``SimulationEnvironment.reset_loadflow_mode_to_baseline``.
+
+These tests use the built-in IEEE-9 network so they need neither the France
+grid fixture nor the (deprecated) ``pypowsybl2grid`` bridge.
+"""
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+
+def _base_vmag_nan_count(nm) -> int:
+    """NaN ``v_mag`` count on the base variant (the corruption signature)."""
+    cur = nm.network.get_working_variant_id()
+    nm.set_working_variant(nm.base_variant_id)
+    try:
+        return int(np.isnan(nm.network.get_buses()["v_mag"].values).sum())
+    finally:
+        nm.network.set_working_variant(cur)
+
+
+def _make_ieee9_env():
+    pp = pytest.importorskip("pypowsybl")
+    from expert_op4grid_recommender.pypowsybl_backend import SimulationEnvironment
+    return SimulationEnvironment(network=pp.network.create_ieee9())
+
+
+# ---------------------------------------------------------------------------
+# SimulationEnvironment.reset_loadflow_mode_to_baseline
+# ---------------------------------------------------------------------------
+
+def test_fresh_env_starts_ac_and_energised():
+    """A freshly built env is in AC mode with an energised base variant."""
+    env = _make_ieee9_env()
+    assert env._use_dc is False
+    assert env.network_manager._default_dc is False
+    assert env._dc_escalation_pending is False
+    # AC load flow computes voltage magnitudes for every bus.
+    assert _base_vmag_nan_count(env.network_manager) == 0
+
+
+def test_reset_loadflow_mode_to_baseline_reenergises_base_after_dc():
+    """DC-solving the base de-energises it (v_mag=NaN); the baseline restore
+    puts the env back into AC mode with an energised base variant."""
+    env = _make_ieee9_env()
+    nm = env.network_manager
+    n_buses = len(nm.network.get_buses())
+    assert n_buses > 0
+
+    # Emulate the transient DC escalation switch_to_dc performs on the SHARED env.
+    nm._default_dc = True
+    env._use_dc = True
+    env._dc_escalation_pending = True
+    nm.reset_to_base()
+    env._ensure_valid_state()  # runs a DC load flow (respects _default_dc)
+    # DC load flow leaves every bus v_mag NaN.
+    assert _base_vmag_nan_count(nm) == n_buses
+
+    # The fix: restore the configured baseline (AC) mode + a valid base state.
+    env.reset_loadflow_mode_to_baseline(dc=False)
+
+    assert env._use_dc is False
+    assert nm._default_dc is False
+    assert env._dc_escalation_pending is False
+    # Base variant is energised again — AC solved, no NaN voltages.
+    assert _base_vmag_nan_count(nm) == 0
+
+
+def test_reset_loadflow_mode_to_baseline_honours_dc_baseline():
+    """When the configured baseline is DC, the restore keeps DC mode (it does
+    not force AC) — it only undoes an *unexpected* escalation relative to the
+    caller-supplied baseline."""
+    env = _make_ieee9_env()
+    nm = env.network_manager
+    env.reset_loadflow_mode_to_baseline(dc=True)
+    assert env._use_dc is True
+    assert nm._default_dc is True
+    assert env._dc_escalation_pending is False
+
+
+# ---------------------------------------------------------------------------
+# switch_to_dc_load_flow_pypowsybl flags the escalation
+# ---------------------------------------------------------------------------
+
+def test_switch_to_dc_flags_escalation_and_deenergises_base():
+    """switch_to_dc escalates a (reused) env to DC and marks it so a later
+    analysis can undo it. It also DC-solves base (v_mag=NaN)."""
+    from expert_op4grid_recommender.environment_pypowsybl import (
+        switch_to_dc_load_flow_pypowsybl,
+    )
+
+    env = _make_ieee9_env()
+    nm = env.network_manager
+    assert env._dc_escalation_pending is False
+    assert _base_vmag_nan_count(nm) == 0
+
+    first_line = nm.name_line[0]
+    # No overloads to keep, no maintenance — just exercise the DC switch.
+    switch_to_dc_load_flow_pypowsybl(env, [first_line], [], [])
+
+    assert nm._default_dc is True
+    assert env._dc_escalation_pending is True
+    # Base variant is DC-solved → de-energised (all v_mag NaN).
+    assert _base_vmag_nan_count(nm) == len(nm.network.get_buses())
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: run_analysis_step1 sanitises a reused, escalated env
+# ---------------------------------------------------------------------------
+
+def test_step1_restores_reused_escalated_env():
+    """The core bug: after a prior analysis escalated a reused env to DC,
+    run_analysis_step1 on the SAME env must restore the AC baseline (energised
+    base + _default_dc=False) instead of silently inheriting DC mode."""
+    from expert_op4grid_recommender.environment_pypowsybl import (
+        switch_to_dc_load_flow_pypowsybl,
+    )
+    from expert_op4grid_recommender.pipeline import run_analysis_step1
+    from expert_op4grid_recommender.backends import Backend
+
+    env = _make_ieee9_env()
+    nm = env.network_manager
+
+    # A prior analysis escalated this shared env to DC (the contamination).
+    switch_to_dc_load_flow_pypowsybl(env, [nm.name_line[0]], [], [])
+    assert env._dc_escalation_pending is True
+    assert nm._default_dc is True
+    assert _base_vmag_nan_count(nm) == len(nm.network.get_buses())
+
+    # Reuse the env for a NEW analysis via prebuilt_env_context.
+    prebuilt = {
+        "env": env,
+        "path_chronic": "",
+        "chronic_name": "ieee9",
+        "custom_layout": None,
+        "lines_non_reconnectable": [],
+        "lines_we_care_about": list(env.name_line),
+    }
+    run_analysis_step1(
+        analysis_date=None,
+        current_timestep=0,
+        current_lines_defaut=[nm.name_line[1]],
+        backend=Backend.PYPOWSYBL,
+        dict_action={},
+        prebuilt_env_context=prebuilt,
+    )
+
+    # The escalation has been undone: AC mode, energised base, flag cleared.
+    assert env._dc_escalation_pending is False
+    assert nm._default_dc is False
+    assert env._use_dc is False
+    assert _base_vmag_nan_count(nm) == 0
+
+
+def test_step1_leaves_unescalated_reused_env_untouched():
+    """The sanitisation only fires for an escalated env: a normal reused env
+    keeps the fast path (plain reset_to_base, no extra baseline re-solve)."""
+    from expert_op4grid_recommender.pipeline import run_analysis_step1
+    from expert_op4grid_recommender.backends import Backend
+
+    env = _make_ieee9_env()
+    nm = env.network_manager
+    assert env._dc_escalation_pending is False
+
+    prebuilt = {
+        "env": env,
+        "path_chronic": "",
+        "chronic_name": "ieee9",
+        "custom_layout": None,
+        "lines_non_reconnectable": [],
+        "lines_we_care_about": list(env.name_line),
+    }
+    run_analysis_step1(
+        analysis_date=None,
+        current_timestep=0,
+        current_lines_defaut=[nm.name_line[1]],
+        backend=Backend.PYPOWSYBL,
+        dict_action={},
+        prebuilt_env_context=prebuilt,
+    )
+
+    assert env._dc_escalation_pending is False
+    assert nm._default_dc is False
+    assert _base_vmag_nan_count(nm) == 0


### PR DESCRIPTION
## Summary

Fixes a silent-correctness bug where reusing a `SimulationEnvironment` across multiple analyses would inherit a DC load-flow mode escalation from a prior analysis, causing real overloads to silently vanish in subsequent analyses.

## Root Cause

When an overload-disconnection load flow diverges during `run_analysis_step2_graph`, the pipeline calls `switch_to_dc_load_flow_pypowsybl` to escalate the analysis to DC mode. This function sets `NetworkManager._default_dc = True` on the *shared, reused* env and DC-solves the base variant (leaving every bus `v_mag = NaN` since DC load flows compute no voltage magnitudes). 

The escalation was never reset, so the next analysis reusing the same env would run *all* its load flows in DC — where branch currents are not populated, so `rho ≈ 0` on every line, and real overloads silently vanish. The earlier diagnosis of "deep, unrecoverable pypowsybl network-global corruption" was incorrect; the confounder was the leaked `_default_dc` flag silently turning every "recovery" AC solve back into DC.

## Changes

- **`SimulationEnvironment`** (`simulation_env.py`):
  - Added `_use_dc` attribute to track DC mode state (mirrors `network_manager._default_dc`)
  - Added `_dc_escalation_pending` flag to record transient DC escalations
  - Implemented `reset_loadflow_mode_to_baseline(dc)` method to restore the configured baseline load-flow mode and re-energize the base variant by re-solving it in the restored mode

- **`switch_to_dc_load_flow_pypowsybl`** (`environment_pypowsybl.py`):
  - Now sets `env._dc_escalation_pending = True` when escalating to DC, marking the escalation for later recovery

- **`run_analysis_step1`** (`pipeline.py`):
  - Enhanced reused-env branch to detect and undo DC escalations: calls `reset_loadflow_mode_to_baseline(config.USE_DC_LOAD_FLOW)` when `_dc_escalation_pending` is set, otherwise uses the fast path (`reset_to_base()`)

- **Documentation** (`docs/reviews/2026-07_env_corruption_overflow_graph.md`):
  - Corrected root-cause analysis to reflect the actual state leak (not deep network corruption)
  - Documented the fix and why the earlier investigation was misled by the `_default_dc` confounder

- **Regression tests** (`tests/test_env_reuse_dc_escalation.py`):
  - Comprehensive test suite covering fresh env initialization, DC escalation and recovery, and end-to-end reuse scenarios
  - Uses IEEE-9 network (no France-grid fixture or `pypowsybl2grid` bridge required)

## Implementation Details

- The fix is **behavior-preserving on the non-divergent path**: the restore only fires after an actual DC escalation, so analyses that never diverge incur no overhead
- Recovery cost is a single baseline load flow (~0.1 s), far cheaper than the ~4 s full env rebuild the workaround previously required
- The escalation flag is idempotent and self-clears, making the mechanism robust to multiple reuses
- Removes the need for the game-mode classifier's env-rebuild workaround entirely

## Changelog

Updated `CHANGELOG.md` with a detailed entry explaining the bug, its impact, and the fix.

https://claude.ai/code/session_01GCXS3yXop3xfRLjyMFa1qS