### PR TITLE
release 0.3.2 — « art de la manœuvre » (R20–R25) + ouvrages isolés hors périmètre

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Maneuver module — "art de la manœuvre" conformity verifier (rules
+  R20–R25)** (`manoeuvre/algo/conformite.py`). Built from the RTE operating
+  references (CCRT C3-3 authorization matrix, ACT 104 timing directive, the
+  CCO expert-method note): per-manoeuvre **consequence classification** by
+  replay (dead-zone operation, loop open/close, prepare/de-select, energize /
+  de-energize, make/break transit, node-count change) with CCRT organ families
+  (breaker, load-break switch, busbar selector, coupling disconnector, busbar
+  sectionalizer, line disconnector); the **authorization matrix** (a
+  disconnector may not make/break transit nor change the substation node
+  count — generalizes the load-break rule R18); a **busbar-test advisory**
+  (re-energizing a dead busbar section through a disconnector instead of a
+  breaker, R22); the **CCO bay state machine** (désaiguillé / préparé / ±DA /
+  en service, forbidden and "bizarre" transitions, R23); **ACT 104 timings**
+  (10 s after each disconnector operation, ≥60 s between two closures of the
+  same breaker, R24) and **expected SCADA checks** per manoeuvre (TS/TM,
+  node-count checks, R25). Results land in a new, separate
+  `ResultatManoeuvres.conformite` field (`ConformiteSequence`: violations /
+  avertissements / temporisations / contrôles), populated by
+  `plugins.pipeline.verifier_sequence` — historical `ecarts`/`alertes`
+  verdicts (and all goldens) are byte-identical.
+- **Critical coverage analysis + consolidated rule set**
+  (`docs/manoeuvre/art_de_la_manoeuvre.md`): what R1–R19 do and do not cover
+  versus the operating references, the enriched rules R20–R25 (implemented)
+  and R26–R28 (specified: load-flow/Icc validation via the recommender's
+  pypowsybl backend, multi-substation orchestration "phase D" with
+  transformer voltage-order rules, automata alerts), the CCO `listeDordre`
+  code mapping, and the module/algo/verifier restructuring plan.
+  `docs/manoeuvre/regles.md` gains the R20–R25 traceability entries.
+
 ## [0.3.1.post1] - 2026-07-22
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,54 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.2] - 2026-07-27
+
+Maneuver-module release: the "art de la manœuvre" conformity verifier (R20–R25)
+plus a fix for a false-negative nodal → detailed verification on substations
+carrying already-disconnected works. The recommender analysis pipeline is
+untouched. See `docs/release-notes/v0.3.2.md`.
+
+### Fixed
+
+- **Isolated works no longer invalidate a reached nodal target.**
+  `TopologieNodale.from_graph` materializes one `noeuds` entry per connected
+  component carrying an equipment — **including components with no busbar**,
+  i.e. **disconnected works**. A nodal target edited by the expert
+  (`from_node_groups`) only lists the works to place on a node, so the strict
+  partition comparison in `meme_topologie` failed for *any* substation with a
+  pre-disconnected work. That propagated to `ResultatManoeuvres.is_verified`,
+  to `ResultatIdentification.is_realisable` (pipeline independent verification
+  included) and finally to the IHM, which warned
+  « ⚠ Cible partiellement réalisable (obtenu 2 nœud(s) + 5 ouvrage(s) isolé(s) /
+  visé 2 nœud(s)) » while the target *was* reached and the 5 works disconnected
+  at start stayed disconnected. The notion is now explicit in the core:
+  `TopologieNodale.noeuds_isoles` (busbar-less components, filled by
+  `from_graph`), `nb_noeuds_reels` (node count excluding them) and
+  `partition_hors_isoles_inconnus()`, on which `meme_topologie` now compares
+  partitions **within the common scope** — an isolated node whose equipment
+  appears nowhere in the other topology is dropped, symmetrically. The
+  comparison stays **strict** as soon as both sides mention the same equipment
+  (naming an isolated work in a target node = reconnect it; a targeted work that
+  ends up disconnected still fails). `partition()` stays exhaustive, so
+  `partition_obtenue` and all goldens are unchanged; diagnostics now report
+  `nb_noeuds_reels` for the obtained topology. Regression tests:
+  `tests/manoeuvre/test_ouvrages_isoles_verification.py`.
+- **IHM — `Session.nodale_to_detaillee` verdict unified and diagnostics kept.**
+  The verdict is recomputed on the **final** state (post-isolation, which the
+  algorithm does not see) through the same core rule, so both code paths agree.
+  A work **already disconnected at start** and not dropped onto a node is out of
+  the target scope whether or not the client listed it in `isolated`: it is no
+  longer re-injected as an "orphan" node inflating `nb_vise`, and it is
+  force-disconnected consistently (dragging it onto a node still means
+  reconnection, and keeps the strict check). A negative verdict now always
+  carries its `message` / `noeuds_non_realisables` / `ecarts` — the previous
+  isolated-works branch blanked them, which is why the false warning showed up
+  with no explanation.
+- **`test_config_post_updates_dirs` repaired.** It pointed `/api/config` at a
+  `tmp_path` outside every allowed store root, so the path-traversal guard
+  (`_dir_within_allowed`, 0.2.6) legitimately refused it and the test had been
+  failing ever since. It now declares `tmp_path` as the persistent data root.
+
 ### Added
 
 - **Maneuver module — "art de la manœuvre" conformity verifier (rules

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -503,8 +503,30 @@ pytest tests/test_ActionClassifier.py::test_specific  # Single test
 
 ## Current Development Status
 
-**Current version**: `0.3.1.post1` (see `CHANGELOG.md` for full history)
+**Current version**: `0.3.2` (see `CHANGELOG.md` for full history)
 
+> **v0.3.2 highlights** (maneuver module only — the analysis pipeline is
+> untouched): the **"art de la manœuvre" conformity verifier**
+> (`manoeuvre/algo/conformite.py`, rules R20–R25) built from the RTE operating
+> references — per-manoeuvre consequence classification by replay, CCRT
+> authorization matrix, busbar-test advisory, CCO bay state machine, ACT 104
+> timings and expected SCADA checks — reported in a **separate**
+> `ResultatManoeuvres.conformite` field, so `ecarts`/`alertes` and every golden
+> stay byte-identical. Plus a **verification fix for isolated works**:
+> `TopologieNodale.from_graph` counted busbar-less components (i.e. *disconnected
+> works*) as electrical nodes, so `meme_topologie` against a nodal target that
+> never mentions them failed for **any** substation with a pre-disconnected work
+> — surfacing in the IHM as « ⚠ Cible partiellement réalisable (obtenu 2 nœud(s)
+> + 5 ouvrage(s) isolé(s) / visé 2 nœud(s)) » on a target that *was* reached.
+> Isolated components are now marked (`noeuds_isoles`), excluded from
+> `nb_noeuds_reels`, and `meme_topologie` compares partitions **within the common
+> scope** (`partition_hors_isoles_inconnus`) — still strict as soon as both sides
+> mention the same equipment. `partition()` stays exhaustive (goldens iso). The
+> IHM verdict is recomputed on the final state through that same rule and always
+> carries its diagnostics on a negative verdict. See
+> `docs/release-notes/v0.3.2.md` and `docs/manoeuvre/ihm.md` § « Ouvrages isolés
+> et vérification ».
+>
 > **v0.3.1.post1 highlights** (silent-correctness fix, issue #6): a reused
 > pypowsybl `SimulationEnvironment` is no longer contaminated by a transient DC
 > escalation. When an overload-disconnection load flow diverges,

--- a/docs/README.md
+++ b/docs/README.md
@@ -54,8 +54,14 @@ historical dataset it is validated against. (Its pluggable calculation phases ar
 documented under [`architecture/plugins.md`](architecture/plugins.md).)
 - [`manoeuvre/module.md`](manoeuvre/module.md) — module reference: objectives,
   pipeline, node-breaker topology analysis.
-- [`manoeuvre/regles.md`](manoeuvre/regles.md) — business rules (R1–R16) with
+- [`manoeuvre/regles.md`](manoeuvre/regles.md) — business rules (R1–R25) with
   rule-to-code traceability.
+- [`manoeuvre/art_de_la_manoeuvre.md`](manoeuvre/art_de_la_manoeuvre.md) —
+  critical coverage analysis against the RTE operating references (CCRT C3-3,
+  ACT 104, CCO expert method), the consolidated/enriched rule set R20–R28
+  (consequence classification, authorization matrix, busbar test, bay state
+  machine, timing, expected SCADA checks, electrical validation, multi-substation
+  orchestration, automata) and the module/algo/verifier restructuring plan.
 - [`manoeuvre/ihm.md`](manoeuvre/ihm.md) — the interactive web IHM (topology
   editor + sequence animation, day-exploration map, ⚙ config modal, isolated-device
   declaration, scenario author/date metadata) and the hosted HuggingFace Space.

--- a/docs/README.md
+++ b/docs/README.md
@@ -89,12 +89,11 @@ dataset, used to validate the maneuver module.
   session handoff: status, results, and next tasks.
 
 ## Release notes (`release-notes/`)
-Per-version notes (v0.2.2 → v0.2.6, v0.2.9). The canonical, continuously updated
-history is [CHANGELOG.md](../CHANGELOG.md). Latest:
-[`release-notes/v0.2.9.md`](release-notes/v0.2.9.md) — discovery restructured
-around data (R5/A5), `ActionType` + C7 rule-bypass fix, container-aware
-reassessment. Built on `0.2.8` (deep revisions **R3** config single-source +
-**R4** unified simulation seam / `BaselineContext`; see the CHANGELOG).
+Per-version notes (v0.2.2 → v0.2.6, v0.2.9, v0.3.0 → v0.3.2). The canonical,
+continuously updated history is [CHANGELOG.md](../CHANGELOG.md). Latest:
+[`release-notes/v0.3.2.md`](release-notes/v0.3.2.md) — maneuver "art de la
+manœuvre" conformity verifier (R20–R25) and isolated works no longer
+invalidating a reached nodal target.
 
 ## Reviews (`reviews/`)
 Point-in-time audits of the codebase at a given version — findings age with the

--- a/docs/manoeuvre/art_de_la_manoeuvre.md
+++ b/docs/manoeuvre/art_de_la_manoeuvre.md
@@ -1,0 +1,418 @@
+# Art de la manœuvre — analyse critique, consolidation et enrichissement des règles
+
+> Confrontation du module manœuvre (règles **R1-R19**, cf. [`regles.md`](regles.md))
+> aux référentiels d'exploitation RTE, consolidation en un corpus de règles
+> enrichi (**R20-R28**) et proposition de restructuration du module, de
+> l'algorithme et du vérificateur.
+
+Sources analysées :
+
+| Source | Contenu |
+|--------|---------|
+| **Méthode expertes pour reproduire la fiche de manœuvres d'un CCO** (note DRD-PILOT, 2024) | Ouvrages/départs à partir du graphe réseau, typologie ordonnée des manœuvres (~20 codes), essais de jeu de barre, changement de barre sans DA, temporisations ACT 104, suivi d'état des départs, validations (répartition/Icc), contrôles TITIEN (TS/TM), automates |
+| **Manœuvres autorisées ou interdites et conséquences** (tableur) | Matrice « conséquence × organe → autorisée ? » (CCRT) et tableau « organe × manœuvre → conséquence → contrôle → conditions » |
+| **Présentation automatisation de la manœuvre DRD** (mars 2024) | Découpage fonctionnel (représentation, heuristiques, validation/contrôle, documentation opérationnelle), bilan et limites du POC |
+
+Document de référence métier : **CCRT chapitre C3-3** ; consigne **ACT 104**
+(temporisations) ; consigne **AUT 102** (réenclencheurs/automates sur antennes).
+
+---
+
+## 1. Analyse critique : ce que le module couvre — et ne couvre pas
+
+### 1.1 Cartographie de couverture
+
+| Concept métier (sources) | État dans le module (avant enrichissement) | Règle |
+|---|---|---|
+| Sectionneur manœuvré **hors charge** uniquement | ✅ Couvert et vérifié (rejeu par manœuvre, messages de parade contextuels) | R6bis, R18 |
+| Dé-énergisation d'une section avant ouverture de **sectionnement** | ✅ Couvert (parking one-by-one, cross-feed, isolement par DJ d'abord) | R10, R10bis, R10ter |
+| Boucle **courte** / boucle **longue** (ré-aiguillage) | ✅ Couvert, choix automatique par équipotentialité | R7-R9 |
+| Ordonnancement de séquence (`listeDordre` libTOPO) | ✅ Couvert (phases 0→E) mais **sans taxonomie de types** exposée | R11 |
+| « Un seul ouvrage hors tension à la fois » | ✅ Couvert (alerte non bloquante, mode smooth) | R10ter |
+| Vérification post-manœuvre (partition nodale, écarts détaillés) | ✅ Couvert, indépendante des algorithmes (façade plugins) | R14, R15 |
+| Dégradation gracieuse / connaître ses limites | ✅ Couvert (écarts, `noeuds_non_realisables`) — même philosophie que le POC CCO et l'outil Elia | R16 |
+| **Classification des conséquences** d'une manœuvre (transit, boucle, mise sous/hors tension, HU…) | ❌ Absente : le vérificateur ne connaissait qu'*une* règle (sectionneur hors charge) | → **R20** |
+| **Matrice d'autorisation** conséquence × organe (CCRT) | ❌ Absente (la règle du sectionneur n'en couvre qu'une ligne) | → **R21** |
+| **Essai de jeu de barre** (remise sous tension d'une section par DJ, préférence ligne > couplage > TR, « force » du départ) | ❌ Absent : le séquenceur referme un sectionnement sur section morte sans essai préalable par disjoncteur | → **R22** |
+| **Vocabulaire et états des départs** (désaiguillé, préparé, ±DA, en service, SUAV/MES/MHU) + table des transitions permises/interdites | ❌ Absent (les manœuvres portent une `raison` libre, aucun suivi d'état) | → **R23** |
+| **Temporisations ACT 104** (10 s sectionneur, 1 min regonflage DJ, 2 min régleurs, PSEM, 1 min MHU→SUAV 225/400 kV) | ❌ Absentes (la séquence est purement ordinale) | → **R24** |
+| **Contrôles SCADA attendus** (TS manque tension, TM I, conformité au calcul, contrôle nœuds) | ❌ Absents | → **R25** |
+| **Validations électriques** (calcul de répartition à chaque coupure/établissement de transit, seuil % IST, plages U, Icc) | ❌ Absentes du module (assumé : R12 « simplifié ») — alors que le dépôt possède un backend pypowsybl complet | → **R26** (spécifiée) |
+| **Ordre inter-postes / inter-tensions** (MHU du plus bas au plus haut niveau de tension, MES inversée pour les TR ; départ manœuvré au poste en service avant le poste hors tension) | ❌ Hors périmètre : le module est **mono-poste** (un voltage level) | → **R27** (spécifiée) |
+| **Ouvrages multi-postes, zone de manœuvre** (départ + ouvrage + postes fictifs/piquages, anneau de garde, antennes) | ❌ Hors périmètre mono-poste ; le recommandeur possède par ailleurs une détection d'antennes (`graph_analysis/antenna_graph.py`) non reliée | → **R27** (spécifiée) |
+| **Automates** (RA, AMU/RMU, RTS, zonaux) : mise hors service avant manœuvre, reprogrammation antennes | ❌ Absents — également non codés dans le POC CCO (données non numérisées, politiques régionales) | → **R28** (spécifiée, non planifiée) |
+| Changement de barre **sans couplage et sans DA** (pseudo-couplage par les SA d'un départ) | ⚠ Partiel : le module traite le changement de barre par couplage ou boucle longue, pas le schéma miroir par pseudo-couplage | § 4.3 |
+| Cas pathologiques de description des postes (omnibus, mix_elements) | ⚠ Partiel : omnibus et organes internes gérés ; pas de taux de couverture mesuré sur le réseau complet (le POC CCO annonce 98,77 %) | § 4.3 |
+
+### 1.2 Lecture critique
+
+**Ce que le module fait bien.** Le cœur « sûreté sectionneur » est plus abouti
+que le POC CCO : la règle du sectionneur est vérifiée *manœuvre par manœuvre*
+par rejeu indépendant (y compris pour des séquences éditées à la main), le
+choix boucle courte/longue est déduit de l'équipotentialité réelle et non d'une
+heuristique de phase, et les postes complexes (N barres, faisceaux partagés,
+omnibus) sont couverts avec des filets de régression (goldens). La philosophie
+« savoir dire je ne sais pas » (R16) est exactement celle préconisée par la
+note CCO et par le retour d'expérience Elia.
+
+**L'angle mort principal : un vérificateur mono-règle.** Avant enrichissement,
+tout le « verdict » du module se réduisait à : *la partition est-elle atteinte*
+(R14/R15) et *aucun sectionneur n'est-il manœuvré sous charge* (R18). Or l'art
+de la manœuvre du CCRT est défini par **conséquences** : chaque manœuvre
+*établit ou coupe un transit*, *ouvre ou ferme une boucle*, *met sous ou hors
+tension*, *change le nombre de nœuds* ou *n'a aucun effet électrique* — et
+c'est le couple (conséquence, type d'organe) qui est autorisé ou interdit. La
+règle du sectionneur n'est qu'une ligne de cette matrice. Sans classification
+des conséquences, le module ne peut ni motiver ses verdicts dans le langage des
+opérateurs, ni produire les contrôles et temporisations qui font une fiche de
+manœuvres exploitable.
+
+**Le vocabulaire opérateur est absent.** La note CCO montre que les CCO
+raisonnent en états de départs (« préparé », « en service - DA »…) et
+d'ouvrages (« SUAV », « MES/MHU »). Le module produit des `OPEN/CLOSE` avec une
+raison libre : correct topologiquement, mais inexploitable pour la validation
+métier ou le dialogue avec un opérateur. La machine à états CCO fournit en
+outre un **second vérificateur indépendant** (les transitions interdites de la
+table croisent la règle du sectionneur par un autre chemin — défense en
+profondeur).
+
+**La séquence n'est pas encore une fiche de manœuvres.** Une fiche CCO comporte
+l'ordre *et* les temporisations *et* les contrôles attendus *et* les
+validations amont. Le module s'arrêtait à l'ordre. Les temporisations ACT 104
+et les contrôles TS/TM sont pourtant dérivables en grande partie du seul graphe
+et de la séquence (voir R24/R25) ; les validations électriques (R26)
+nécessitent un load flow — disponible ailleurs dans ce dépôt.
+
+**L'essai de barre est la règle experte manquante la plus structurante pour le
+séquenceur.** Remettre sous tension une section morte doit se faire par un
+**disjoncteur** (capable de couper sur défaut de barre), de préférence de
+ligne, jamais par la simple fermeture d'un sectionneur ; l'ouvrage d'essai doit
+être sous tension jusqu'au DJ d'essai ; le choix se fait par « force » du
+départ. Le séquenceur actuel referme un sectionnement sur section morte
+(conforme à la règle du sectionneur, la section étant hors tension) mais sans
+essai préalable : les séquences de *remise en service* de sections s'écartent
+donc de la pratique CCO. C'est détecté désormais (avertissement R22) ; la
+*génération* de l'essai reste à intégrer au séquenceur (§ 4.2).
+
+**Le périmètre mono-poste est le plafond de verre.** Ouvrages multi-postes,
+ordre inter-tensions des transformateurs, essais par la liaison remise en
+service, zone de manœuvre avec postes fictifs : tout cela exige une couche
+d'orchestration au-dessus des `PosteTopologique` (§ 4.3). C'est cohérent avec
+le contrat pluggable existant (phases A/B/C) : il manque une **phase D**
+(plan multi-postes).
+
+---
+
+## 2. Règles consolidées R20-R28
+
+Les règles R20-R25 sont **implémentées** dans
+`manoeuvre/algo/conformite.py` (point d'entrée `analyser_conformite`, résultat
+`ConformiteSequence` attaché à `ResultatManoeuvres.conformite` par
+`plugins.pipeline.verifier_sequence`). Les règles R26-R28 sont **spécifiées**
+(cibles d'implémentation). Traçabilité code/tests : [`regles.md`](regles.md).
+
+Trois niveaux de verdict, volontairement séparés des champs historiques
+(`ecarts`/`alertes`, dont le contenu est figé par les goldens) :
+
+- **violation** — règle d'exploitation enfreinte (matrice CCRT, transition
+  interdite) ;
+- **avertissement** — bonne pratique non bloquante (essai de barre,
+  transitions « bizarres ») ;
+- **annotation** — information exécutoire (contrôles attendus, temporisations).
+
+### R20 — Classification des conséquences de chaque manœuvre
+
+Toute manœuvre est classée par rejeu sur le graphe du poste en conséquences
+élémentaires CCRT : `manoeuvre_hors_tension`, `ouverture_boucle` /
+`fermeture_boucle`, `preparer` / `desaiguiller`, `mise_sous_tension`,
+`mise_hors_tension`, `etablir_transit`, `couper_transit`,
+`changer_nb_noeuds`, `sans_effet`. Une manœuvre peut porter plusieurs
+conséquences (ouvrir le DJ d'un départ de charge = coupure de transit **et**
+mise hors tension).
+
+Modèle d'énergisation mono-poste (hypothèse conservative documentée) : une
+composante est **présumée sous tension** si elle contient au moins un
+équipement « feeder » (ligne, transformateur, groupe, batterie, HVDC, ligne
+frontière) ; charges et compensation sont passives. L'état de l'extrémité
+distante d'une ligne étant inconnu, une coupure de transit peut en réalité
+n'être qu'une mise hors tension d'un ouvrage à vide.
+
+- **Code** : `conformite.classifier_manoeuvres`, `Consequence`,
+  `familles_organes` (familles CCRT : DJ, interrupteur, SA d'aiguillage, SA de
+  couplage, sectionnement SS, sectionneur de ligne).
+
+### R21 — Matrice d'autorisation conséquence × organe (CCRT)
+
+Un **sectionneur** (SA d'aiguillage, SA de couplage, sectionnement, sectionneur
+de ligne) ne peut ni **établir** ni **couper un transit**, ni **changer le
+nombre de nœuds** du poste — conséquences réservées au **disjoncteur** et à
+l'**interrupteur**. Les manœuvres de boucle, hors tension, préparer /
+désaiguiller sont autorisées pour tous. La mise sous/hors tension par
+sectionneur est tolérée « sous conditions » (limitée au jeu de barres et au
+départ — la mise sous tension d'une *section* déclenche l'avertissement R22).
+
+Cette règle **généralise** R18 (sectionneur hors charge) : elle produit les
+mêmes verdicts sur les cas couverts par R18, et couvre en plus le pontage de
+deux nœuds par SA (fermeture) et la scission de nœuds par sectionneur.
+
+- **Code** : `conformite.verifier_matrice_autorisation`,
+  `CONSEQUENCES_INTERDITES_SECTIONNEUR`, `FAMILLES_SECTIONNEUR`.
+
+### R22 — Essai de jeu de barre (remise sous tension d'une section)
+
+La remise sous tension d'une section de barre morte se fait par un
+**disjoncteur** (l'essai « couvre » un défaut de barre), de préférence dans
+l'ordre : **DJ de ligne > DJ de couplage > DJ de transformateur** ; l'ouvrage
+d'essai doit être sous tension jusqu'au DJ d'essai ; à défaut d'opportunité
+(un départ déjà à manœuvrer), choisir le départ le plus « fort » (approximation
+CCO : nombre de départs hors antennes du nœud distant). Après essai, ouvrir le
+DJ, fermer le sectionnement, refermer le DJ.
+
+- **Implémenté (détection)** : la mise sous tension d'une section par un
+  sectionneur lève un **avertissement** (`verifier_matrice_autorisation`).
+- **À implémenter (génération)** : insertion de la sous-séquence d'essai par le
+  séquenceur (§ 4.2), choix du DJ d'essai par opportunité puis par force.
+
+### R23 — Suivi d'état des départs (machine à états CCO)
+
+État d'un départ = (nb de barres aiguillées par SA fermés) × (OC ligne) :
+`désaiguillé`, `préparé`, `préparé - DA`, `en service`, `en service - DA`,
+`bizarre non préparé fermé`. Les transitions observées lors du rejeu sont
+confrontées à la table CCO : transitions **interdites** (ouvrir le dernier SA
+d'un départ en service ; fermer un SA sous OC ligne fermé non préparé),
+transitions **bizarres** (fermeture d'OC ligne d'un départ non préparé, DA sous
+OC ouvert) et contrôles associés (±I/Scc à l'établissement/coupure, contrôle du
+nombre de nœuds sur les ±DA).
+
+L'état des **ouvrages** complets (en service / SUAV / hors tension = somme des
+départs de *toutes* les extrémités) exige la vision multi-postes → R27.
+
+- **Code** : `conformite.suivre_etats_departs`, `EtatDepart`,
+  `_TRANSITIONS_DEPART`, `TransitionDepart`.
+
+### R24 — Temporisations (consigne ACT 104)
+
+À insérer dans la séquence :
+
+| Temporisation | Portée | Statut |
+|---|---|---|
+| **10 s** après toute manœuvre de sectionneur (schémas fantômes) | graphe seul | ✅ implémentée |
+| **60 s** min entre deux fermetures d'un même DJ (regonflage, cycle O-F-O) — le temps déjà écoulé en temporisations est décompté | graphe seul | ✅ implémentée |
+| 2 min avant fermeture du DJ secondaire d'un TR neuf ou longuement consigné (régleurs) | contexte (historique de consignation) | spécifiée |
+| 2 min entre manœuvres de sectionneurs d'un départ **PSEM** (manœuvres programmées) | données poste (technologie PSEM) | spécifiée |
+| 1 min entre MHU et remise SUAV d'une liaison **225/400 kV** (surtensions) | suivi d'état d'**ouvrage** (R27) | spécifiée |
+
+- **Code** : `conformite.calculer_temporisations`, `Temporisation`,
+  `TEMPO_SECTIONNEUR_S`, `TEMPO_REGONFLAGE_DJ_S`.
+
+### R25 — Contrôles SCADA attendus par manœuvre
+
+Chaque manœuvre classée porte ses contrôles (tableau « contrôle lors des
+manœuvres ») :
+
+| Conséquence | Contrôle attendu |
+|---|---|
+| coupure de transit | TM I passe à 0 sur le départ |
+| mise hors tension | TS absence de tension **apparaît** (si la TS existe), sections nommées |
+| mise sous tension | TS absence de tension **disparaît**, sections nommées |
+| établissement de transit | TM I/P/Q conformes au calcul de répartition ; si dépassement d'Icc, absence de TS PRESENCE dans les postes |
+| changement du nombre de nœuds / ±DA | contrôle du nombre de nœuds du poste avant/après |
+| boucle, manœuvre HU, préparer/désaiguiller | aucun |
+
+La traduction en requêtes temps réel (TITIEN : libellés TS/TM, fenêtres
+20 s avant / 30 s après, pas 10 s) est hors périmètre du module — l'annotation
+fournit le *besoin* de contrôle, pas la requête.
+
+- **Code** : `conformite._controles_pour` (porté par
+  `ManoeuvreClassee.controles`), plus les contrôles de transition R23.
+
+### R26 — Validations par calcul de répartition et de court-circuit *(spécifiée)*
+
+Toute étape portant `etablir_transit` / `couper_transit` (et les fermetures de
+couplage) doit être validée en amont par calcul de répartition (transits
+< X % de l'IST — 80 % dans le POC CCO —, tensions dans les plages) ; les
+établissements de transit exigent de plus une validation Icc. Le cadre de
+référence en manœuvre diffère du cadre général (pas d'étude N-1, dépassements
+d'Icc possibles sous condition d'absence de personnel).
+
+**Chemin d'implémentation dans ce dépôt** : la classification R20 fournit
+exactement les étapes à valider ; le backend pypowsybl du recommandeur
+(`pypowsybl_backend/simulation_env.py`, variantes réseau, load flow) fournit le
+simulateur. Un `ValidateurElectrique` (phase de vérification optionnelle,
+activée quand un réseau pypowsybl est disponible — IHM et dataset RTE-7000 en
+ont un) appliquerait les lots de manœuvres entre étapes à valider, comme décrit
+dans la note CCO. C'est le pont naturel entre le module manœuvre (aujourd'hui
+autonome) et le reste du recommandeur.
+
+### R27 — Ouvrages multi-postes et ordre inter-tensions *(spécifiée)*
+
+Couche d'orchestration au-dessus des postes (« phase D », § 4.3) :
+
+1. **Ouvrages** : un ouvrage = ses départs dans chaque poste + la
+   liaison/le TR ; états en service / SUAV / hors tension par somme des états
+   de départs (R23) ; postes fictifs (piquages, 3 enroulements) absorbés dans
+   l'ouvrage.
+2. **Ordre inter-postes** : manœuvrer le départ du poste **en service** avant
+   celui du poste hors tension (l'essai de barre est fait par la liaison que
+   l'on remet en service) ; tri MHU par tension croissante, **MES par tension
+   décroissante pour les transformateurs** (MHU du TR par le plus bas niveau,
+   MES par le plus haut).
+3. **Zone de manœuvre** : postes modifiés + anneau de garde de profondeur 1
+   (en sautant les postes fictifs), antennes identifiées — se raccorder à la
+   détection d'antennes du recommandeur.
+4. Temporisation « 1 min MHU→SUAV 225/400 kV » (R24) : détectable à ce niveau.
+
+### R28 — Automates *(spécifiée, non planifiée)*
+
+Les manœuvres réelles modifient presque toujours des automates (RA, AMU/RMU,
+RTS, automates zonaux) : mise hors service avant manœuvre, remise en service
+après, reprogrammation des renvois lors des mises en/hors antenne (AUT 102).
+Les données (Tomate II, TITIEN) ne sont pas dans le fichier réseau : hors de
+portée du module. Le modèle de résultat doit en revanche pouvoir **porter
+l'alerte** : toute séquence qui met un ouvrage en antenne ou l'en sort devrait
+signaler « vérifier la position des réenclencheurs (AUT 102) ». La détection
+d'antenne au niveau zone (R27) en est le prérequis.
+
+---
+
+## 3. Correspondance avec la typologie CCO (`listeDordre` à ~20 codes)
+
+La méthode CCO ordonne les manœuvres par **types** globaux (un ordre unique qui
+respecte toujours l'art de la manœuvre). Correspondance avec les phases du
+séquenceur et la classification R20 :
+
+| Code CCO | Sens | Équivalent module |
+|---|---|---|
+| `mhu_fermeture` / `mhu_ouverture` | manœuvre d'OC en zone hors tension | R20 `manoeuvre_hors_tension` |
+| `fermeture_boucle` / `ouverture_boucle` | OC de JdB sans changement de nœud | R20 `fermeture/ouverture_boucle` ; phases 0/D |
+| `prep_essai_-u`, `prep_essai_des`, `essai_section_pp`, `essai_section_+u`, `essai_section_-u`, `+u_section_ss`, `essai_section_des` | sous-séquence d'essai de jeu de barre | **manquant** (R22 génération, § 4.2) |
+| `preparer` / `desaiguiller` | fermeture du 1er SA / ouverture du dernier SA | R20 `preparer`/`desaiguiller` ; boucle longue R9 |
+| `+u_dep` / `-u_dep` | fermeture / ouverture d'un DJ de départ | R20 `etablir_transit`/`couper_transit`+`mise_*_tension` |
+| `+da` / `-da` | fermeture / ouverture d'un second SA | R20 boucles + transition R23 `en service ↔ en service - DA` |
+| `-u_section_ss_def` | changement de barre sans couplage, dernier désaiguillage | partiel (§ 4.3, pseudo-couplage) |
+
+L'ordre global CCO (essais avant mises en service, `+u_dep` avant `-u_dep`,
+désaiguillages en dernier) est **compatible** avec l'ordre R11 du séquenceur ;
+la classification R20 permet désormais d'**annoter** chaque manœuvre du code
+CCO correspondant (utile pour l'IHM et la comparaison à des fiches réelles).
+
+---
+
+## 4. Restructuration proposée (module, algo, vérificateur)
+
+### 4.1 Vérificateur : d'une règle unique à un pipeline de contrôleurs — **fait**
+
+Le vérificateur devient un empilement de contrôleurs indépendants, tous fondés
+sur le **rejeu** (l'invariant « `poste.graph` jamais muté » le permet) :
+
+```
+verifier_sequence (façade plugins — verdict unique pour tout algorithme)
+├── rejeu topologique        → is_verified / is_verified_detaillee / ecarts   (R14, R15)
+├── sûreté sectionneur       → ecarts (bloquant)                              (R18)
+├── bonne pratique smooth    → alertes (« un seul ouvrage HS »)               (R10ter)
+└── conformité art de la manœuvre → conformite (nouveau champ)                (R20-R25)
+    ├── classification des conséquences + familles d'organes                  (R20)
+    ├── matrice d'autorisation CCRT   → violations                           (R21)
+    ├── essai de barre                → avertissements                        (R22)
+    ├── machine à états des départs   → violations / avertissements          (R23)
+    ├── temporisations ACT 104        → annotations                          (R24)
+    └── contrôles SCADA attendus      → annotations                          (R25)
+```
+
+Chaque étage est appelable isolément (API publique), la façade les agrège. Les
+champs historiques restent inchangés (compatibilité des goldens et de l'IHM) ;
+`ResultatManoeuvres.conformite` porte le nouveau verdict. À terme, si le nombre
+de contrôleurs croît (R26+), promouvoir `verification.py` + `conformite.py`
+en package `algo/verification/` avec un protocole `Controleur` commun.
+
+### 4.2 Algorithme : générer ce que le vérificateur exige
+
+Par ordre de valeur :
+
+1. **Essai de barre (R22, génération)** — dans le séquenceur, remplacer la
+   fermeture directe d'un sectionnement sur section morte par la sous-séquence
+   CCO : choisir le DJ d'essai (opportunité → force, ligne > couplage > TR),
+   essayer (+DJ), rouvrir (-DJ), fermer le SS, refermer le DJ. Points
+   d'insertion : `determiner_manoeuvres_avec_sections` (fermetures de
+   sectionnement) et `_aligner_couplers_sur_cible`. Le vérificateur R22 sert de
+   test d'acceptation (0 avertissement attendu sur les séquences générées).
+2. **Annotation en codes CCO** — porter sur `Manoeuvre` un champ
+   `type_manoeuvre` déduit de R20/R23 (table § 3). Aucune modification de
+   l'ordre : uniquement de l'explicabilité (IHM, comparaison à des fiches
+   réelles du dataset RTE-7000).
+3. **Plan temporisé** — un `PlanManoeuvres` = séquence + temporisations R24
+   intercalées + contrôles R25, prêt pour une exécution/animation IHM (l'IHM
+   anime déjà les séquences ; les temporisations donnent l'échelle de temps).
+4. **Changement de barre sans couplage et sans DA** (schéma miroir par
+   pseudo-couplage des SA d'un départ, essai de la barre d'arrivée compris) —
+   complète les limites « cible arbitraire » et « barre de réserve fusionnée ».
+
+### 4.3 Module : ouvrir le périmètre mono-poste (phase D)
+
+Le contrat pluggable actuel (A identification, B séquencement, C planification)
+est **par poste**. Ajouter une **phase D — plan de manœuvre multi-postes** :
+
+```
+PlanificateurZone (phase D, nouveau)
+  entrées : situation initiale + cible (réseau), liste de postes impactés
+  1. zone de manœuvre (postes + anneau de garde, postes fictifs absorbés)   (R27.3)
+  2. ouvrages et leurs départs ; états ES/SUAV/HU                            (R27.1)
+  3. par poste : phases A/B/C existantes (inchangées)
+  4. entrelacement inter-postes : poste en service d'abord, tri par tension,
+     règle TR (MES tension décroissante)                                     (R27.2)
+  5. temporisations d'ouvrage (1 min MHU→SUAV 225/400 kV)                    (R24)
+  6. validations électriques sur les étapes à transit (backend pypowsybl)    (R26)
+  7. alerte automates sur mise/fin d'antenne                                 (R28)
+```
+
+Le module reste sans dépendance au reste du recommandeur pour les étapes 1-5 ;
+l'étape 6 introduit une dépendance **optionnelle** (protocole `Simulateur`
+injecté, implémenté par `pypowsybl_backend` côté recommandeur — le module ne
+l'importe pas). La brique dataset (RTE-7000, chronologies de topologies) fournit
+les cas de test réels : les journées à re-groupements de nœuds
+(`dataset/exploration.py`) donnent des couples avant/après pour confronter les
+plans générés aux manœuvres réellement observées — la méthode de validation
+que la note CCO appelle de ses vœux (« % de réussite, % de non-fait, absence
+d'échec »).
+
+### 4.4 Ce qu'il ne faut PAS restructurer
+
+- **Le cœur séquenceur (R1-R19)** : éprouvé par goldens et postes réels ; les
+  enrichissements s'ajoutent en couches (vérification, annotation, génération
+  d'essais) sans en modifier l'architecture.
+- **La séparation `ecarts`/`alertes`/`conformite`** : fusionner les verdicts
+  casserait les goldens et mélangerait sûreté (bloquante) et conformité
+  métier (contextuelle).
+- **L'autonomie du module** vis-à-vis de grid2op/du recommandeur : les ponts
+  (R26, antennes) passent par des protocoles injectés, pas par des imports.
+
+---
+
+## 5. Hypothèses et limites du vérificateur de conformité
+
+1. **Présomption de tension** (mono-poste) : les feeders (ligne, TR, groupe)
+   sont présumés sous tension. Conséquences : une manœuvre sur un ouvrage
+   réellement consigné peut être classée « transit » (conservatif — faux
+   positif possible sur les cellules de ré-aiguillage sans DJ) ; une coupure de
+   transit peut en réalité être une MHU d'ouvrage à vide. La levée de cette
+   hypothèse exige la vision zone (R27) ou l'état électrique réel (R26).
+2. **Pas de calcul électrique** : les conséquences sont topologiques ; les
+   valeurs (transits, tensions, Icc) relèvent de R26.
+3. **Machine à états** : les cellules sans OC ligne propre (ré-aiguillage
+   direct) sont hors modèle CCO ; les ouvrages multi-OC-lignes sont suivis par
+   l'état agrégé de leurs OC (comme le POC CCO, qui documente la même limite).
+4. **Temporisations** : sous-ensemble calculable du graphe (10 s sectionneur,
+   60 s regonflage DJ) ; les temporisations contextuelles (régleurs TR, PSEM,
+   MHU→SUAV 225/400 kV) sont listées mais non calculées (R24).
+
+---
+
+## 6. Références croisées
+
+- Spécification des règles implémentées (traçabilité code/tests) :
+  [`regles.md`](regles.md) — R20-R25 y sont référencées.
+- Code : `expert_op4grid_recommender/manoeuvre/algo/conformite.py` ;
+  intégration `manoeuvre/plugins/pipeline.py::verifier_sequence`.
+- Tests : `tests/manoeuvre/test_conformite_art_manoeuvre.py`.
+- Architecture plugins (phases A/B/C) : `docs/architecture/plugins.md`.
+- Dataset de validation : `docs/manoeuvre/dataset_rte7000/`.

--- a/docs/manoeuvre/ihm.md
+++ b/docs/manoeuvre/ihm.md
@@ -479,6 +479,16 @@ nœud électrique**.
   affiche « **N nœud(s) + M ouvrage(s) isolé(s)** » (`nb_obtenu` = nœuds réels,
   `nb_isoles` = isolés) et **non** un total gonflé (plus de « obtenu 4 » pour
   2 nœuds + 2 isolés).
+  Un ouvrage **déjà déconnecté au départ** et non replacé sur un nœud est
+  **hors périmètre de la cible**, qu'il figure ou non dans `isolated` : il ne
+  compte ni dans `nb_vise` (plus de nœud « orphelin » qui gonflait la cible) ni
+  dans le verdict de réalisabilité. C'est la même sémantique que le cœur
+  (`TopologieNodale.noeuds_isoles`) — voir « Ouvrages isolés et vérification »
+  ci-dessous. Le glisser d'un ouvrage isolé **sur un nœud** vaut au contraire
+  demande de **reconnexion** : il rentre alors dans le périmètre et la
+  vérification redevient stricte à son égard.
+  Quand le verdict est négatif, le statut porte **toujours** son diagnostic
+  (`message`, `noeuds_non_realisables`, `ecarts`) — plus d'avertissement nu.
   Le volet nodal cible est alors **resynchronisé sur la topologie réalisée**
   (partition, **couleurs** topological_coloring et ouvrages isolés renvoyés dans
   `nodale` par `/api/nodale_to_detaillee`) : il prend les mêmes nœuds et couleurs
@@ -499,6 +509,33 @@ glisser-déposer nodal (et **＋ Nœud**) sont des **propositions** de partition
 cible détaillée et resynchronise le volet nodal sur la topologie **obtenue**
 (d'où, en cas de réalisation partielle, un volet nodal qui correspond bien au
 détail réalisé et non à la proposition).
+
+### Ouvrages isolés et vérification
+
+Un **ouvrage isolé** est un ouvrage dont la composante électrique (organes
+fermés) ne contient **aucune barre** : il est déconnecté, ce n'est pas un nœud
+électrique. Le cœur les distingue désormais explicitement :
+`TopologieNodale.from_graph` renseigne `noeuds_isoles` (noms des composantes
+0-barre) et expose `nb_noeuds_reels` (= `nb_noeuds` − isolés). Une topologie
+**cible** construite depuis une partition (`from_node_groups`) n'a pas cette
+notion : elle ne décrit que les ouvrages à placer sur un nœud.
+
+`TopologieNodale.meme_topologie` compare donc les partitions **dans le périmètre
+commun** : un nœud isolé d'un côté dont aucun équipement n'apparaît de l'autre
+côté est écarté (`partition_hors_isoles_inconnus`). Conséquences :
+
+- un ouvrage **déjà déconnecté** et absent de la cible ne rend plus la cible
+  « non réalisable » — c'était la cause du faux avertissement
+  « ⚠ Cible partiellement réalisable (obtenu 2 nœud(s) + 5 ouvrage(s) isolé(s)
+  / visé 2 nœud(s)) » alors que la cible était atteinte ;
+- la comparaison reste **stricte** dès que la cible mentionne l'ouvrage — le
+  citer dans un nœud vaut demande de reconnexion, le citer comme nœud à lui seul
+  reste comparé à l'identique (comportement historique) ;
+- un ouvrage **visé sur un nœud** qui finit déconnecté fait toujours échouer la
+  vérification.
+
+`partition()` reste **exhaustive** (isolés inclus) : les goldens et
+`partition_obtenue` sont inchangés.
 
 ### Naviguer et éditer la séquence (expert)
 La séquence calculée peut être **parcourue et modifiée** directement, sans avoir

--- a/docs/manoeuvre/regles.md
+++ b/docs/manoeuvre/regles.md
@@ -526,6 +526,75 @@ mécanismes, branchés **transactionnellement** (retenus seulement s'ils vérifi
 
 ---
 
+## Conformité « art de la manœuvre » (R20-R25)
+
+> Analyse critique, spécification complète et règles non encore implémentées
+> (R26 validations électriques, R27 multi-postes, R28 automates) :
+> **`docs/manoeuvre/art_de_la_manoeuvre.md`**. Les verdicts de ces règles sont
+> portés par le champ **séparé** `ResultatManoeuvres.conformite`
+> (`ConformiteSequence` : `violations` / `avertissements` / annotations),
+> renseigné par `plugins.pipeline.verifier_sequence` — les champs historiques
+> `ecarts`/`alertes` sont inchangés (goldens iso).
+
+### R20 — Classification des conséquences de chaque manœuvre
+Chaque manœuvre est classée par rejeu en conséquences élémentaires CCRT
+(manœuvre hors tension, ouverture/fermeture de boucle, préparer/désaiguiller,
+mise sous/hors tension, établissement/coupure de transit, changement du nombre
+de nœuds, sans effet), avec la famille CCRT de l'organe (DJ, interrupteur, SA
+d'aiguillage, SA de couplage, sectionnement SS, sectionneur de ligne).
+Présomption de tension sur les feeders (mono-poste, conservatif).
+- **Code** : `algo/conformite.py` — `classifier_manoeuvres`, `Consequence`,
+  `FamilleOrgane`, `familles_organes`.
+- **Test** : `test_conformite_art_manoeuvre.py::test_boucle_courte_classee_boucle`,
+  `::test_boucle_longue_conforme`, `::test_ouverture_couplage_change_nb_noeuds`,
+  `::test_manoeuvre_hors_tension`, `::test_familles_organes_carrip3`.
+
+### R21 — Matrice d'autorisation conséquence × organe (CCRT)
+Un sectionneur ne peut ni établir/couper un transit ni changer le nombre de
+nœuds (réservé DJ/interrupteur) → **violation**. Généralise R18 : couvre aussi
+le pontage de deux nœuds par fermeture de SA.
+- **Code** : `conformite.verifier_matrice_autorisation`.
+- **Test** : `::test_sa_en_charge_est_une_violation`,
+  `::test_fermeture_sa_pontant_deux_noeuds_est_une_violation`,
+  `::test_sequence_algo_est_conforme` (les séquences natives sont conformes).
+
+### R22 — Essai de jeu de barre (détection)
+La remise sous tension d'une section morte par un **sectionneur** lève un
+**avertissement** (préférer un essai par disjoncteur : ligne > couplage >
+transformateur). La *génération* de la sous-séquence d'essai par le séquenceur
+reste à faire (cf. art_de_la_manoeuvre.md § 4.2).
+- **Code** : `conformite.verifier_matrice_autorisation` (branche essai de barre).
+- **Test** : `::test_essai_de_barre_avertissement`.
+
+### R23 — Suivi d'état des départs (machine à états CCO)
+États (nb SA fermés × OC ligne) : désaiguillé, préparé, préparé-DA, en service,
+en service-DA, bizarre non préparé fermé. Transitions **interdites** (ouvrir le
+dernier SA en service ; fermer un SA sous OC fermé non préparé) → violation ;
+transitions « bizarres » → avertissement ; contrôles associés (±I/Scc,
+contrôle nœuds sur ±DA).
+- **Code** : `conformite.suivre_etats_departs`, `EtatDepart`, `_TRANSITIONS_DEPART`.
+- **Test** : `::test_trajectoire_etats_boucle_longue`,
+  `::test_double_aiguillage_controle_noeuds`, `::test_sa_en_charge_est_une_violation`.
+
+### R24 — Temporisations (ACT 104, sous-ensemble graphe)
+10 s après toute manœuvre de sectionneur ; 60 s minimum entre deux fermetures
+d'un même DJ (regonflage, temps déjà écoulé décompté). Temporisations
+contextuelles (régleurs TR, PSEM, MHU→SUAV 225/400 kV) spécifiées non calculées.
+- **Code** : `conformite.calculer_temporisations`, `Temporisation`.
+- **Test** : `::test_tempo_sectionneur_10s`, `::test_tempo_regonflage_dj_60s`,
+  `::test_pas_de_tempo_dj_ferme_une_seule_fois`.
+
+### R25 — Contrôles SCADA attendus par manœuvre
+Par conséquence : TM I passe à 0 (coupure), TS absence tension apparaît /
+disparaît (mise hors/sous tension, sections nommées), TM I/P/Q conformes au
+calcul + Icc/TS PRESENCE (établissement), contrôle du nombre de nœuds
+(changement de nœuds, ±DA). Boucles et manœuvres HU : aucun contrôle.
+- **Code** : `conformite._controles_pour` (→ `ManoeuvreClassee.controles`),
+  contrôles de transition dans `_TRANSITIONS_DEPART`.
+- **Test** : `::test_controles_attendus`, `::test_trajectoire_etats_boucle_longue`.
+
+---
+
 ## Postes multi-sections
 
 Les postes à plusieurs **sections par barre** (ex. **CARRIP6** : 2 barres × 3

--- a/docs/release-notes/v0.3.2.md
+++ b/docs/release-notes/v0.3.2.md
@@ -1,0 +1,119 @@
+# v0.3.2 — « Art de la manœuvre » (R20–R25) + ouvrages isolés et vérification
+
+A minor release on top of `0.3.1.post1`. It ships the **maneuver conformity
+verifier** ("art de la manœuvre", rules R20–R25) and fixes a **false negative in
+the nodal → detailed verification** when a substation carries works that are
+already disconnected.
+
+Both changes are confined to the `manoeuvre` module (and its Flask IHM); the
+recommender analysis pipeline is untouched.
+
+## Highlights
+
+### 1. Maneuver module — "art de la manœuvre" conformity verifier (R20–R25)
+
+`manoeuvre/algo/conformite.py`, built from the RTE operating references (CCRT
+C3-3 authorization matrix, ACT 104 timing directive, the CCO expert-method
+note):
+
+- per-manoeuvre **consequence classification** by replay (dead-zone operation,
+  loop open/close, prepare/de-select, energize / de-energize, make/break
+  transit, node-count change) with CCRT organ families (breaker, load-break
+  switch, busbar selector, coupling disconnector, busbar sectionalizer, line
+  disconnector);
+- the **authorization matrix** — a disconnector may neither make/break transit
+  nor change the substation node count (generalizes the load-break rule R18);
+- a **busbar-test advisory** (re-energizing a dead busbar section through a
+  disconnector instead of a breaker, R22);
+- the **CCO bay state machine** (désaiguillé / préparé / ±DA / en service,
+  forbidden and "bizarre" transitions, R23);
+- **ACT 104 timings** (10 s after each disconnector operation, ≥60 s between two
+  closures of the same breaker, R24) and **expected SCADA checks** per manoeuvre
+  (TS/TM, node-count checks, R25).
+
+Verdicts land in a new, **separate** `ResultatManoeuvres.conformite` field
+(`ConformiteSequence`: violations / avertissements / temporisations /
+contrôles), populated by `plugins.pipeline.verifier_sequence` — the historical
+`ecarts` / `alertes` verdicts and every golden stay byte-identical.
+
+`docs/manoeuvre/art_de_la_manoeuvre.md` documents the critical coverage analysis
+(what R1–R19 do and do not cover versus the operating references), the enriched
+rules R20–R25 (implemented) and R26–R28 (specified: load-flow/Icc validation via
+the recommender's pypowsybl backend, multi-substation orchestration "phase D",
+automata alerts), the CCO `listeDordre` code mapping, and the
+module/algo/verifier restructuring plan. `docs/manoeuvre/regles.md` gains the
+R20–R25 traceability entries.
+
+### 2. Isolated works no longer invalidate a reached nodal target
+
+**Symptom.** After running the nodal → detailed algorithm on a substation whose
+works were partly disconnected already, the IHM reported
+
+> ⚠ Cible partiellement réalisable (obtenu 2 nœud(s) + 5 ouvrage(s) isolé(s) /
+> visé 2 nœud(s))
+
+even though the target *was* reached and the 5 works disconnected at the start
+stayed disconnected in the target topology.
+
+**Root cause.** `TopologieNodale.from_graph` materializes one `noeuds` entry per
+connected component carrying an equipment — **including components with no
+busbar**, i.e. disconnected works. The nodal target edited by the expert
+(`from_node_groups`) only describes the works to place on a node. Comparing the
+two partitions strictly therefore failed for *any* substation with a
+pre-disconnected work: `meme_topologie` saw extra "nodes" the target never
+mentioned. This propagated to `ResultatManoeuvres.is_verified`,
+`ResultatIdentification.is_realisable` (including the pipeline's independent
+verification) and, finally, to the IHM warning.
+
+**Fix.** The notion of an isolated work is now explicit in the core:
+
+- `TopologieNodale.noeuds_isoles` — names of the busbar-less components,
+  populated by `from_graph` (a target built from a partition has none);
+- `TopologieNodale.nb_noeuds_reels` — node count excluding them;
+- `TopologieNodale.partition_hors_isoles_inconnus(univers_autre)` and
+  `meme_topologie`, which now compare partitions **within the common scope**: an
+  isolated node whose equipment appears nowhere in the other topology is
+  dropped, symmetrically.
+
+The comparison stays **strict** as soon as both sides talk about the same
+equipment — naming an isolated work inside a target node means "reconnect it",
+and a work targeted on a node that ends up disconnected still fails
+verification. `partition()` remains exhaustive, so `partition_obtenue` and every
+golden are unchanged.
+
+Consequences elsewhere:
+
+- diagnostics report `nb_noeuds_reels` for the obtained topology, so "obtenu N
+  nœud(s)" no longer counts disconnected works;
+- **IHM** (`Session.nodale_to_detaillee`): the verdict is recomputed on the
+  **final** state (post-isolation) through the same core rule, so both code
+  paths agree. A work **already disconnected at start** and not dropped onto a
+  node is out of the target scope whether or not the client listed it in
+  `isolated` — it no longer becomes an "orphan" node inflating `nb_vise`, and it
+  is force-disconnected consistently. Dragging it onto a node still means
+  reconnection, and keeps the strict check.
+- **IHM diagnostics**: a negative verdict now always carries its `message` /
+  `noeuds_non_realisables` / `ecarts`. The previous isolated-works branch blanked
+  them, which is why the false warning appeared with no explanation at all. A
+  work that could not actually be disconnected is named explicitly
+  (« Ouvrage(s) impossible(s) à isoler : … ») instead of silently degrading the
+  verdict.
+
+Regression tests: `tests/manoeuvre/test_ouvrages_isoles_verification.py` (core on
+a pure NetworkX graph, algo level through `PlanificateurTopologie`, IHM level
+through `Session.nodale_to_detaillee`, plus the negative cases).
+
+## Also in this release
+
+- `tests/manoeuvre/test_ihm_ui_improvements.py::test_config_post_updates_dirs`
+  repaired: it pointed `/api/config` at a `tmp_path` outside every allowed store
+  root, so the path-traversal guard (`_dir_within_allowed`, added in 0.2.6)
+  legitimately refused it and the test had been failing ever since. It now
+  declares `tmp_path` as the persistent data root.
+
+## Compatibility
+
+No API removal. `TopologieNodale` gains a field and three members; existing
+constructors, `partition()`, `nb_noeuds` and every golden are unchanged. The
+only behavioural change is that a verification which used to fail *because of
+out-of-scope disconnected works* now succeeds.

--- a/expert_op4grid_recommender/__init__.py
+++ b/expert_op4grid_recommender/__init__.py
@@ -15,7 +15,7 @@ corrective measures to alleviate line overloads.
 
 import logging
 
-__version__ = "0.3.1.post1"
+__version__ = "0.3.2"
 
 _logger = logging.getLogger(__name__)
 

--- a/expert_op4grid_recommender/manoeuvre/CLAUDE.md
+++ b/expert_op4grid_recommender/manoeuvre/CLAUDE.md
@@ -32,6 +32,7 @@ Sous-modules en couches, **dependances strictement descendantes** (sans cycle) :
 | `algo/graph_ops.py`  | Helpers bas niveau : index O(1), `_is_open`/`_set_switch`, chemins SA, `_inter_sjb_couplers` |
 | `algo/placement.py`  | Placement noeud → sections (`_placement_automatique`, best-effort, glouton, `_main_busbar_sjb`) |
 | `algo/verification.py`| Regle du sectionneur (`_rejeu_securite`, `sectionneurs_sous_charge_par_manoeuvre`), `_optimiser_sequence` |
+| `algo/conformite.py` | Conformite « art de la manoeuvre » (R20-R25) : classification des consequences par rejeu (`classifier_manoeuvres`), matrice d'autorisation CCRT (`verifier_matrice_autorisation`), machine a etats des departs (`suivre_etats_departs`), temporisations ACT 104 (`calculer_temporisations`), controles SCADA attendus. Point d'entree `analyser_conformite` -> `ConformiteSequence`, attache a `ResultatManoeuvres.conformite` par `verifier_sequence` (champ **separe** d'`ecarts`/`alertes` : goldens iso). Doc : `docs/manoeuvre/art_de_la_manoeuvre.md` |
 | `algo/sequencing.py` | Sequenceur general (`determiner_manoeuvres_avec_sections`), re-aiguillages |
 | `algo/targets.py`    | Points d'entree : `determiner_topo_complete_cible`, `determiner_manoeuvres_cible_detaillee`, modes smooth/aggressive/multi-barres |
 | `algo/__init__.py`   | **Reexporte toute la surface** de l'ancien module (publics + prives) : `manoeuvre.algo.X` et `from ...algo import X` restent inchanges |
@@ -372,11 +373,17 @@ Limites connues (cf. docstring `algo.py`) :
 
 ### Specification des regles
 
-Toutes les regles metier du sequencement (R1-R14 : faisabilite, distinction
+Toutes les regles metier du sequencement (R1-R19 : faisabilite, distinction
 sectionnement/couplage, tronconnement, placement noeud->SJB, boucle courte/
 longue, DJ d'ensemble de cellule, regle du sectionneur de barre, ordonnancement
 listeDordre, controle court-circuit, verification) sont tracees avec leurs
-fonctions et tests dans **`docs/manoeuvre/regles.md`**.
+fonctions et tests dans **`docs/manoeuvre/regles.md`**, ainsi que les regles
+de **conformite « art de la manoeuvre »** (R20-R25, `algo/conformite.py`).
+L'analyse critique de couverture face aux referentiels RTE (CCRT C3-3, ACT 104,
+methode experte CCO), les regles specifiees non implementees (R26 validations
+electriques, R27 orchestration multi-postes, R28 automates) et le plan de
+restructuration module/algo/verificateur sont dans
+**`docs/manoeuvre/art_de_la_manoeuvre.md`**.
 
 ### Convention de detection des barres
 

--- a/expert_op4grid_recommender/manoeuvre/CLAUDE.md
+++ b/expert_op4grid_recommender/manoeuvre/CLAUDE.md
@@ -16,7 +16,7 @@ de couplage.
 | `graph.py`     | Etape 1.1 : `build_vl_graph()` — graphe NetworkX depuis un voltage level pypowsybl |
 | `cellules.py`  | Etape 1.2 : `detecter_cellules()` — BFS structurel + connectivite electrique |
 | `troncons.py`  | Etapes 1.3-1.4 : `construire_tronconnement()` — barres, troncons, attribution |
-| `topologie.py` | Etapes 1.5-1.6 : `TopologieNodale`, `PosteTopologique`, `attribuer_noeuds()` |
+| `topologie.py` | Etapes 1.5-1.6 : `TopologieNodale`, `PosteTopologique`, `attribuer_noeuds()`. `from_graph` marque les composantes **sans barre** dans `noeuds_isoles` (ouvrages deconnectes) ; `nb_noeuds_reels` les exclut et `meme_topologie` compare **dans le perimetre commun** (`partition_hors_isoles_inconnus`) — un ouvrage deja deconnecte absent de la cible ne rend plus la cible « non realisable ». `partition()` reste exhaustive (goldens iso). Doc : `docs/manoeuvre/ihm.md` § « Ouvrages isoles et verification » |
 | `algo/`        | Phase 2 : `determiner_topo_complete_cible()` — package en couches (voir ci-dessous) |
 | `plugins/`     | Couche **pluggable** : contrats des 3 phases (identification nodale→détaillée, séquencement détaillée→manœuvres, planification bout-en-bout), registre + entry points, façade `PlanificateurTopologie` avec vérification indépendante. Doc : `docs/architecture/plugins.md` |
 | `__init__.py`  | API publique                                     |
@@ -199,6 +199,13 @@ ces tests garantissent l'invariance du comportement :
   (id inconnu, validite sur copie de graphe).
 - `test_couplers_memoisation.py` — invariance a l'etat des couplers, purete,
   non-mutation de `poste.graph` par le pipeline.
+- `test_ouvrages_isoles_verification.py` — **ouvrages isoles et verification**
+  (3 niveaux) : cœur (`noeuds_isoles` / `nb_noeuds_reels` / `meme_topologie`
+  hors perimetre, sur graphe NX pur), algo
+  (`PlanificateurTopologie.identifier_topologie_detaillee`) et IHM
+  (`Session.nodale_to_detaillee`). Verrouille le correctif du faux
+  « Cible partiellement realisable » et le fait qu'un verdict negatif reste
+  **diagnostique** (message / nœuds non realisables / ecarts).
 
 ### Filets pre-eclatement d'`algo.py` (#7)
 

--- a/expert_op4grid_recommender/manoeuvre/algo/__init__.py
+++ b/expert_op4grid_recommender/manoeuvre/algo/__init__.py
@@ -12,6 +12,9 @@ couches (dépendances strictement descendantes, sans cycle) :
                     chemins structurels, couplers inter-SJB)
     placement     — placement nœud → sections de barres (phases 2.2-2.4)
     verification  — vérificateurs de la règle du sectionneur (rejeu unique)
+    conformite    — conformité « art de la manœuvre » (R20-R25) : conséquences,
+                    matrice d'autorisation CCRT, états des départs,
+                    temporisations ACT 104, contrôles SCADA attendus
     sequencing    — séquenceur général (couplage + sectionnement) + ré-aiguillage
     targets       — points d'entrée (cible nodale / cible détaillée)
 
@@ -133,6 +136,21 @@ from .verification import (
     _optimiser_sequence as _optimiser_sequence,
     _sectionneurs_sous_charge_par_manoeuvre as _sectionneurs_sous_charge_par_manoeuvre,
 )
+from .conformite import (
+    FamilleOrgane as FamilleOrgane,
+    Consequence as Consequence,
+    EtatDepart as EtatDepart,
+    ManoeuvreClassee as ManoeuvreClassee,
+    TransitionDepart as TransitionDepart,
+    Temporisation as Temporisation,
+    ConformiteSequence as ConformiteSequence,
+    familles_organes as familles_organes,
+    classifier_manoeuvres as classifier_manoeuvres,
+    verifier_matrice_autorisation as verifier_matrice_autorisation,
+    suivre_etats_departs as suivre_etats_departs,
+    calculer_temporisations as calculer_temporisations,
+    analyser_conformite as analyser_conformite,
+)
 from .sequencing import (
     _reaiguiller_vers_sjb as _reaiguiller_vers_sjb,
     _isoler_depart_hors_barre as _isoler_depart_hors_barre,
@@ -156,4 +174,18 @@ __all__ = [
     "determiner_manoeuvres_cible_detaillee",
     "sectionneurs_sous_charge_par_manoeuvre",
     "ouvrages_simultanement_hors_tension",
+    # Conformité « art de la manœuvre » (R20-R25)
+    "FamilleOrgane",
+    "Consequence",
+    "EtatDepart",
+    "ManoeuvreClassee",
+    "TransitionDepart",
+    "Temporisation",
+    "ConformiteSequence",
+    "familles_organes",
+    "classifier_manoeuvres",
+    "verifier_matrice_autorisation",
+    "suivre_etats_departs",
+    "calculer_temporisations",
+    "analyser_conformite",
 ]

--- a/expert_op4grid_recommender/manoeuvre/algo/conformite.py
+++ b/expert_op4grid_recommender/manoeuvre/algo/conformite.py
@@ -1,0 +1,714 @@
+"""
+manoeuvre/algo/conformite.py — Vérificateur de conformité « art de la manœuvre ».
+
+Enrichit la vérification des séquences au-delà de la seule règle du sectionneur
+(``verification.py``) en portant les référentiels d'exploitation RTE (CCRT
+C3-3, consigne ACT 104, méthode experte « fiche de manœuvres d'un CCO ») :
+
+1. **Classification des conséquences** (R20) — chaque manœuvre est classée par
+   rejeu sur le graphe du poste : manœuvre hors tension, ouverture/fermeture de
+   boucle, préparer/désaiguiller, mise sous tension (à vide), mise hors
+   tension, établissement/coupure de transit, changement du nombre de nœuds.
+2. **Matrice d'autorisation par type d'organe** (R21) — un sectionneur (SA,
+   SS, SL) ne peut ni établir ni couper un transit, ni changer le nombre de
+   nœuds électriques du poste ; seuls le DJ et l'interrupteur le peuvent.
+   Généralise la règle « sectionneur hors charge » (R18).
+3. **Essai de barre** (R22, avertissement) — la remise sous tension d'une
+   section de barre morte doit se faire par un **disjoncteur** (de préférence
+   de ligne, sinon de couplage, en dernier recours de transformateur), pas par
+   la simple fermeture d'un sectionneur.
+4. **Suivi de l'état des départs** (R23) — machine à états (désaiguillé /
+   préparé / préparé-DA / en service / en service-DA / états « bizarres »)
+   avec table des transitions permises, bizarres ou **interdites**.
+5. **Temporisations ACT 104** (R24) — 10 s après chaque manœuvre de
+   sectionneur ; 60 s minimum entre deux fermetures d'un même disjoncteur
+   (regonflage après cycle O-F-O).
+6. **Contrôles attendus** (R25) — pour chaque manœuvre, les télésignalisations
+   (TS) et télémesures (TM) SCADA à contrôler (TM I à 0, TS manque tension,
+   conformité au calcul de répartition, nombre de nœuds…).
+
+Le point d'entrée est :func:`analyser_conformite` ; son résultat
+(:class:`ConformiteSequence`) est attaché par ``plugins.pipeline.
+verifier_sequence`` au champ ``ResultatManoeuvres.conformite``. Les
+**violations** et **avertissements** produits ici sont volontairement séparés
+des ``ecarts`` / ``alertes`` historiques (compatibilité des goldens) : ils
+constituent un étage de vérification additionnel, pas un remplacement.
+
+Limites (documentées dans ``docs/manoeuvre/art_de_la_manoeuvre.md``) :
+
+- **Présomption de tension** : l'analyse est mono-poste (un voltage level).
+  Les équipements « feeders » (ligne, transformateur, groupe, batterie, HVDC)
+  sont présumés pouvoir tenir leur composante sous tension ; les charges et
+  moyens de compensation sont passifs. L'état de l'extrémité distante d'une
+  ligne est inconnu : une coupure de transit peut en réalité être une simple
+  mise hors tension d'un ouvrage déjà à vide (classification conservative).
+- Pas de calcul électrique : ni transit (validation par calcul de répartition,
+  R26), ni Icc — hors de portée du graphe seul.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Optional
+
+import networkx as nx
+
+from ..models import EquipmentType, SwitchKind
+from ..topologie import PosteTopologique
+from .results import Manoeuvre
+from .graph_ops import (
+    _inter_sjb_couplers,
+    _is_open,
+    _set_switch,
+    _switch_edge_index,
+    _wired_sjbs,
+)
+
+
+# ---------------------------------------------------------------------------
+# Vocabulaire : familles d'organes, conséquences, états de départ
+# ---------------------------------------------------------------------------
+
+class FamilleOrgane(Enum):
+    """Famille d'organe de coupure au sens du CCRT (matrice d'autorisation)."""
+    DJ = "DJ"                              # disjoncteur
+    INTERRUPTEUR = "INTERRUPTEUR"          # interrupteur / interrupteur-sectionneur
+    SA_AIGUILLAGE = "SA_AIGUILLAGE"        # sectionneur d'aiguillage barre (SAB)
+    SA_COUPLAGE = "SA_COUPLAGE"            # sectionneur d'une travée de couplage
+    SS_SECTIONNEMENT = "SS_SECTIONNEMENT"  # sectionneur de sectionnement de barre
+    SL_AUTRE = "SL_AUTRE"                  # sectionneur de ligne / autre sectionneur
+    INCONNU = "INCONNU"                    # organe absent du poste
+
+
+#: Familles soumises à la règle du sectionneur (manœuvre hors charge uniquement).
+FAMILLES_SECTIONNEUR = frozenset({
+    FamilleOrgane.SA_AIGUILLAGE,
+    FamilleOrgane.SA_COUPLAGE,
+    FamilleOrgane.SS_SECTIONNEMENT,
+    FamilleOrgane.SL_AUTRE,
+})
+
+
+class Consequence(Enum):
+    """Conséquence élémentaire d'une manœuvre (référentiel CCRT C3-3).
+
+    Une manœuvre peut porter **plusieurs** conséquences simultanées (ex.
+    l'ouverture du DJ d'un départ de charge coupe un transit **et** met la
+    charge hors tension).
+    """
+    SANS_EFFET = "sans_effet"                    # l'organe est déjà dans l'état visé
+    MANOEUVRE_HU = "manoeuvre_hors_tension"      # aucune des deux parties n'est sous tension
+    OUVERTURE_BOUCLE = "ouverture_boucle"        # les deux côtés restent reliés par ailleurs
+    FERMETURE_BOUCLE = "fermeture_boucle"        # les deux côtés étaient déjà reliés
+    PREPARER = "preparer"                        # fermeture d'un SA, jonction de cellule morte
+    DESAIGUILLER = "desaiguiller"                # ouverture d'un SA, jonction de cellule morte
+    MISE_SOUS_TENSION = "mise_sous_tension"      # une partie morte est énergisée (à vide)
+    MISE_HORS_TENSION = "mise_hors_tension"      # une partie devient morte
+    ETABLIR_TRANSIT = "etablir_transit"          # deux parties actives sont reliées
+    COUPER_TRANSIT = "couper_transit"            # deux parties actives sont séparées
+    CHANGER_NB_NOEUDS = "changer_nb_noeuds"      # fusion/scission de nœuds électriques à barres
+
+
+#: Conséquences qu'un **sectionneur** n'a pas le droit de porter (matrice CCRT :
+#: « Établir un transit / Couper un transit / Changer le nombre de nœuds » = Non
+#: pour SRB, SAB, SS ; oui pour DJ, INTER).
+CONSEQUENCES_INTERDITES_SECTIONNEUR = frozenset({
+    Consequence.ETABLIR_TRANSIT,
+    Consequence.COUPER_TRANSIT,
+    Consequence.CHANGER_NB_NOEUDS,
+})
+
+
+#: Équipements présumés capables de **tenir une composante sous tension**
+#: (feeders vers le reste du réseau ou sources). Les charges et moyens de
+#: compensation sont passifs : une composante qui n'en contient aucun est morte.
+SOURCES_TENSION = frozenset({
+    EquipmentType.LINE_SIDE1,
+    EquipmentType.LINE_SIDE2,
+    EquipmentType.TRANSFORMER_SIDE1,
+    EquipmentType.TRANSFORMER_SIDE2,
+    EquipmentType.DANGLING_LINE,
+    EquipmentType.GENERATOR,
+    EquipmentType.BATTERY,
+    EquipmentType.HVDC_CONVERTER_STATION,
+})
+
+
+class EtatDepart(Enum):
+    """État d'un départ au sens CCO : position des SA (aiguillage) × OC ligne.
+
+    Nommage de la méthode experte « fiche de manœuvres d'un CCO » :
+    ``PREPARE_DA`` y est aussi appelé « bizarre DA ouvert » dans la table des
+    transitions (≥ 2 SA fermés, OC ligne ouvert).
+    """
+    DESAIGUILLE = "hors tension désaiguillé"     # 0 SA fermé, OC ligne ouvert
+    PREPARE = "préparé"                          # 1 SA fermé, OC ligne ouvert
+    PREPARE_DA = "préparé - DA"                  # ≥2 SA fermés, OC ligne ouvert
+    EN_SERVICE = "en service"                    # 1 SA fermé, OC ligne fermé
+    EN_SERVICE_DA = "en service - DA"            # ≥2 SA fermés, OC ligne fermé
+    NON_PREPARE_FERME = "bizarre non préparé fermé"  # 0 SA fermé, OC ligne fermé
+
+
+# Table des transitions d'état d'un départ (méthode experte CCO, « Suivi de
+# l'état des départs et des ouvrages »). Valeur : (interdite ?, avertissement,
+# contrôles attendus). Une transition observée absente de la table est signalée
+# « étrange » (avertissement).
+_TRANSITIONS_DEPART: dict[tuple[EtatDepart, EtatDepart],
+                          tuple[bool, Optional[str], list[str]]] = {
+    (EtatDepart.DESAIGUILLE, EtatDepart.PREPARE): (False, None, []),
+    (EtatDepart.DESAIGUILLE, EtatDepart.NON_PREPARE_FERME): (
+        False, "fermeture de l'OC ligne d'un départ non préparé "
+               "(bizarre sauf manœuvre programmée)", []),
+    (EtatDepart.PREPARE, EtatDepart.DESAIGUILLE): (False, None, []),
+    (EtatDepart.PREPARE, EtatDepart.EN_SERVICE): (
+        False, None,
+        ["TM I/P/Q conformes au calcul de répartition (établissement du transit)",
+         "vérifier les puissances de court-circuit (Scc) si dépassement possible"]),
+    (EtatDepart.PREPARE, EtatDepart.PREPARE_DA): (
+        False, "double aiguillage sous OC ligne ouvert (bizarre)",
+        ["contrôle du nombre de nœuds du poste avant/après"]),
+    (EtatDepart.PREPARE_DA, EtatDepart.PREPARE): (False, None, []),
+    (EtatDepart.PREPARE_DA, EtatDepart.EN_SERVICE_DA): (
+        False, None,
+        ["TM I/P/Q conformes au calcul de répartition (établissement du transit)",
+         "vérifier les puissances de court-circuit (Scc) si dépassement possible"]),
+    (EtatDepart.EN_SERVICE, EtatDepart.PREPARE): (
+        False, None,
+        ["TM I passe à 0 ; liste des éléments qui passent hors tension le cas échéant"]),
+    (EtatDepart.EN_SERVICE, EtatDepart.EN_SERVICE_DA): (
+        False, None, ["contrôle du nombre de nœuds du poste avant/après"]),
+    (EtatDepart.EN_SERVICE, EtatDepart.NON_PREPARE_FERME): (
+        True, "ouverture du dernier SA d'un départ en service : manœuvre en "
+              "charge interdite", []),
+    (EtatDepart.EN_SERVICE_DA, EtatDepart.EN_SERVICE): (
+        False, None, ["contrôle du nombre de nœuds du poste avant/après"]),
+    (EtatDepart.EN_SERVICE_DA, EtatDepart.PREPARE_DA): (
+        False, None,
+        ["TM I passe à 0 ; liste des éléments qui passent hors tension le cas échéant"]),
+    (EtatDepart.NON_PREPARE_FERME, EtatDepart.DESAIGUILLE): (
+        False, "ouverture de l'OC ligne d'un départ non préparé "
+               "(bizarre sauf manœuvre programmée)", []),
+    (EtatDepart.NON_PREPARE_FERME, EtatDepart.EN_SERVICE): (
+        True, "fermeture d'un SA sur un départ dont l'OC ligne est fermé : le "
+              "sectionneur établirait le courant — interdit", []),
+}
+
+
+# ---------------------------------------------------------------------------
+# Structures de résultat
+# ---------------------------------------------------------------------------
+
+@dataclass
+class ManoeuvreClassee:
+    """Classification d'une manœuvre : famille d'organe + conséquences + contrôles."""
+    index: int                       # position dans la séquence (0-based)
+    switch_id: str
+    action: str                      # "OPEN" | "CLOSE"
+    famille: FamilleOrgane
+    consequences: frozenset[Consequence]
+    #: Sections de barre (busbar_section_id) mises sous/hors tension par la manœuvre.
+    sjb_impactees: tuple[str, ...] = ()
+    controles: list[str] = field(default_factory=list)
+    commentaire: str = ""
+
+    def __repr__(self) -> str:  # pragma: no cover - debug
+        cons = ",".join(sorted(c.value for c in self.consequences))
+        return (f"{self.index:2d}. {self.action:5s} {self.switch_id} "
+                f"[{self.famille.value}] -> {cons}")
+
+
+@dataclass
+class TransitionDepart:
+    """Changement d'état d'un départ provoqué par une manœuvre."""
+    index: int                       # manœuvre déclenchante
+    equipment_id: str
+    avant: EtatDepart
+    apres: EtatDepart
+    interdite: bool = False
+    avertissement: Optional[str] = None
+    controles: list[str] = field(default_factory=list)
+
+
+@dataclass
+class Temporisation:
+    """Temps d'attente à insérer dans la séquence (consigne ACT 104)."""
+    index: int                       # manœuvre concernée
+    avant: bool                      # True : attendre avant ; False : après
+    duree_s: int
+    motif: str
+
+
+@dataclass
+class ConformiteSequence:
+    """Résultat de l'analyse de conformité « art de la manœuvre » d'une séquence.
+
+    ``violations`` : règles d'exploitation enfreintes (bloquantes au sens du
+    CCRT — matrice d'autorisation des organes, transitions interdites).
+    ``avertissements`` : bonnes pratiques non bloquantes (essai de barre par
+    disjoncteur, transitions « bizarres »…).
+    """
+    voltage_level_id: str
+    classees: list[ManoeuvreClassee] = field(default_factory=list)
+    transitions: list[TransitionDepart] = field(default_factory=list)
+    temporisations: list[Temporisation] = field(default_factory=list)
+    violations: list[str] = field(default_factory=list)
+    avertissements: list[str] = field(default_factory=list)
+
+    @property
+    def is_conforme(self) -> bool:
+        """True si aucune violation (les avertissements n'empêchent pas la conformité)."""
+        return not self.violations
+
+    @property
+    def duree_temporisations_s(self) -> int:
+        return sum(t.duree_s for t in self.temporisations)
+
+    def resume(self) -> str:
+        lines = [
+            f"Conformité art de la manœuvre '{self.voltage_level_id}' : "
+            f"{'CONFORME' if self.is_conforme else f'{len(self.violations)} violation(s)'}"
+            f" · {len(self.avertissements)} avertissement(s)"
+            f" · {self.duree_temporisations_s} s de temporisations"
+        ]
+        for c in self.classees:
+            cons = ", ".join(sorted(x.value for x in c.consequences))
+            lines.append(f"  {c.index:2d}. {c.action:5s} {c.switch_id} "
+                         f"[{c.famille.value}] -> {cons}")
+            for ctl in c.controles:
+                lines.append(f"        contrôle : {ctl}")
+        for v in self.violations:
+            lines.append(f"  ✗ {v}")
+        for a in self.avertissements:
+            lines.append(f"  ⚠ {a}")
+        return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Familles d'organes
+# ---------------------------------------------------------------------------
+
+def familles_organes(poste: PosteTopologique) -> dict[str, FamilleOrgane]:
+    """Classe chaque organe du poste dans sa famille CCRT.
+
+    Priorité : liaisons inter-SJB (sectionnements ``SS``, organes de travée de
+    couplage ``DJ``/``SA_COUPLAGE``) puis cellules de départ (DJ, interrupteur,
+    ``SA_AIGUILLAGE`` = sectionneur dont une borne est une SJB, ``SL_AUTRE``
+    sinon), enfin repli sur le ``SwitchKind`` brut.
+    """
+    familles: dict[str, FamilleOrgane] = {}
+    bb_nodes = set(poste.tronconnement.barre_par_busbar)
+
+    # Repli générique par nature de l'organe.
+    for _u, _v, d in poste.graph.edges(data=True):
+        sid = d.get("switch_id")
+        if sid is None:
+            continue
+        kind = d.get("kind")
+        if kind == SwitchKind.BREAKER:
+            familles[sid] = FamilleOrgane.DJ
+        elif kind == SwitchKind.LOAD_BREAK_SWITCH:
+            familles[sid] = FamilleOrgane.INTERRUPTEUR
+        elif kind == SwitchKind.DISCONNECTOR:
+            familles[sid] = FamilleOrgane.SL_AUTRE
+
+    # Cellules de départ : SA d'aiguillage = sectionneur touchant une SJB.
+    for cell in poste.cellules.cellules_depart:
+        for sw in cell.switches:
+            if sw.kind == SwitchKind.DISCONNECTOR and (
+                    sw.node1 in bb_nodes or sw.node2 in bb_nodes):
+                familles[sw.switch_id] = FamilleOrgane.SA_AIGUILLAGE
+
+    # Liaisons inter-SJB : priment (un organe de travée de couplage ou un
+    # sectionnement n'est pas un organe de départ).
+    for cp in _inter_sjb_couplers(poste):
+        if cp.is_sectionnement:
+            for sid in cp.switch_ids:
+                familles[sid] = FamilleOrgane.SS_SECTIONNEMENT
+        else:
+            for sid in cp.switch_ids:
+                if sid not in cp.breaker_ids:
+                    familles[sid] = FamilleOrgane.SA_COUPLAGE
+    return familles
+
+
+# ---------------------------------------------------------------------------
+# Classification des conséquences (rejeu)
+# ---------------------------------------------------------------------------
+
+def _graphe_live(G: nx.Graph) -> nx.Graph:
+    """Sous-graphe des liaisons fermées (connectivité électrique courante)."""
+    H = nx.Graph()
+    H.add_nodes_from(G.nodes())
+    H.add_edges_from((u, v) for u, v, d in G.edges(data=True)
+                     if not d.get("open", False))
+    return H
+
+
+def _profil_composante(G: nx.Graph, comp: set) -> tuple[bool, bool, list[str]]:
+    """(contient une source de tension ?, contient un équipement ?, SJB de la
+    composante — ``busbar_section_id`` triés)."""
+    source = False
+    equip = False
+    sjbs: list[str] = []
+    for n in comp:
+        d = G.nodes[n]
+        if d.get("equipment_id"):
+            equip = True
+            if d.get("equipment_type") in SOURCES_TENSION:
+                source = True
+        bb = d.get("busbar_section_id")
+        if bb:
+            sjbs.append(bb)
+    return source, equip, sorted(sjbs)
+
+
+def classifier_manoeuvres(
+    poste: PosteTopologique, manoeuvres: list[Manoeuvre]
+) -> list[ManoeuvreClassee]:
+    """Classifie chaque manœuvre de la séquence par **rejeu** sur une copie du
+    graphe du poste (jamais muté) : famille d'organe, conséquences élémentaires
+    (CCRT C3-3), sections de barre impactées, contrôles SCADA attendus (R25).
+    """
+    familles = familles_organes(poste)
+    G = poste.graph.copy()
+    idx = _switch_edge_index(G)
+    out: list[ManoeuvreClassee] = []
+
+    for i, m in enumerate(manoeuvres):
+        edge = idx.get(m.switch_id)
+        if edge is None:
+            out.append(ManoeuvreClassee(
+                i, m.switch_id, m.action, FamilleOrgane.INCONNU,
+                frozenset({Consequence.SANS_EFFET}),
+                commentaire="organe inconnu du poste"))
+            continue
+
+        famille = familles.get(m.switch_id, FamilleOrgane.INCONNU)
+        u, v = edge
+        veut_ouvrir = (m.action == "OPEN")
+        deja = (_is_open(G, m.switch_id) == veut_ouvrir)
+        if deja:
+            out.append(ManoeuvreClassee(
+                i, m.switch_id, m.action, famille,
+                frozenset({Consequence.SANS_EFFET})))
+            continue
+
+        cons: set[Consequence] = set()
+        sjb_impactees: tuple[str, ...] = ()
+
+        if veut_ouvrir:
+            # Connectivité APRÈS ouverture : l'organe retiré du graphe live.
+            _set_switch(G, m.switch_id, True)
+            H = _graphe_live(G)
+            if nx.has_path(H, u, v):
+                comp = nx.node_connected_component(H, u)
+                source, _equip, _ = _profil_composante(G, comp)
+                cons.add(Consequence.OUVERTURE_BOUCLE if source
+                         else Consequence.MANOEUVRE_HU)
+            else:
+                cu = nx.node_connected_component(H, u)
+                cv = nx.node_connected_component(H, v)
+                src_u, eq_u, sjb_u = _profil_composante(G, cu)
+                src_v, eq_v, sjb_v = _profil_composante(G, cv)
+                if not src_u and not src_v:
+                    cons.add(Consequence.MANOEUVRE_HU)
+                elif src_u and src_v:
+                    cons.add(Consequence.COUPER_TRANSIT)
+                    if sjb_u and sjb_v:
+                        cons.add(Consequence.CHANGER_NB_NOEUDS)
+                else:
+                    # Un seul côté reste sous tension ; l'autre devient mort.
+                    eq_mort, sjb_mort = (eq_u, sjb_u) if not src_u else (eq_v, sjb_v)
+                    if eq_mort:
+                        cons.update({Consequence.COUPER_TRANSIT,
+                                     Consequence.MISE_HORS_TENSION})
+                    elif sjb_mort:
+                        cons.add(Consequence.MISE_HORS_TENSION)
+                        sjb_impactees = tuple(sjb_mort)
+                    elif famille == FamilleOrgane.SA_AIGUILLAGE:
+                        cons.add(Consequence.DESAIGUILLER)
+                    else:
+                        cons.add(Consequence.MISE_HORS_TENSION)
+        else:
+            # Connectivité AVANT fermeture (l'organe est encore ouvert).
+            H = _graphe_live(G)
+            if nx.has_path(H, u, v):
+                comp = nx.node_connected_component(H, u)
+                source, _equip, _ = _profil_composante(G, comp)
+                cons.add(Consequence.FERMETURE_BOUCLE if source
+                         else Consequence.MANOEUVRE_HU)
+            else:
+                cu = nx.node_connected_component(H, u)
+                cv = nx.node_connected_component(H, v)
+                src_u, eq_u, sjb_u = _profil_composante(G, cu)
+                src_v, eq_v, sjb_v = _profil_composante(G, cv)
+                if not src_u and not src_v:
+                    cons.add(Consequence.PREPARER
+                             if famille == FamilleOrgane.SA_AIGUILLAGE
+                             else Consequence.MANOEUVRE_HU)
+                elif src_u and src_v:
+                    cons.add(Consequence.ETABLIR_TRANSIT)
+                    if sjb_u and sjb_v:
+                        cons.add(Consequence.CHANGER_NB_NOEUDS)
+                else:
+                    eq_mort, sjb_mort = (eq_u, sjb_u) if not src_u else (eq_v, sjb_v)
+                    if eq_mort:
+                        cons.update({Consequence.MISE_SOUS_TENSION,
+                                     Consequence.ETABLIR_TRANSIT})
+                    elif sjb_mort:
+                        cons.add(Consequence.MISE_SOUS_TENSION)
+                        sjb_impactees = tuple(sjb_mort)
+                    elif famille == FamilleOrgane.SA_AIGUILLAGE:
+                        cons.add(Consequence.PREPARER)
+                    else:
+                        cons.add(Consequence.MISE_SOUS_TENSION)
+            _set_switch(G, m.switch_id, False)
+
+        mc = ManoeuvreClassee(i, m.switch_id, m.action, famille,
+                              frozenset(cons), sjb_impactees)
+        mc.controles = _controles_pour(mc)
+        out.append(mc)
+    return out
+
+
+def _controles_pour(mc: ManoeuvreClassee) -> list[str]:
+    """Contrôles SCADA attendus pour une manœuvre classée (R25 — tableau
+    « Contrôle lors des manœuvres » : TS manque tension, TM I, calcul de
+    répartition, nombre de nœuds)."""
+    ctl: list[str] = []
+    cons = mc.consequences
+    if Consequence.COUPER_TRANSIT in cons:
+        ctl.append("TM I passe à 0 sur le départ")
+    if Consequence.MISE_HORS_TENSION in cons:
+        cible = (" sur la/les section(s) " + ", ".join(mc.sjb_impactees)
+                 if mc.sjb_impactees else "")
+        ctl.append("TS absence de tension apparaît (si la TS existe)" + cible)
+    if Consequence.MISE_SOUS_TENSION in cons:
+        cible = (" sur la/les section(s) " + ", ".join(mc.sjb_impactees)
+                 if mc.sjb_impactees else "")
+        ctl.append("TS absence de tension disparaît (si la TS existe)" + cible)
+    if Consequence.ETABLIR_TRANSIT in cons:
+        ctl.append("TM I/P/Q prennent les valeurs du calcul de répartition "
+                   "(peuvent être proches de 0)")
+        ctl.append("si dépassement d'Icc : vérifier l'absence de TS PRESENCE "
+                   "dans les postes concernés")
+    if Consequence.CHANGER_NB_NOEUDS in cons:
+        ctl.append("contrôle du nombre de nœuds électriques du poste avant/après")
+    return ctl
+
+
+# ---------------------------------------------------------------------------
+# Matrice d'autorisation + essai de barre
+# ---------------------------------------------------------------------------
+
+def verifier_matrice_autorisation(
+    classees: list[ManoeuvreClassee],
+) -> tuple[list[str], list[str]]:
+    """Confronte chaque manœuvre classée à la **matrice d'autorisation** CCRT
+    (conséquence × famille d'organe) et à la bonne pratique de l'**essai de
+    barre** (R22).
+
+    Returns
+    -------
+    (violations, avertissements)
+        - violation : un sectionneur porte une conséquence interdite (établir /
+          couper un transit, changer le nombre de nœuds) — présomption de
+          tension sur les feeders, cf. limites du module ;
+        - avertissement : remise sous tension d'une section morte par un
+          sectionneur (préférer un essai par disjoncteur) ou par le disjoncteur
+          d'un départ **transformateur** (préférer ligne, sinon couplage).
+    """
+    violations: list[str] = []
+    avertissements: list[str] = []
+    for mc in classees:
+        interdites = mc.consequences & CONSEQUENCES_INTERDITES_SECTIONNEUR
+        if mc.famille in FAMILLES_SECTIONNEUR and interdites:
+            noms = ", ".join(sorted(c.value for c in interdites))
+            violations.append(
+                f"manœuvre {mc.index + 1} ({mc.action} {mc.switch_id}) : un "
+                f"sectionneur [{mc.famille.value}] ne peut pas « {noms} » "
+                "(matrice CCRT : réservé au disjoncteur/interrupteur)")
+        if (Consequence.MISE_SOUS_TENSION in mc.consequences
+                and mc.sjb_impactees
+                and mc.famille in FAMILLES_SECTIONNEUR):
+            avertissements.append(
+                f"manœuvre {mc.index + 1} ({mc.action} {mc.switch_id}) : remise "
+                f"sous tension de section(s) {', '.join(mc.sjb_impactees)} par "
+                "un sectionneur — réaliser d'abord un essai de barre par un "
+                "disjoncteur (de préférence de ligne, sinon de couplage, en "
+                "dernier recours de transformateur) [R22]")
+    return violations, avertissements
+
+
+# ---------------------------------------------------------------------------
+# Machine à états des départs (R23)
+# ---------------------------------------------------------------------------
+
+def _etat_depart(nb_sa_fermes: int, oc_ligne_tous_fermes: bool) -> EtatDepart:
+    """État CCO d'un départ à partir du câblage (nb de barres aiguillées ×
+    position des OC ligne)."""
+    if not oc_ligne_tous_fermes:
+        if nb_sa_fermes == 0:
+            return EtatDepart.DESAIGUILLE
+        if nb_sa_fermes == 1:
+            return EtatDepart.PREPARE
+        return EtatDepart.PREPARE_DA
+    if nb_sa_fermes == 0:
+        return EtatDepart.NON_PREPARE_FERME
+    if nb_sa_fermes == 1:
+        return EtatDepart.EN_SERVICE
+    return EtatDepart.EN_SERVICE_DA
+
+
+def suivre_etats_departs(
+    poste: PosteTopologique, manoeuvres: list[Manoeuvre]
+) -> list[TransitionDepart]:
+    """Rejoue la séquence et suit l'**état de chaque départ** (machine à états
+    CCO). Chaque changement d'état est confronté à la table des transitions :
+    transitions interdites (manœuvre en charge), bizarres (avertissement) ou
+    étranges (hors table).
+
+    Les cellules sans OC ligne propre (ré-aiguillage direct) sont hors du
+    modèle d'état CCO et ignorées. L'état d'un **ouvrage** complet (en service /
+    sous tension à vide / hors tension) exige les départs de *toutes* ses
+    extrémités : hors de portée mono-poste, non traité ici.
+    """
+    cells = poste.cellules
+    suivis = []  # (equipment_id, oc_ligne_ids, cellule)
+    for c in cells.cellules_depart:
+        oc_ligne = [s.switch_id for s in c.switches
+                    if s.kind in (SwitchKind.BREAKER, SwitchKind.LOAD_BREAK_SWITCH)]
+        if oc_ligne:
+            suivis.append((c.equipment_id, oc_ligne))
+    switch_vers_departs: dict[str, set[str]] = {}
+    for c in cells.cellules_depart:
+        for s in c.switches:
+            switch_vers_departs.setdefault(s.switch_id, set()).add(c.equipment_id)
+
+    G = poste.graph.copy()
+
+    def etat(eq_id: str, oc_ligne: list[str]) -> EtatDepart:
+        nb_sa = len(_wired_sjbs(G, cells, eq_id))
+        tous_fermes = all(not _is_open(G, sid) for sid in oc_ligne)
+        return _etat_depart(nb_sa, tous_fermes)
+
+    courant = {eq: etat(eq, oc) for eq, oc in suivis}
+    oc_par_depart = dict(suivis)
+
+    transitions: list[TransitionDepart] = []
+    for i, m in enumerate(manoeuvres):
+        _set_switch(G, m.switch_id, m.action == "OPEN")
+        for eq in switch_vers_departs.get(m.switch_id, ()):
+            if eq not in courant:
+                continue
+            nouveau = etat(eq, oc_par_depart[eq])
+            avant = courant[eq]
+            if nouveau == avant:
+                continue
+            courant[eq] = nouveau
+            regle = _TRANSITIONS_DEPART.get((avant, nouveau))
+            if regle is None:
+                transitions.append(TransitionDepart(
+                    i, eq, avant, nouveau, interdite=False,
+                    avertissement=f"transition étrange : « {avant.value} » → "
+                                  f"« {nouveau.value} » (hors table CCO)"))
+            else:
+                interdite, avert, controles = regle
+                transitions.append(TransitionDepart(
+                    i, eq, avant, nouveau, interdite=interdite,
+                    avertissement=avert, controles=list(controles)))
+    return transitions
+
+
+# ---------------------------------------------------------------------------
+# Temporisations ACT 104 (R24)
+# ---------------------------------------------------------------------------
+
+#: Attente après toute manœuvre de sectionneur (mise à jour des schémas fantômes).
+TEMPO_SECTIONNEUR_S = 10
+#: Délai minimal entre deux fermetures d'un même DJ (regonflage après cycle O-F-O).
+TEMPO_REGONFLAGE_DJ_S = 60
+
+
+def calculer_temporisations(
+    poste: PosteTopologique, manoeuvres: list[Manoeuvre]
+) -> list[Temporisation]:
+    """Temporisations à insérer dans la séquence (consigne ACT 104, sous-ensemble
+    calculable depuis le seul graphe) :
+
+    - **10 s après chaque manœuvre de sectionneur** ;
+    - **60 s minimum entre deux fermetures d'un même disjoncteur** (regonflage
+      après un cycle ouverture-fermeture) — le temps déjà écoulé en
+      temporisations intermédiaires est décompté, comme dans la méthode CCO.
+
+    Non calculables ici (contexte hors graphe, cf. R24 de la doc) : 2 min de
+    passage de prises des régleurs (mise en service de transformateur neuf ou
+    longuement consigné), 2 min entre manœuvres de sectionneurs d'un départ
+    PSEM, 1 min entre mise hors tension et remise sous tension à vide d'une
+    liaison 225/400 kV.
+    """
+    idx = _switch_edge_index(poste.graph)
+    out: list[Temporisation] = []
+    horloge = 0.0                       # temps simulé = somme des attentes
+    derniere_fermeture: dict[str, float] = {}
+
+    for i, m in enumerate(manoeuvres):
+        edge = idx.get(m.switch_id)
+        kind = poste.graph.edges[edge].get("kind") if edge else None
+
+        if kind == SwitchKind.BREAKER and m.action == "CLOSE":
+            prec = derniere_fermeture.get(m.switch_id)
+            if prec is not None and horloge - prec < TEMPO_REGONFLAGE_DJ_S:
+                attente = int(TEMPO_REGONFLAGE_DJ_S - (horloge - prec))
+                out.append(Temporisation(
+                    i, avant=True, duree_s=attente,
+                    motif=f"regonflage du DJ {m.switch_id} : {TEMPO_REGONFLAGE_DJ_S} s "
+                          "minimum entre deux fermetures (ACT 104)"))
+                horloge += attente
+            derniere_fermeture[m.switch_id] = horloge
+
+        if kind == SwitchKind.DISCONNECTOR:
+            out.append(Temporisation(
+                i, avant=False, duree_s=TEMPO_SECTIONNEUR_S,
+                motif="temporisation sectionneur : mise à jour des schémas "
+                      "fantômes (ACT 104)"))
+            horloge += TEMPO_SECTIONNEUR_S
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Point d'entrée
+# ---------------------------------------------------------------------------
+
+def analyser_conformite(
+    poste: PosteTopologique, manoeuvres: list[Manoeuvre]
+) -> ConformiteSequence:
+    """Analyse de conformité « art de la manœuvre » d'une séquence complète :
+    classification des conséquences (R20), matrice d'autorisation (R21), essai
+    de barre (R22), suivi d'état des départs (R23), temporisations ACT 104
+    (R24) et contrôles SCADA attendus (R25).
+
+    Ne mute ni ``poste`` ni ``manoeuvres``. Complémentaire (et non redondant)
+    des vérificateurs historiques : la règle du sectionneur hors charge (R18)
+    reste portée par ``verification.py`` dans ``ecarts`` ; les verdicts produits
+    ici alimentent le champ ``ResultatManoeuvres.conformite``.
+    """
+    classees = classifier_manoeuvres(poste, manoeuvres)
+    violations, avertissements = verifier_matrice_autorisation(classees)
+    transitions = suivre_etats_departs(poste, manoeuvres)
+    for t in transitions:
+        prefixe = (f"manœuvre {t.index + 1} — départ {t.equipment_id} : "
+                   f"« {t.avant.value} » → « {t.apres.value} »")
+        if t.interdite:
+            violations.append(f"{prefixe} : {t.avertissement}")
+        elif t.avertissement:
+            avertissements.append(f"{prefixe} : {t.avertissement}")
+    temporisations = calculer_temporisations(poste, manoeuvres)
+    return ConformiteSequence(
+        voltage_level_id=poste.voltage_level_id,
+        classees=classees,
+        transitions=transitions,
+        temporisations=temporisations,
+        violations=violations,
+        avertissements=avertissements,
+    )

--- a/expert_op4grid_recommender/manoeuvre/algo/results.py
+++ b/expert_op4grid_recommender/manoeuvre/algo/results.py
@@ -4,9 +4,12 @@ manoeuvre/algo/results.py — Structures de sortie de l'algorithme (manœuvre un
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Literal, Optional
+from typing import TYPE_CHECKING, Literal, Optional
 
 from ..topologie import TopologieNodale
+
+if TYPE_CHECKING:  # import différé (conformite dépend de results)
+    from .conformite import ConformiteSequence
 
 
 @dataclass
@@ -44,6 +47,12 @@ class ResultatManoeuvres:
     # Dégradation gracieuse : départs des nœuds cibles **non réalisables** sur ce
     # poste (cible partiellement atteinte, à compléter manuellement par l'opérateur).
     noeuds_non_realisables: list[list[str]] = field(default_factory=list)
+    # Analyse de conformité « art de la manœuvre » (classification des
+    # conséquences, matrice d'autorisation CCRT, états des départs,
+    # temporisations ACT 104, contrôles attendus). Renseignée par
+    # ``plugins.pipeline.verifier_sequence`` ; indépendante d'``ecarts`` /
+    # ``alertes`` (compatibilité des goldens).
+    conformite: Optional["ConformiteSequence"] = None
 
     @property
     def nb_manoeuvres(self) -> int:

--- a/expert_op4grid_recommender/manoeuvre/algo/sequencing.py
+++ b/expert_op4grid_recommender/manoeuvre/algo/sequencing.py
@@ -815,7 +815,7 @@ def determiner_manoeuvres_avec_sections(
     res.message = (
         "Topologie cible atteinte et vérifiée."
         if res.is_verified
-        else f"Cible non atteinte (obtenu {topo_obtenue.nb_noeuds} nœuds, "
+        else f"Cible non atteinte (obtenu {topo_obtenue.nb_noeuds_reels} nœuds, "
              f"visé {topo_cible.nb_noeuds})."
     )
     return res
@@ -982,6 +982,6 @@ def determiner_manoeuvres_par_connectivite(poste, placement, topo_cible):
         "Topologie cible atteinte (réalisateur connectivité)."
         if res.is_verified
         else f"Cible non atteinte (connectivité) : obtenu "
-             f"{res.topo_obtenue.nb_noeuds} nœud(s), visé {topo_cible.nb_noeuds}."
+             f"{res.topo_obtenue.nb_noeuds_reels} nœud(s), visé {topo_cible.nb_noeuds}."
     )
     return res

--- a/expert_op4grid_recommender/manoeuvre/algo/targets.py
+++ b/expert_op4grid_recommender/manoeuvre/algo/targets.py
@@ -266,7 +266,7 @@ def _aggressive_impl(
     if not res.is_verified:
         res.message = (
             "Topologie nodale cible non atteinte (mode agressif) : obtenu "
-            f"{res.topo_obtenue.nb_noeuds} nœud(s), visé {res.topo_cible.nb_noeuds}.")
+            f"{res.topo_obtenue.nb_noeuds_reels} nœud(s), visé {res.topo_cible.nb_noeuds}.")
     elif res.is_verified_detaillee:
         res.message = "Topologie détaillée cible atteinte et vérifiée (mode agressif)."
     else:
@@ -529,7 +529,7 @@ def _sequence_detaillee_multibarres(
         _consigner_non_realisables(res, non_realises)
         res.message = (
             "Topologie cible partiellement atteinte (poste multi-barres) : "
-            f"{res.topo_obtenue.nb_noeuds}/{topo_cible.nb_noeuds} nœuds atteints ; "
+            f"{res.topo_obtenue.nb_noeuds_reels}/{topo_cible.nb_noeuds} nœuds atteints ; "
             f"{len(non_realises)} nœud(s) à compléter manuellement — manœuvres sur "
             "les niveaux de barres supplémentaires (self/réactance) non gérées.")
     return res
@@ -629,7 +629,7 @@ def determiner_topo_complete_cible(
             core.message = (
                 "Topologie cible atteinte et vérifiée." if core.is_verified
                 else "La topologie obtenue ne correspond pas à la cible "
-                     f"(obtenu {core.topo_obtenue.nb_noeuds if core.topo_obtenue else 0} "
+                     f"(obtenu {core.topo_obtenue.nb_noeuds_reels if core.topo_obtenue else 0} "
                      f"nœud(s), visé {topo_cible.nb_noeuds})."
             )
         else:
@@ -821,7 +821,7 @@ def _determiner_manoeuvres_cible_detaillee_principal(
     elif not res.is_verified:
         res.message = (
             "Topologie nodale cible non atteinte : la topologie obtenue ne "
-            f"correspond pas à la cible (obtenu {res.topo_obtenue.nb_noeuds} "
+            f"correspond pas à la cible (obtenu {res.topo_obtenue.nb_noeuds_reels} "
             f"nœud(s), visé {topo_cible.nb_noeuds})."
         )
     elif res.is_verified_detaillee:

--- a/expert_op4grid_recommender/manoeuvre/plugins/pipeline.py
+++ b/expert_op4grid_recommender/manoeuvre/plugins/pipeline.py
@@ -24,6 +24,7 @@ import networkx as nx
 from ..topologie import PosteTopologique, TopologieNodale
 from ..algo.results import ResultatManoeuvres
 from ..algo.graph_ops import _set_switch, _switch_edge_index, _wired_busbar
+from ..algo.conformite import analyser_conformite
 from ..algo.verification import (
     _verifier_regles,
     ouvrages_simultanement_hors_tension,
@@ -80,7 +81,11 @@ def verifier_sequence(
       (si fournie), règles de sûreté du sectionneur ;
     - ``is_verified_detaillee`` (si ``cible`` est fournie) ;
     - ``alertes`` « un seul ouvrage hors tension à la fois » (sauf
-      ``mode="aggressive"``, qui dé-énergise en lot par construction).
+      ``mode="aggressive"``, qui dé-énergise en lot par construction) ;
+    - ``conformite`` : analyse « art de la manœuvre » (classification des
+      conséquences, matrice d'autorisation CCRT, états des départs,
+      temporisations ACT 104, contrôles SCADA attendus — R20-R25). Champ
+      **séparé** d'``ecarts``/``alertes`` (verdicts historiques inchangés).
 
     Mute ``res`` (et le retourne). Ne mute jamais ``poste``.
     """
@@ -113,6 +118,8 @@ def verifier_sequence(
 
     if mode != "aggressive":
         res.alertes = ouvrages_simultanement_hors_tension(poste, res.manoeuvres)
+
+    res.conformite = analyser_conformite(poste, res.manoeuvres)
 
     if not res.message:
         res.message = ("Topologie cible atteinte et vérifiée." if res.is_verified

--- a/expert_op4grid_recommender/manoeuvre/topologie.py
+++ b/expert_op4grid_recommender/manoeuvre/topologie.py
@@ -17,7 +17,7 @@ from typing import Optional
 import networkx as nx
 
 from .models import EquipmentType
-from .graph import equipment_nodes, get_node_attrs
+from .graph import busbar_nodes, equipment_nodes, get_node_attrs
 from .cellules import CellulesVL, detecter_cellules
 from .troncons import Tronconnement, construire_tronconnement
 
@@ -59,6 +59,11 @@ class TopologieNodale:
     voltage_level_id: str
     noeuds: dict[str, NoeudElectrique] = field(default_factory=dict)
     noeud_par_depart: dict[str, str] = field(default_factory=dict)
+    #: Noms des « nœuds » qui ne portent **aucune barre** : ce sont des ouvrages
+    #: **déconnectés** (composante 0-barre), pas de véritables nœuds électriques.
+    #: Renseigné par ``from_graph`` uniquement — une topologie *cible* construite
+    #: depuis une partition (``from_node_groups``) n'a pas cette notion.
+    noeuds_isoles: set[str] = field(default_factory=set)
 
     # ------------------------------------------------------------------
     # Constructeurs
@@ -72,6 +77,12 @@ class TopologieNodale:
         Un nœud électrique = composante connexe du sous-graphe restreint aux
         switches **fermés** (+ connexions internes), regroupant les équipements
         au même potentiel.
+
+        Les composantes ne contenant **aucune barre** sont des ouvrages
+        **déconnectés** (« ouvrages isolés » de l'IHM) : elles restent des
+        entrées de ``noeuds`` (compatibilité) mais sont référencées dans
+        ``noeuds_isoles`` pour que la comparaison de topologies puisse les
+        distinguer d'un vrai nœud électrique.
         """
         closed_G = nx.Graph()
         closed_G.add_nodes_from(G.nodes(data=True))
@@ -80,10 +91,13 @@ class TopologieNodale:
                 closed_G.add_edge(u, v)
 
         eq_nodes = equipment_nodes(G)
+        barres = set(busbar_nodes(G))
 
         # Composante connexe de chaque nœud d'équipement
         comp_id: dict[int, int] = {}
+        comp_avec_barre: dict[int, bool] = {}
         for idx, comp in enumerate(nx.connected_components(closed_G)):
+            comp_avec_barre[idx] = bool(comp & barres)
             for n in comp:
                 comp_id[n] = idx
 
@@ -98,14 +112,16 @@ class TopologieNodale:
         topo = cls(voltage_level_id=voltage_level_id)
         # Nommage déterministe : trier les groupes par plus petit equipment_id
         ordered = sorted(
-            groupes.values(),
-            key=lambda nodes: min(
-                G.nodes[n].get("equipment_id") or "" for n in nodes
+            groupes.items(),
+            key=lambda item: min(
+                G.nodes[n].get("equipment_id") or "" for n in item[1]
             ),
         )
-        for i, nodes in enumerate(ordered):
+        for i, (cid, nodes) in enumerate(ordered):
             nom = f"N{i}"
             noeud = NoeudElectrique(nom=nom)
+            if not comp_avec_barre.get(cid, True):
+                topo.noeuds_isoles.add(nom)   # composante sans barre = ouvrage isolé
             for n in nodes:
                 attrs = get_node_attrs(G, n)
                 dep = DepartInfo(
@@ -183,16 +199,57 @@ class TopologieNodale:
         """Partition des équipements en ensembles (un par nœud électrique)."""
         return {frozenset(n.equipment_ids) for n in self.noeuds.values()}
 
+    def univers(self) -> set[str]:
+        """Ensemble des équipements couverts par cette topologie."""
+        return set(self.noeud_par_depart)
+
+    def partition_hors_isoles_inconnus(
+        self, univers_autre: set[str]
+    ) -> set[frozenset[str]]:
+        """Partition restreinte au **périmètre** de ``univers_autre`` : les
+        ouvrages **isolés** (composante 0-barre) dont aucun équipement
+        n'apparaît dans ``univers_autre`` sont écartés.
+
+        C'est ce qui permet de comparer une topologie *réalisée* (issue du
+        graphe, qui « voit » les ouvrages déconnectés) à une topologie *cible*
+        éditée par l'expert, qui ne mentionne que les ouvrages à placer sur un
+        nœud : un ouvrage déjà déconnecté et laissé hors cible ne doit pas
+        rendre la cible non réalisable. Un isolé **mentionné** par la cible
+        reste comparé strictement (l'expert demande sa reconnexion)."""
+        garde: set[frozenset[str]] = set()
+        for nom, noeud in self.noeuds.items():
+            ids = frozenset(noeud.equipment_ids)
+            if nom in self.noeuds_isoles and not (ids & univers_autre):
+                continue          # ouvrage isolé hors du périmètre comparé
+            garde.add(ids)
+        return garde
+
     def meme_topologie(self, other: "TopologieNodale") -> bool:
         """
         Compare deux topologies nodales par isomorphisme de partition
         (les noms de nœuds sont ignorés).
+
+        Les **ouvrages isolés hors périmètre** (déconnectés d'un côté, absents
+        de l'autre) sont ignorés de part et d'autre : ce ne sont pas des nœuds
+        électriques et ils ne peuvent donc pas invalider une cible qui ne les
+        mentionne pas. La comparaison reste **stricte** dès que les deux
+        topologies parlent du même équipement.
         """
-        return self.partition() == other.partition()
+        return (self.partition_hors_isoles_inconnus(other.univers())
+                == other.partition_hors_isoles_inconnus(self.univers()))
 
     @property
     def nb_noeuds(self) -> int:
         return len(self.noeuds)
+
+    @property
+    def nb_noeuds_reels(self) -> int:
+        """Nombre de **vrais** nœuds électriques : ouvrages isolés exclus.
+
+        (``nb_noeuds`` compte toute composante portant un équipement, ouvrages
+        déconnectés compris — conservé tel quel car le placement/séquencement
+        s'appuie dessus.)"""
+        return len(self.noeuds) - len(self.noeuds_isoles)
 
     def resume(self) -> str:
         parts = [f"TopologieNodale VL '{self.voltage_level_id}': {self.nb_noeuds} nœud(s)"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "expert_op4grid_recommender"
-version = "0.3.1.post1"
+version = "0.3.2"
 authors = [
     { name="RTE", email="rte@rte-france.com" },
 ]

--- a/scripts/manoeuvre_ihm.py
+++ b/scripts/manoeuvre_ihm.py
@@ -945,6 +945,9 @@ class Session:
 
         ``isolated`` liste les départs à **laisser déconnectés** (hors partition
         cible : non placés sur un nœud ; ils conservent leur état de départ).
+        Les ouvrages **déjà déconnectés au départ** que l'expert n'a pas
+        replacés sur un nœud sont traités de même (hors partition cible), que
+        l'IHM les ait ou non listés explicitement.
 
         Phase **A** de la couche pluggable (``identifier_topologie_detaillee``
         de la façade), avec l'algorithme sélectionné (``self.algos``).
@@ -956,10 +959,18 @@ class Session:
         poste = PosteTopologique.from_graph(self._graph(self.initial), self.vl)
 
         iso = set(isolated or [])
+        # Ouvrages **hors partition cible** : ceux déclarés isolés par l'expert
+        # + ceux **déjà déconnectés au départ** qu'il n'a placé sur aucun nœud
+        # (les glisser sur un nœud = demande explicite de reconnexion, ils
+        # restent alors dans le périmètre de la cible).
+        demandes = {e for g in (groups or []) for e in g}
+        depart_iso = set(self.nodale_state(self.initial)["isolated"])
+        hors_cible = iso | (depart_iso - demandes)
         univers = [eq for grp in self.groups_of(self.initial)
-                   for eq in grp if eq not in iso]
+                   for eq in grp if eq not in hors_cible]
         groups = _normalize_groups(
-            univers, [[e for e in g if e not in iso] for g in (groups or [])])
+            univers,
+            [[e for e in g if e not in hors_cible] for g in (groups or [])])
         topo_cible = TopologieNodale.from_node_groups(self.vl, groups)
 
         ident = self._pipe().identifier_topologie_detaillee(poste, topo_cible)
@@ -972,12 +983,13 @@ class Session:
                             for k, v in self.initial.items()}
         else:
             self.current = dict(self.initial)
-        # Ouvrages **explicitement déclarés isolés** par l'expert : forcer leur
-        # déconnexion réelle (nœud 0-barre) au lieu de les laisser sur une barre —
-        # l'algo ne manœuvre que les départs de la partition, donc un ouvrage en
-        # service déclaré isolé resterait sinon connecté.
-        if iso:
-            self.current = self._isoler_dans_etat(self.current, iso)
+        # Ouvrages **hors partition cible** : forcer leur déconnexion réelle
+        # (nœud 0-barre) au lieu de les laisser sur une barre — l'algo ne
+        # manœuvre que les départs de la partition, donc un ouvrage en service
+        # déclaré isolé resterait sinon connecté. No-op pour ceux déjà
+        # déconnectés (cas des ouvrages isolés dès le départ).
+        if hors_cible:
+            self.current = self._isoler_dans_etat(self.current, hors_cible)
         self.scenario_name = None   # cible à revalider avant calcul de séquence
 
         svg, switches, nb = self.view(self.current)
@@ -986,21 +998,25 @@ class Session:
         nb_isoles = len(iso_real)
         seq = ident.sequence   # sous-produit éventuel (écarts détaillés)
 
-        if iso:
-            # Verdict **recalculé sur l'état final** (post-isolation) : on ne
-            # compte que les nœuds RÉELS — les ouvrages isolés sont présentés à
-            # part, **jamais** comptés comme des nœuds (sinon le verdict de l'algo,
-            # calculé avant l'isolation, gonfle le compte : « obtenu 4 » au lieu de
-            # « 2 nœuds + 2 ouvrages isolés »).
-            real_part = {frozenset(e for e in g if e not in iso_real)
-                         for g in realized["groups"]}
-            real_part.discard(frozenset())
-            target_part = {frozenset(g) for g in groups}
-            is_ok = (real_part == target_part) and iso <= iso_real
+        # Verdict **recalculé sur l'état final** (post-isolation, que l'algo ne
+        # voit pas) avec la sémantique « ouvrages isolés » du cœur : un ouvrage
+        # déconnecté hors périmètre de la cible n'est **pas** un nœud électrique
+        # et ne peut donc pas rendre la cible non réalisable. Les ouvrages
+        # explicitement écartés de la partition doivent l'être **réellement**.
+        with self.applied(self.current):
+            topo_reelle = self._topo(self.current)
+        partition_ok = topo_reelle.meme_topologie(topo_cible)
+        non_isoles = sorted(hors_cible - iso_real)   # isolement non réalisable
+        is_ok = partition_ok and not non_isoles
+        if is_ok:
             message, ecarts, non_real = "", [], []
         else:
-            is_ok = ident.is_realisable
-            message = ident.message
+            # Diagnostic complet quand la cible n'est effectivement pas atteinte.
+            message = ident.message if not partition_ok else ""
+            if non_isoles:
+                message = (message + " " if message else "") + (
+                    "Ouvrage(s) impossible(s) à isoler : "
+                    + ", ".join(non_isoles) + ".")
             ecarts = seq.ecarts if seq is not None else []
             non_real = ident.noeuds_non_realisables
         return {

--- a/tests/manoeuvre/test_conformite_art_manoeuvre.py
+++ b/tests/manoeuvre/test_conformite_art_manoeuvre.py
@@ -1,0 +1,349 @@
+"""
+tests/manoeuvre/test_conformite_art_manoeuvre.py
+--------------------------------------------------
+Vérificateur de conformité « art de la manœuvre » (``algo/conformite.py``,
+règles R20-R25 de ``docs/manoeuvre/art_de_la_manoeuvre.md``) :
+
+- classification des conséquences par rejeu (R20) : boucles, transit,
+  mise sous/hors tension, préparer/désaiguiller, manœuvre hors tension ;
+- matrice d'autorisation CCRT par famille d'organe (R21) ;
+- avertissement « essai de barre par disjoncteur » (R22) ;
+- machine à états des départs + transitions interdites (R23) ;
+- temporisations ACT 104 (R24) ;
+- contrôles SCADA attendus (R25) ;
+- intégration : ``verifier_sequence`` renseigne ``ResultatManoeuvres.conformite``
+  sans toucher ``ecarts``/``alertes`` (compatibilité des goldens).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from expert_op4grid_recommender.manoeuvre.topologie import (
+    PosteTopologique,
+    TopologieNodale,
+)
+from expert_op4grid_recommender.manoeuvre.algo import (
+    Consequence,
+    EtatDepart,
+    FamilleOrgane,
+    Manoeuvre,
+    analyser_conformite,
+    calculer_temporisations,
+    classifier_manoeuvres,
+    determiner_topo_complete_cible,
+    familles_organes,
+)
+from expert_op4grid_recommender.manoeuvre.algo.graph_ops import _sa_path_to_sjb
+from expert_op4grid_recommender.manoeuvre.plugins.pipeline import verifier_sequence
+
+from .fixture_loader import build_graph_from_fixture, list_available_fixtures
+
+
+def _fixtures_available() -> bool:
+    return len(list_available_fixtures()) > 0
+
+
+pytestmark = pytest.mark.skipif(
+    not _fixtures_available(), reason="Fixtures de postes non générées."
+)
+
+SS_112 = "CARRIP3_CARRI3SEC..12 SS.1.12_OC"
+DJ_COUPL = "CARRIP3_CARRI3COUPL.1 DJ_OC"
+DJ_BARR6 = "CARRIP3_CARRI3BARR6.1 DJ_OC"
+SA1_BARR6 = "CARRIP3_CARRI3BARR6.1 SA.1_OC"
+SA2_BARR6 = "CARRIP3_CARRI3BARR6.1 SA.2_OC"
+
+
+@pytest.fixture
+def poste_carrip3() -> PosteTopologique:
+    G = build_graph_from_fixture("CARRIP3")
+    return PosteTopologique.from_graph(G, "CARRIP3")
+
+
+def _set_switch_in_graph(G, switch_id, open_):
+    for _u, _v, d in G.edges(data=True):
+        if d.get("switch_id") == switch_id:
+            d["open"] = open_
+
+
+# ---------------------------------------------------------------------------
+# Familles d'organes
+# ---------------------------------------------------------------------------
+
+def test_familles_organes_carrip3(poste_carrip3):
+    fam = familles_organes(poste_carrip3)
+    # Sectionnements de barre : les deux SS de CARRIP3.
+    assert fam[SS_112] == FamilleOrgane.SS_SECTIONNEMENT
+    assert fam["CARRIP3_CARRI3SEC..12 SS.2.12_OC"] == FamilleOrgane.SS_SECTIONNEMENT
+    # Travée de couplage : DJ + SA de couplage.
+    assert fam[DJ_COUPL] == FamilleOrgane.DJ
+    assert fam["CARRIP3_CARRI3COUPL.1 SA.1_OC"] == FamilleOrgane.SA_COUPLAGE
+    # Cellule de départ : DJ + SA d'aiguillage.
+    assert fam[DJ_BARR6] == FamilleOrgane.DJ
+    assert fam[SA1_BARR6] == FamilleOrgane.SA_AIGUILLAGE
+
+
+# ---------------------------------------------------------------------------
+# Classification des conséquences (R20)
+# ---------------------------------------------------------------------------
+
+def test_boucle_courte_classee_boucle(poste_carrip3):
+    """Ré-aiguillage en boucle courte (couplage fermé) : fermeture puis
+    ouverture de SA = fermeture/ouverture de boucle — autorisé pour un SA."""
+    seq = [Manoeuvre(SA2_BARR6, "CLOSE", "boucle courte"),
+           Manoeuvre(SA1_BARR6, "OPEN", "boucle courte")]
+    classees = classifier_manoeuvres(poste_carrip3, seq)
+    assert classees[0].consequences == frozenset({Consequence.FERMETURE_BOUCLE})
+    assert classees[1].consequences == frozenset({Consequence.OUVERTURE_BOUCLE})
+    conf = analyser_conformite(poste_carrip3, seq)
+    assert conf.is_conforme
+
+
+def test_boucle_longue_conforme(poste_carrip3):
+    """Boucle longue dans les règles : -DJ (coupure), ±SA hors charge
+    (désaiguiller/préparer), +DJ (établissement du transit)."""
+    seq = [Manoeuvre(DJ_BARR6, "OPEN", "mhu départ"),
+           Manoeuvre(SA1_BARR6, "OPEN", "désaiguiller"),
+           Manoeuvre(SA2_BARR6, "CLOSE", "préparer"),
+           Manoeuvre(DJ_BARR6, "CLOSE", "mes")]
+    classees = classifier_manoeuvres(poste_carrip3, seq)
+    assert Consequence.COUPER_TRANSIT in classees[0].consequences
+    assert classees[1].consequences == frozenset({Consequence.DESAIGUILLER})
+    assert classees[2].consequences == frozenset({Consequence.PREPARER})
+    assert Consequence.ETABLIR_TRANSIT in classees[3].consequences
+    conf = analyser_conformite(poste_carrip3, seq)
+    assert conf.is_conforme
+    assert not conf.avertissements
+
+
+def test_ouverture_couplage_change_nb_noeuds(poste_carrip3):
+    """Ouvrir le DJ de couplage scinde le poste en 2 nœuds : couper un transit
+    + changer le nombre de nœuds — autorisé pour un DJ."""
+    classees = classifier_manoeuvres(
+        poste_carrip3, [Manoeuvre(DJ_COUPL, "OPEN", "split")])
+    assert classees[0].famille == FamilleOrgane.DJ
+    assert Consequence.COUPER_TRANSIT in classees[0].consequences
+    assert Consequence.CHANGER_NB_NOEUDS in classees[0].consequences
+    conf = analyser_conformite(poste_carrip3, [Manoeuvre(DJ_COUPL, "OPEN", "s")])
+    assert conf.is_conforme
+
+
+def test_sans_effet(poste_carrip3):
+    """Une manœuvre plaçant l'organe dans son état courant est « sans effet »."""
+    classees = classifier_manoeuvres(
+        poste_carrip3, [Manoeuvre(SA1_BARR6, "CLOSE", "déjà fermé")])
+    assert classees[0].consequences == frozenset({Consequence.SANS_EFFET})
+
+
+def test_organe_inconnu(poste_carrip3):
+    classees = classifier_manoeuvres(
+        poste_carrip3, [Manoeuvre("ORGANE_INEXISTANT", "OPEN", "?")])
+    assert classees[0].famille == FamilleOrgane.INCONNU
+    assert "inconnu" in classees[0].commentaire
+
+
+def test_manoeuvre_hors_tension(poste_carrip3):
+    """SA manœuvré derrière un DJ ouvert **et** vers une section morte :
+    manœuvre hors tension / préparer, sans violation."""
+    G = build_graph_from_fixture("CARRIP3")
+    p0 = PosteTopologique.from_graph(G, "CARRIP3")
+    # Section 1.2 (node 1) rendue morte : SS ouvert + départs désaiguillés.
+    _set_switch_in_graph(G, SS_112, True)
+    for c in p0.cellules.cellules_depart:
+        if 1 in c.busbar_nodes:
+            for sid in _sa_path_to_sjb(c, 1):
+                _set_switch_in_graph(G, sid, True)
+    poste = PosteTopologique.from_graph(G, "CARRIP3")
+    # Ouvrir puis refermer le SS entre 1.1 (vive) et 1.2 (morte) n'est qu'une
+    # mise hors/sous tension de la section - pas un transit.
+    classees = classifier_manoeuvres(
+        poste, [Manoeuvre(SS_112, "CLOSE", "resection")])
+    assert classees[0].consequences == frozenset({Consequence.MISE_SOUS_TENSION})
+    assert classees[0].sjb_impactees == ("CARRIP3_1.2",)
+
+
+# ---------------------------------------------------------------------------
+# Matrice d'autorisation (R21) + essai de barre (R22)
+# ---------------------------------------------------------------------------
+
+def test_sa_en_charge_est_une_violation(poste_carrip3):
+    """Ouvrir le SA d'un départ en service (sans chemin parallèle) coupe le
+    transit par un sectionneur : violation de la matrice CCRT **et**
+    transition d'état interdite (R23)."""
+    conf = analyser_conformite(
+        poste_carrip3, [Manoeuvre(SA1_BARR6, "OPEN", "faute")])
+    assert not conf.is_conforme
+    assert any("couper_transit" in v for v in conf.violations)
+    assert any("manœuvre en charge interdite" in v for v in conf.violations)
+
+
+def test_fermeture_sa_pontant_deux_noeuds_est_une_violation(poste_carrip3):
+    """Couplage ouvert (2 nœuds) : fermer le 2e SA d'un départ en service
+    ponterait les deux barres par le sectionneur — interdit."""
+    G = build_graph_from_fixture("CARRIP3")
+    _set_switch_in_graph(G, DJ_COUPL, True)          # scinde le poste en 2 nœuds
+    poste = PosteTopologique.from_graph(G, "CARRIP3")
+    conf = analyser_conformite(
+        poste, [Manoeuvre(SA2_BARR6, "CLOSE", "DA interdit")])
+    assert not conf.is_conforme
+    assert any("etablir_transit" in v or "changer_nb_noeuds" in v
+               for v in conf.violations)
+
+
+def test_essai_de_barre_avertissement(poste_carrip3):
+    """Remettre sous tension une section morte par la seule fermeture du SS :
+    avertissement R22 (préférer un essai par disjoncteur)."""
+    G = build_graph_from_fixture("CARRIP3")
+    p0 = PosteTopologique.from_graph(G, "CARRIP3")
+    _set_switch_in_graph(G, SS_112, True)
+    for c in p0.cellules.cellules_depart:
+        if 1 in c.busbar_nodes:
+            for sid in _sa_path_to_sjb(c, 1):
+                _set_switch_in_graph(G, sid, True)
+    poste = PosteTopologique.from_graph(G, "CARRIP3")
+    conf = analyser_conformite(
+        poste, [Manoeuvre(SS_112, "CLOSE", "remise en service section")])
+    assert conf.is_conforme                       # autorisé (limité au JdB)…
+    assert any("essai de barre" in a for a in conf.avertissements)  # …mais déconseillé
+
+
+# ---------------------------------------------------------------------------
+# Machine à états des départs (R23)
+# ---------------------------------------------------------------------------
+
+def test_trajectoire_etats_boucle_longue(poste_carrip3):
+    seq = [Manoeuvre(DJ_BARR6, "OPEN", "mhu"),
+           Manoeuvre(SA1_BARR6, "OPEN", "désaiguiller"),
+           Manoeuvre(SA2_BARR6, "CLOSE", "préparer"),
+           Manoeuvre(DJ_BARR6, "CLOSE", "mes")]
+    conf = analyser_conformite(poste_carrip3, seq)
+    tr = [(t.avant, t.apres) for t in conf.transitions
+          if t.equipment_id == "BARR6L31CARRI"]
+    assert tr == [
+        (EtatDepart.EN_SERVICE, EtatDepart.PREPARE),
+        (EtatDepart.PREPARE, EtatDepart.DESAIGUILLE),
+        (EtatDepart.DESAIGUILLE, EtatDepart.PREPARE),
+        (EtatDepart.PREPARE, EtatDepart.EN_SERVICE),
+    ]
+    assert not any(t.interdite for t in conf.transitions)
+    # L'établissement du transit porte les contrôles +I / Scc.
+    dern = conf.transitions[-1]
+    assert any("calcul de répartition" in c for c in dern.controles)
+
+
+def test_double_aiguillage_controle_noeuds(poste_carrip3):
+    """Passage en service → en service - DA : transition permise avec contrôle
+    du nombre de nœuds (couplage fermé : boucle courte)."""
+    conf = analyser_conformite(
+        poste_carrip3, [Manoeuvre(SA2_BARR6, "CLOSE", "+DA")])
+    t = next(t for t in conf.transitions if t.equipment_id == "BARR6L31CARRI")
+    assert (t.avant, t.apres) == (EtatDepart.EN_SERVICE, EtatDepart.EN_SERVICE_DA)
+    assert not t.interdite
+    assert any("nombre de nœuds" in c for c in t.controles)
+    assert conf.is_conforme
+
+
+# ---------------------------------------------------------------------------
+# Temporisations ACT 104 (R24)
+# ---------------------------------------------------------------------------
+
+def test_tempo_sectionneur_10s(poste_carrip3):
+    seq = [Manoeuvre(SA2_BARR6, "CLOSE", "boucle courte"),
+           Manoeuvre(SA1_BARR6, "OPEN", "boucle courte")]
+    tempos = calculer_temporisations(poste_carrip3, seq)
+    assert [(t.index, t.avant, t.duree_s) for t in tempos] == [
+        (0, False, 10), (1, False, 10)]
+
+
+def test_tempo_regonflage_dj_60s(poste_carrip3):
+    """Cycle fermeture → ouverture → re-fermeture d'un même DJ : la seconde
+    fermeture attend le complément à 60 s (temporisations déjà écoulées
+    déduites, comme dans la méthode CCO)."""
+    seq = [Manoeuvre(DJ_BARR6, "OPEN", "essai -u"),
+           Manoeuvre(DJ_BARR6, "CLOSE", "essai +u"),        # 1re fermeture (t=0)
+           Manoeuvre(DJ_BARR6, "OPEN", "-u"),
+           Manoeuvre(SA2_BARR6, "CLOSE", "préparer"),        # +10 s (sectionneur)
+           Manoeuvre(DJ_BARR6, "CLOSE", "mes")]              # 2e fermeture
+    tempos = calculer_temporisations(poste_carrip3, seq)
+    regonflage = [t for t in tempos if "regonflage" in t.motif]
+    assert len(regonflage) == 1
+    t = regonflage[0]
+    assert (t.index, t.avant) == (4, True)
+    assert t.duree_s == 50          # 60 s - 10 s de tempo sectionneur déjà écoulée
+    # Pas de tempo à la première fermeture du DJ.
+    assert not any(t.index == 1 for t in regonflage)
+
+
+def test_pas_de_tempo_dj_ferme_une_seule_fois(poste_carrip3):
+    seq = [Manoeuvre(DJ_BARR6, "OPEN", "-u"),
+           Manoeuvre(DJ_BARR6, "CLOSE", "mes")]
+    tempos = calculer_temporisations(poste_carrip3, seq)
+    assert not [t for t in tempos if "regonflage" in t.motif]
+
+
+# ---------------------------------------------------------------------------
+# Contrôles attendus (R25)
+# ---------------------------------------------------------------------------
+
+def test_controles_attendus(poste_carrip3):
+    seq = [Manoeuvre(DJ_BARR6, "OPEN", "coupure"),
+           Manoeuvre(DJ_BARR6, "CLOSE", "mes")]
+    classees = classifier_manoeuvres(poste_carrip3, seq)
+    assert any("TM I passe à 0" in c for c in classees[0].controles)
+    assert any("calcul de répartition" in c for c in classees[1].controles)
+    # Boucles et manœuvres hors charge : aucun contrôle.
+    boucle = classifier_manoeuvres(
+        poste_carrip3, [Manoeuvre(SA2_BARR6, "CLOSE", "boucle")])
+    assert boucle[0].controles == []
+
+
+# ---------------------------------------------------------------------------
+# Intégration : séquences de l'algorithme + verifier_sequence
+# ---------------------------------------------------------------------------
+
+def test_sequence_algo_est_conforme(poste_carrip3):
+    """Les séquences produites par le séquenceur natif respectent la matrice
+    d'autorisation (aucune violation)."""
+    deps = sorted({c.equipment_id for c in poste_carrip3.cellules.cellules_depart})
+    cible = TopologieNodale.from_node_groups(
+        poste_carrip3.voltage_level_id, [deps[:8], deps[8:]])
+    res = determiner_topo_complete_cible(poste_carrip3, cible)
+    conf = analyser_conformite(poste_carrip3, res.manoeuvres)
+    assert conf.is_conforme, conf.violations
+
+
+def test_verifier_sequence_renseigne_conformite(poste_carrip3):
+    """``verifier_sequence`` attache l'analyse au champ ``conformite`` sans
+    modifier les verdicts historiques (``ecarts``/``alertes``)."""
+    from expert_op4grid_recommender.manoeuvre.algo import ResultatManoeuvres
+
+    res = ResultatManoeuvres(
+        voltage_level_id=poste_carrip3.voltage_level_id,
+        topo_initiale=poste_carrip3.topologie_nodale,
+        topo_cible=poste_carrip3.topologie_nodale,
+        manoeuvres=[Manoeuvre(SA1_BARR6, "OPEN", "faute")],
+    )
+    ecarts_regle_historique = None
+    verifier_sequence(poste_carrip3, res)
+    assert res.conformite is not None
+    assert not res.conformite.is_conforme
+    # La règle historique du sectionneur sous charge reste portée par ecarts.
+    ecarts_regle_historique = [e for e in res.ecarts if "sous charge" in e]
+    assert ecarts_regle_historique
+    # …et les violations de conformité n'y sont PAS dupliquées.
+    assert not any("matrice CCRT" in e for e in res.ecarts)
+    assert not any("matrice CCRT" in a for a in res.alertes)
+
+
+def test_analyser_conformite_ne_mute_pas_le_poste(poste_carrip3):
+    etats_avant = {d.get("switch_id"): d.get("open")
+                   for _u, _v, d in poste_carrip3.graph.edges(data=True)
+                   if d.get("switch_id")}
+    analyser_conformite(poste_carrip3, [
+        Manoeuvre(DJ_BARR6, "OPEN", "x"),
+        Manoeuvre(SA1_BARR6, "OPEN", "y")])
+    etats_apres = {d.get("switch_id"): d.get("open")
+                   for _u, _v, d in poste_carrip3.graph.edges(data=True)
+                   if d.get("switch_id")}
+    assert etats_avant == etats_apres

--- a/tests/manoeuvre/test_ihm_ui_improvements.py
+++ b/tests/manoeuvre/test_ihm_ui_improvements.py
@@ -97,6 +97,10 @@ def test_config_get(session, monkeypatch):
 def test_config_post_updates_dirs(session, monkeypatch, tmp_path):
     monkeypatch.setattr(ihm, "SESSION", session)
     monkeypatch.setitem(ihm.DATASET, "hosted", False)
+    # ``/api/config`` n'accepte de repointer que **dans** une racine autorisée
+    # (cwd / racine de données persistantes) — cf. ``_dir_within_allowed``. On
+    # déclare donc ``tmp_path`` comme racine de données pour ce test.
+    monkeypatch.setattr(ihm, "_persist_root", lambda: str(tmp_path))
     sd, qd = tmp_path / "scen", tmp_path / "seq"
     d = ihm.app.test_client().post("/api/config", json={
         "scenarios_dir": str(sd), "sequences_dir": str(qd)}).get_json()

--- a/tests/manoeuvre/test_ouvrages_isoles_verification.py
+++ b/tests/manoeuvre/test_ouvrages_isoles_verification.py
@@ -1,0 +1,237 @@
+"""
+tests/manoeuvre/test_ouvrages_isoles_verification.py
+-----------------------------------------------------
+Régression : un **ouvrage isolé** (déconnecté — composante sans barre) ne doit
+pas faire échouer la vérification d'une cible nodale qui ne le mentionne pas.
+
+Contexte du bug : ``TopologieNodale.from_graph`` matérialise **une entrée de
+``noeuds`` par composante portant un équipement**, y compris les composantes
+**sans barre** (ouvrages déconnectés). La cible nodale éditée dans l'IHM, elle,
+ne décrit que les ouvrages à placer sur un nœud. La comparaison stricte de
+partitions rendait donc *toute* cible « non réalisable » dès qu'un ouvrage était
+déjà déconnecté au départ, d'où le faux avertissement de l'IHM :
+
+    ⚠ Cible partiellement réalisable (obtenu 2 nœud(s) + 5 ouvrage(s) isolé(s)
+      / visé 2 nœud(s))
+
+alors que la cible était bel et bien atteinte et que les ouvrages déjà
+déconnectés au départ le restaient dans la topologie cible.
+
+Trois niveaux couverts :
+1. cœur — ``TopologieNodale`` (``noeuds_isoles`` / ``nb_noeuds_reels`` /
+   ``meme_topologie``), sur graphe NetworkX pur ;
+2. algo — ``PlanificateurTopologie.identifier_topologie_detaillee`` ;
+3. IHM  — ``Session.nodale_to_detaillee``.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import pathlib
+
+import networkx as nx
+import pytest
+
+from expert_op4grid_recommender.manoeuvre.models import NodeType
+from expert_op4grid_recommender.manoeuvre.topologie import TopologieNodale
+
+
+# ---------------------------------------------------------------------------
+# 1. Cœur — TopologieNodale (graphe NX pur, ni Flask ni pypowsybl)
+# ---------------------------------------------------------------------------
+
+def _graphe(deconnecte=("L3",)) -> nx.Graph:
+    """Poste jouet : une barre, ``L1``/``L2`` raccordés, ``L3`` déconnecté."""
+    G = nx.Graph()
+    G.add_node(0, node_type=NodeType.BUSBAR_SECTION, equipment_id="BB")
+    for i, eq in enumerate(("L1", "L2", "L3"), start=1):
+        G.add_node(i, node_type=NodeType.EQUIPMENT, equipment_id=eq)
+        G.add_edge(0, i, open=eq in deconnecte, switch_id=f"S{i}")
+    return G
+
+
+def test_from_graph_marque_les_composantes_sans_barre():
+    topo = TopologieNodale.from_graph(_graphe(), "VL")
+    isole = {nom for nom in topo.noeuds_isoles}
+    assert len(isole) == 1
+    (nom_isole,) = isole
+    assert topo.noeuds[nom_isole].equipment_ids == {"L3"}
+    # ``noeuds`` reste exhaustif (compatibilité : le placement s'appuie dessus).
+    assert topo.nb_noeuds == 2
+    assert topo.nb_noeuds_reels == 1
+
+
+def test_from_node_groups_na_pas_de_noeud_isole():
+    """Une cible construite depuis une partition n'a pas la notion d'isolé."""
+    cible = TopologieNodale.from_node_groups("VL", [["L1", "L2"]])
+    assert cible.noeuds_isoles == set()
+    assert cible.nb_noeuds_reels == cible.nb_noeuds == 1
+
+
+def test_partition_reste_exhaustive():
+    """``partition()`` (utilisée par les goldens) est inchangée : elle inclut
+    toujours les ouvrages isolés."""
+    topo = TopologieNodale.from_graph(_graphe(), "VL")
+    assert topo.partition() == {frozenset({"L1", "L2"}), frozenset({"L3"})}
+
+
+def test_meme_topologie_ignore_un_isole_hors_cible():
+    """Le cas du bug : la cible ne parle pas de ``L3`` (déjà déconnecté)."""
+    obtenue = TopologieNodale.from_graph(_graphe(), "VL")
+    cible = TopologieNodale.from_node_groups("VL", [["L1", "L2"]])
+    assert obtenue.meme_topologie(cible)
+    assert cible.meme_topologie(obtenue)          # symétrique
+
+
+def test_meme_topologie_reste_stricte_si_la_cible_mentionne_lisole():
+    """L'expert demande explicitement ``L3`` sur le nœud → reconnexion exigée,
+    la cible n'est donc **pas** réalisée."""
+    obtenue = TopologieNodale.from_graph(_graphe(), "VL")
+    cible = TopologieNodale.from_node_groups("VL", [["L1", "L2", "L3"]])
+    assert not obtenue.meme_topologie(cible)
+    assert not cible.meme_topologie(obtenue)
+
+
+def test_meme_topologie_isole_declare_comme_noeud_a_part():
+    """Cible mentionnant ``L3`` comme nœud à lui seul : comparaison stricte,
+    satisfaite (comportement historique préservé)."""
+    obtenue = TopologieNodale.from_graph(_graphe(), "VL")
+    cible = TopologieNodale.from_node_groups("VL", [["L1", "L2"], ["L3"]])
+    assert obtenue.meme_topologie(cible)
+
+
+def test_meme_topologie_detecte_une_vraie_difference_avec_un_isole():
+    """La relaxation ne masque pas une partition réellement fausse."""
+    obtenue = TopologieNodale.from_graph(_graphe(), "VL")
+    cible = TopologieNodale.from_node_groups("VL", [["L1"], ["L2"]])
+    assert not obtenue.meme_topologie(cible)
+
+
+def test_meme_topologie_detecte_un_ouvrage_de_la_cible_qui_finit_isole():
+    """``L2`` est visé sur un nœud mais se retrouve déconnecté → non réalisé."""
+    obtenue = TopologieNodale.from_graph(_graphe(deconnecte=("L2", "L3")), "VL")
+    cible = TopologieNodale.from_node_groups("VL", [["L1", "L2"]])
+    assert not obtenue.meme_topologie(cible)
+
+
+# ---------------------------------------------------------------------------
+# 2 & 3. Algo + IHM (nécessitent pypowsybl / flask)
+# ---------------------------------------------------------------------------
+
+pytest.importorskip("flask")
+pytest.importorskip("pypowsybl")
+
+import pypowsybl as pp  # noqa: E402
+
+from expert_op4grid_recommender.manoeuvre.topologie import (  # noqa: E402
+    PosteTopologique,
+)
+from expert_op4grid_recommender.manoeuvre.plugins import (  # noqa: E402
+    PlanificateurTopologie,
+)
+
+_IHM_PATH = (pathlib.Path(__file__).resolve().parents[2]
+             / "scripts" / "manoeuvre_ihm.py")
+VL = "S1VL2"
+
+
+def _load_ihm():
+    spec = importlib.util.spec_from_file_location("manoeuvre_ihm_iso_mod", _IHM_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+ihm = _load_ihm()
+
+
+@pytest.fixture()
+def session_avec_isole():
+    """Session dont l'état de **départ** comporte un ouvrage déjà déconnecté.
+
+    Renvoie ``(session, ouvrage_isolé, [départs connectés])``."""
+    net = pp.network.create_four_substations_node_breaker_network()
+    s = ihm.Session(net)
+    s.load(VL)
+    feeders = sorted({eq for g in s.groups_of(s.initial) for eq in g})
+    iso_eq = feeders[0]
+    s.initial = ihm.Session._isoler_dans_etat(s, s.initial, [iso_eq])
+    s.current = dict(s.initial)
+    s._graph_cache.clear()
+    s._topo_cache.clear()
+    assert s.nodale_state(s.initial)["isolated"] == [iso_eq]
+    return s, iso_eq, [e for e in feeders if e != iso_eq]
+
+
+def _cible_deux_noeuds(connectes):
+    moitie = len(connectes) // 2
+    return [connectes[:moitie], connectes[moitie:]]
+
+
+def test_algo_identifie_la_cible_malgre_un_ouvrage_deja_deconnecte(session_avec_isole):
+    s, _iso, connectes = session_avec_isole
+    s.apply(s.initial)
+    poste = PosteTopologique.from_graph(s._graph(s.initial), s.vl)
+    cible = TopologieNodale.from_node_groups(VL, _cible_deux_noeuds(connectes))
+
+    ident = PlanificateurTopologie().identifier_topologie_detaillee(poste, cible)
+
+    assert ident.is_realisable, ident.message
+    assert ident.noeuds_non_realisables == []
+
+
+def test_ihm_pas_de_faux_avertissement_ouvrages_isoles(session_avec_isole):
+    """Cas du bug, ouvrages isolés **déclarés** par l'IHM."""
+    s, iso, connectes = session_avec_isole
+    res = s.nodale_to_detaillee(_cible_deux_noeuds(connectes), [iso])
+
+    assert res["is_verified"] is True
+    assert res["nb_obtenu"] == res["nb_vise"] == 2
+    assert res["nb_isoles"] == 1
+    assert res["message"] == ""
+    assert res["noeuds_non_realisables"] == []
+    assert iso in res["nodale"]["isolated"]        # reste déconnecté
+
+
+def test_ihm_ouvrages_deja_deconnectes_non_declares(session_avec_isole):
+    """Même cas mais sans liste ``isolated`` : un ouvrage **déjà déconnecté au
+    départ** et non replacé sur un nœud reste hors de la partition cible (il
+    n'est plus réinjecté comme nœud « orphelin », qui gonflait ``nb_vise``)."""
+    s, iso, connectes = session_avec_isole
+    res = s.nodale_to_detaillee(_cible_deux_noeuds(connectes), [])
+
+    assert res["is_verified"] is True
+    assert res["nb_obtenu"] == res["nb_vise"] == 2
+    assert res["nb_isoles"] == 1
+    assert iso in res["nodale"]["isolated"]
+
+
+def test_ihm_reconnexion_demandee_reste_dans_le_perimetre(session_avec_isole):
+    """Glisser un ouvrage isolé sur un nœud = demande de **reconnexion** : il
+    reste dans le périmètre de la cible (``nb_vise`` couvre tous les départs) et
+    n'est pas re-déconnecté d'office."""
+    s, iso, connectes = session_avec_isole
+    groupes = _cible_deux_noeuds(connectes)
+    groupes[0] = groupes[0] + [iso]
+    res = s.nodale_to_detaillee(groupes, [])
+
+    assert res["nb_vise"] == 2
+    # La reconnexion d'un départ déconnecté est hors de portée de l'algo (limite
+    # documentée) : le verdict est négatif — mais **expliqué**, jamais nu.
+    assert res["is_verified"] is False
+    assert res["message"]
+    assert iso in res["nodale"]["isolated"]         # pas reconnecté
+
+
+def test_ihm_verdict_negatif_reste_diagnostique(session_avec_isole):
+    """Une cible réellement inatteignable garde son diagnostic. Avant le
+    correctif, la branche « ouvrages isolés » de l'IHM renvoyait un
+    avertissement **nu** (``message``/``ecarts``/``noeuds_non_realisables``
+    forcés à vide)."""
+    s, iso, connectes = session_avec_isole
+    # Un nœud par départ : irréalisable sur un poste à 2 jeux de barres.
+    res = s.nodale_to_detaillee([[eq] for eq in connectes], [iso])
+
+    assert res["is_verified"] is False
+    assert res["message"]
+    assert res["noeuds_non_realisables"]

--- a/tests/manoeuvre/test_postes_3barres_400kv.py
+++ b/tests/manoeuvre/test_postes_3barres_400kv.py
@@ -356,10 +356,15 @@ def test_cible_3_ou_4_noeuds_innocuite(name, shape):
     viol = sectionneurs_sous_charge_par_manoeuvre(poste, res.manoeuvres)
     assert len(viol) == len(res.manoeuvres)
     assert all(v is None or isinstance(v, str) for v in viol)
-    # (e) cohérence : si vérifié, alors topologie exacte et aucun écart.
+    # (e) cohérence : si vérifié, alors topologie exacte et aucun écart. La
+    #     partition obtenue est comparée **dans le périmètre de la cible** : un
+    #     ouvrage déjà déconnecté et absent de la cible n'est pas un nœud
+    #     électrique (cf. ``TopologieNodale.noeuds_isoles``).
     assert res.topo_obtenue is not None
     if res.is_verified:
-        assert res.topo_obtenue.nb_noeuds == cible.nb_noeuds
+        obtenue = res.topo_obtenue.partition_hors_isoles_inconnus(cible.univers())
+        assert obtenue == cible.partition()
+        assert len(obtenue) == cible.nb_noeuds
         assert res.ecarts == []
 
 


### PR DESCRIPTION
Release **0.3.2** — module manœuvre uniquement ; le pipeline d'analyse du
recommandeur est inchangé. Notes : `docs/release-notes/v0.3.2.md`.

## Objet

Confrontation du module manœuvre (règles R1-R19) aux référentiels d'exploitation
RTE — matrice d'autorisation CCRT C3-3, consigne ACT 104 (temporisations),
méthode experte « fiche de manœuvres d'un CCO » — puis consolidation en un
corpus de règles enrichi et implémentation d'un vérificateur de conformité.

## 1. Art de la manoeuvre

- **`docs/manoeuvre/art_de_la_manoeuvre.md`** : analyse critique de couverture
  (couvert / manquant), règles consolidées **R20-R28** (R26 validations
  électriques, R27 orchestration multi-postes, R28 automates : spécifiées non
  implémentées), correspondance avec la typologie CCO `listeDordre`, et plan de
  restructuration module / algo / vérificateur.
- **`manoeuvre/algo/conformite.py`** (R20-R25) :
  - classification des **conséquences** de chaque manœuvre par rejeu (transit,
    boucles, mise sous/hors tension, manœuvre HU, préparer/désaiguiller,
    changement du nombre de nœuds) avec familles d'organes CCRT ;
  - **matrice d'autorisation** conséquence × organe (généralise R18 : capte
    aussi le pontage de deux nœuds par fermeture de SA) ;
  - avertissement **essai de barre** (remise sous tension d'une section par
    sectionneur au lieu d'un DJ) ;
  - **machine à états des départs** CCO (transitions interdites / bizarres +
    contrôles associés) ;
  - **temporisations ACT 104** (10 s sectionneur, ≥ 60 s regonflage DJ) ;
  - **contrôles SCADA attendus** par manœuvre (TS/TM, contrôle nœuds).
- Verdicts portés par un **nouveau champ** `ResultatManoeuvres.conformite`
  (renseigné par `verifier_sequence`), séparé d'`ecarts`/`alertes`.
- Traçabilité R20-R25 ajoutée à `docs/manoeuvre/regles.md` ; CLAUDE.md du
  module, index docs et CHANGELOG mis à jour.

## 2. Ouvrages isolés : plus de faux « Cible partiellement réalisable »

`TopologieNodale.from_graph` matérialisait une entrée de `noeuds` par composante
portant un équipement, **y compris les composantes sans barre** (ouvrages
déconnectés). Une cible nodale éditée ne décrit que les ouvrages à placer sur un
nœud → la comparaison stricte de `meme_topologie` échouait pour **tout** poste
ayant un ouvrage déjà déconnecté, ce qui remontait à `is_verified`, à
`is_realisable` (vérification indépendante du pipeline comprise) puis à l'IHM.

Correctif : `noeuds_isoles` (composantes 0-barre), `nb_noeuds_reels`, et
`partition_hors_isoles_inconnus()` sur lequel `meme_topologie` compare les
partitions **dans le périmètre commun**. Reste strict dès que les deux côtés
mentionnent le même équipement. `partition()` reste exhaustive → goldens iso.
Côté IHM, verdict unique recalculé sur l'état final via cette règle, et un
verdict négatif porte de nouveau son diagnostic complet.

## Tests

- `tests/manoeuvre/test_ouvrages_isoles_verification.py` (cœur sur graphe NX pur,
  algo via `PlanificateurTopologie`, IHM via `Session.nodale_to_detaillee`, cas
  négatifs) ;
- suite manœuvre : **1090 passed, 4 skipped** ;
- `test_config_post_updates_dirs` réparé (il pointait `/api/config` hors racine
  autorisée, refusé par `_dir_within_allowed` depuis 0.2.6) ;
- `test_postes_3barres_400kv.py` : assertion de cohérence reformulée en
  comparaison de partition restreinte au périmètre de la cible.