### PR TITLE
IHM : diagnostic nominatif quand la cible nodale n'est pas atteinte

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,19 @@ untouched. See `docs/release-notes/v0.3.2.md`.
   carries its `message` / `noeuds_non_realisables` / `ecarts` — the previous
   isolated-works branch blanked them, which is why the false warning showed up
   with no explanation.
+- **IHM — a negative verdict names the offending feeders.** Two different
+  partitions can have the same node count, so « obtenu 1 nœud(s), visé 1 »
+  carried no usable information. `_ecart_cible` (pure function over two
+  `TopologieNodale` + the realized isolated set) now reports: **disconnected
+  works that the target places on a node** — the engine never re-energizes a
+  disconnected feeder (documented limitation), so such a target is structurally
+  unreachable; the message lists them and points at **⌀ Isoler**. This is the
+  typical outcome of « Retenir comme cible » on an hour where those works were
+  still in service. Then **feeders not grouped as targeted** (computed after
+  removing the former, so one unreconnectable work does not flag its whole node)
+  and **works that could not be isolated**. `depart_iso` is also read straight
+  off the memoized graph instead of `nodale_state`, which restores the network to
+  `self.current` as a side effect.
 - **`test_config_post_updates_dirs` repaired.** It pointed `/api/config` at a
   `tmp_path` outside every allowed store root, so the path-traversal guard
   (`_dir_within_allowed`, 0.2.6) legitimately refused it and the test had been

--- a/docs/manoeuvre/ihm.md
+++ b/docs/manoeuvre/ihm.md
@@ -537,6 +537,23 @@ côté est écarté (`partition_hors_isoles_inconnus`). Conséquences :
 `partition()` reste **exhaustive** (isolés inclus) : les goldens et
 `partition_obtenue` sont inchangés.
 
+**Diagnostic nominatif d'un verdict négatif.** Deux partitions différentes
+peuvent avoir le **même nombre de nœuds** : « obtenu 1 nœud(s), visé 1 » ne dit
+rien d'exploitable. Quand la cible n'est pas atteinte, le statut nomme désormais
+les départs en cause (`_ecart_cible`, fonction pure) :
+
+- **ouvrages déconnectés que la cible place sur un nœud** — le moteur ne
+  réénergise **jamais** un départ déconnecté (limite documentée : « le placement
+  ne place que les départs connectés »), donc une telle cible est
+  structurellement inatteignable. Le message les liste et indique la sortie :
+  les déclarer *ouvrages isolés* (**⌀ Isoler**). C'est le cas typique de
+  « **Retenir comme cible** » sur une heure où ces ouvrages étaient en service ;
+- **départs non regroupés comme visé** — une fois les précédents écartés, pour
+  qu'un seul ouvrage non reconnectable ne fasse pas apparaître tout son nœud
+  comme fautif ;
+- **ouvrage(s) impossible(s) à isoler** — un départ déclaré hors cible que
+  `_isoler_dans_etat` n'a pas pu déconnecter.
+
 ### Naviguer et éditer la séquence (expert)
 La séquence calculée peut être **parcourue et modifiée** directement, sans avoir
 à balayer toutes les étapes :

--- a/docs/release-notes/v0.3.2.md
+++ b/docs/release-notes/v0.3.2.md
@@ -94,10 +94,30 @@ Consequences elsewhere:
   reconnection, and keeps the strict check.
 - **IHM diagnostics**: a negative verdict now always carries its `message` /
   `noeuds_non_realisables` / `ecarts`. The previous isolated-works branch blanked
-  them, which is why the false warning appeared with no explanation at all. A
-  work that could not actually be disconnected is named explicitly
-  (« Ouvrage(s) impossible(s) à isoler : … ») instead of silently degrading the
-  verdict.
+  them, which is why the false warning appeared with no explanation at all.
+
+### 3. A negative verdict now names the offending feeders
+
+Two different partitions can have the **same node count**, so
+« obtenu 1 nœud(s), visé 1 » carried no usable information. `_ecart_cible` (a
+pure function over two `TopologieNodale` and the realized isolated set) now
+produces a nominative diagnosis:
+
+- **disconnected works that the target places on a node** — the engine never
+  re-energizes a disconnected feeder (documented limitation: "placement only
+  places connected feeders"), so such a target is structurally unreachable. The
+  message lists them and points at the way out: declare them *isolated works*
+  (**⌀ Isoler**). This is the typical outcome of **« Retenir comme cible »** on
+  an hour where those works were still in service — the retained nodal partition
+  puts them back on the node;
+- **feeders not grouped as targeted** — computed after removing the above, so a
+  single unreconnectable work does not flag its whole node;
+- **works that could not be isolated** — a feeder declared out of scope that
+  `_isoler_dans_etat` failed to disconnect.
+
+Also hardened: `depart_iso` is read straight off the memoized graph
+(`_isolated_assets(self._graph(self.initial))`) instead of `nodale_state`, which
+restores the network to `self.current` as a side effect.
 
 Regression tests: `tests/manoeuvre/test_ouvrages_isoles_verification.py` (core on
 a pure NetworkX graph, algo level through `PlanificateurTopologie`, IHM level

--- a/scripts/manoeuvre_ihm.py
+++ b/scripts/manoeuvre_ihm.py
@@ -257,6 +257,35 @@ def _normalize_groups(all_branches, groups) -> list[list[str]]:
     return result
 
 
+def _ecart_cible(topo_reelle, topo_cible, iso_real) -> tuple[list[str], list[str]]:
+    """Écart **lisible** entre la topologie réalisée et la partition visée.
+
+    Renvoie ``(a_reconnecter, mal_places)`` :
+
+    - ``a_reconnecter`` : départs que la cible place sur un nœud mais qui restent
+      **déconnectés**. Le moteur ne réénergise **jamais** un départ déconnecté
+      (limite documentée : « le placement ne place que les départs connectés »),
+      donc toute cible qui en mentionne un est structurellement inatteignable ;
+    - ``mal_places`` : départs raccordés dont le **regroupement** obtenu diffère
+      du regroupement visé, une fois les précédents écartés (sinon un seul
+      ouvrage non reconnectable ferait apparaître tout son nœud comme fautif).
+
+    Fonction pure (deux ``TopologieNodale`` + un ensemble d'identifiants)."""
+    vise = topo_cible.univers()
+    a_reconnecter = sorted(vise & set(iso_real))
+    reste = vise - set(a_reconnecter)
+    mal_places = []
+    for eq in sorted(reste):
+        grp_vise = set(
+            topo_cible.noeuds[topo_cible.noeud_par_depart[eq]].equipment_ids) & reste
+        nom_reel = topo_reelle.noeud_par_depart.get(eq)
+        grp_reel = (set(topo_reelle.noeuds[nom_reel].equipment_ids)
+                    if nom_reel else set()) & reste
+        if grp_vise != grp_reel:
+            mal_places.append(eq)
+    return a_reconnecter, mal_places
+
+
 def _decode_svg_id(s: str) -> str:
     """Décode un identifiant SVG pypowsybl (``_46_`` → ``.``, ``_95_`` → ``_``,
     ``_45_`` → ``-``…). Fonction pure."""
@@ -964,7 +993,9 @@ class Session:
         # (les glisser sur un nœud = demande explicite de reconnexion, ils
         # restent alors dans le périmètre de la cible).
         demandes = {e for g in (groups or []) for e in g}
-        depart_iso = set(self.nodale_state(self.initial)["isolated"])
+        # (lecture directe sur le graphe mémoïsé : ne touche pas l'état appliqué
+        # au réseau, contrairement à ``nodale_state`` qui restaure ``self.current``)
+        depart_iso = set(_isolated_assets(self._graph(self.initial)))
         hors_cible = iso | (depart_iso - demandes)
         univers = [eq for grp in self.groups_of(self.initial)
                    for eq in grp if eq not in hors_cible]
@@ -1011,12 +1042,29 @@ class Session:
         if is_ok:
             message, ecarts, non_real = "", [], []
         else:
-            # Diagnostic complet quand la cible n'est effectivement pas atteinte.
-            message = ident.message if not partition_ok else ""
+            # Diagnostic **nominatif** quand la cible n'est pas atteinte : dire
+            # quels départs posent problème, pas seulement « obtenu N / visé M »
+            # (deux partitions différentes peuvent avoir le même nombre de nœuds).
+            diag = []
+            if not partition_ok:
+                a_reconnecter, mal_places = _ecart_cible(
+                    topo_reelle, topo_cible, iso_real)
+                if a_reconnecter:
+                    diag.append(
+                        "Ouvrage(s) déconnecté(s) au départ que la cible place sur "
+                        "un nœud : " + ", ".join(a_reconnecter) + " — le moteur ne "
+                        "réénergise pas un départ déconnecté. Déclarez-les "
+                        "« ouvrages isolés » (⌀ Isoler) pour viser une cible "
+                        "réalisable.")
+                if mal_places:
+                    diag.append("Départ(s) non regroupés comme visé : "
+                                + ", ".join(mal_places) + ".")
+                if not diag and ident.message:
+                    diag.append(ident.message)
             if non_isoles:
-                message = (message + " " if message else "") + (
-                    "Ouvrage(s) impossible(s) à isoler : "
-                    + ", ".join(non_isoles) + ".")
+                diag.append("Ouvrage(s) impossible(s) à isoler : "
+                            + ", ".join(non_isoles) + ".")
+            message = " ".join(diag)
             ecarts = seq.ecarts if seq is not None else []
             non_real = ident.noeuds_non_realisables
         return {

--- a/tests/manoeuvre/test_ouvrages_isoles_verification.py
+++ b/tests/manoeuvre/test_ouvrages_isoles_verification.py
@@ -217,10 +217,38 @@ def test_ihm_reconnexion_demandee_reste_dans_le_perimetre(session_avec_isole):
 
     assert res["nb_vise"] == 2
     # La reconnexion d'un départ déconnecté est hors de portée de l'algo (limite
-    # documentée) : le verdict est négatif — mais **expliqué**, jamais nu.
+    # documentée) : le verdict est négatif — mais **expliqué et nominatif**.
     assert res["is_verified"] is False
-    assert res["message"]
+    assert iso in res["message"]
+    assert "ne réénergise pas un départ déconnecté" in res["message"]
     assert iso in res["nodale"]["isolated"]         # pas reconnecté
+
+
+def test_ihm_cible_identite_avec_ouvrages_deja_deconnectes(session_avec_isole):
+    """Cible = **identité** (la partition de départ, isolés présentés à part) :
+    aucune manœuvre nécessaire, verdict positif."""
+    s, iso, connectes = session_avec_isole
+    res = s.nodale_to_detaillee([list(connectes)], [iso])
+
+    assert res["is_verified"] is True
+    assert res["nb_obtenu"] == res["nb_vise"] == 1
+    assert res["nb_isoles"] == 1
+    assert res["message"] == ""
+
+
+def test_ihm_message_nomme_les_ouvrages_non_reconnectables(session_avec_isole):
+    """Régression du second faux positif observé : une cible « identité » issue
+    d'une autre heure remet l'ouvrage déjà déconnecté **sur le nœud**. Le verdict
+    est légitimement négatif, mais l'ancien message (« obtenu 1 nœud(s), visé
+    1 ») était illisible — deux partitions différentes peuvent avoir le même
+    nombre de nœuds. Le message doit **nommer** l'ouvrage fautif."""
+    s, iso, connectes = session_avec_isole
+    res = s.nodale_to_detaillee([connectes + [iso]], [])
+
+    assert res["is_verified"] is False
+    assert res["nb_obtenu"] == res["nb_vise"] == 1     # même compte, écart réel
+    assert iso in res["message"]
+    assert "nœud(s), visé" not in res["message"]       # plus le message opaque
 
 
 def test_ihm_verdict_negatif_reste_diagnostique(session_avec_isole):
@@ -235,3 +263,29 @@ def test_ihm_verdict_negatif_reste_diagnostique(session_avec_isole):
     assert res["is_verified"] is False
     assert res["message"]
     assert res["noeuds_non_realisables"]
+
+
+# ---------------------------------------------------------------------------
+# 4. Diagnostic d'écart — fonction pure
+# ---------------------------------------------------------------------------
+
+def test_ecart_cible_nomme_les_ouvrages_a_reconnecter():
+    reelle = TopologieNodale.from_graph(_graphe(deconnecte=("L3",)), "VL")
+    cible = TopologieNodale.from_node_groups("VL", [["L1", "L2", "L3"]])
+    a_reconnecter, mal_places = ihm._ecart_cible(reelle, cible, {"L3"})
+    assert a_reconnecter == ["L3"]
+    assert mal_places == []          # L1/L2 sont bien regroupés
+
+
+def test_ecart_cible_nomme_les_departs_mal_regroupes():
+    reelle = TopologieNodale.from_graph(_graphe(deconnecte=()), "VL")
+    cible = TopologieNodale.from_node_groups("VL", [["L1"], ["L2", "L3"]])
+    a_reconnecter, mal_places = ihm._ecart_cible(reelle, cible, set())
+    assert a_reconnecter == []
+    assert mal_places == ["L1", "L2", "L3"]
+
+
+def test_ecart_cible_vide_quand_la_cible_est_atteinte():
+    reelle = TopologieNodale.from_graph(_graphe(), "VL")
+    cible = TopologieNodale.from_node_groups("VL", [["L1", "L2"]])
+    assert ihm._ecart_cible(reelle, cible, {"L3"}) == ([], [])


### PR DESCRIPTION
Second cas remonté : cible = topologie retenue d'une autre heure, où des ouvrages déconnectés au départ étaient encore en service. La partition nodale retenue les replace donc **sur le nœud** — une demande de reconnexion que le moteur ne sait pas satisfaire (limite documentée : « le placement ne place que les départs connectés », il ne réénergise jamais un départ déconnecté).

Le verdict négatif est correct, mais le message était illisible :

    ⚠ Cible partiellement réalisable (obtenu 1 nœud(s) + 5 ouvrage(s) isolé(s)
      / visé 1 nœud(s)). La topologie obtenue ne correspond pas à la cible
      (obtenu 1 nœud(s), visé 1).

Deux partitions différentes peuvent avoir le **même nombre de nœuds** : « obtenu 1, visé 1 » ne dit rien d'exploitable, et l'expert lit l'écart comme un bug.

`_ecart_cible` (fonction pure : deux `TopologieNodale` + les isolés réalisés) produit désormais un diagnostic nominatif :

- ouvrages déconnectés que la cible place sur un nœud → nommés, avec la sortie (les déclarer « ouvrages isolés » via ⌀ Isoler) ;
- départs non regroupés comme visé → calculés **après** retrait des précédents, pour qu'un seul ouvrage non reconnectable ne fasse pas apparaître tout son nœud comme fautif ;
- ouvrage(s) impossible(s) à isoler.

Durci au passage : `depart_iso` est lu directement sur le graphe mémoïsé (`_isolated_assets(self._graph(self.initial))`) au lieu de `nodale_state`, qui réapplique `self.current` au réseau en effet de bord.

Tests : 3 tests de la fonction pure + cible identité vérifiée + régression du
message nominatif. Suite manœuvre : 1095 passed, 4 skipped.