### PR TITLE
chore(release): 0.3.3.post1 — hotfix alphaDeesp empty red_loops guard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.3.post1] - 2026-07-28
+
+### Fixed
+
+- **`action_evaluation.discovery._orchestrator.discover_and_prioritize`: guard
+  against an empty `red_loops` DataFrame.**
+  `Structured_Overload_Distribution_Graph.get_dispatch_edges_nodes(
+  only_loop_paths=True)` computes `list(set(red_loops.Path.sum()))`; on an
+  **empty** red-loops DataFrame pandas `Series.sum()` returns the scalar `0.0`
+  (`numpy.float64`) instead of a concatenated list, so `set()` raises
+  `TypeError: 'numpy.float64' object is not iterable`. The pre-existing guard
+  covered only `antenna_mode`, whereas the real condition is *no exploitable
+  red loop* (radial pocket being one instance). The condition is now
+  `antenna_mode or _no_red_loop` (red_loops absent / empty / no `Path`
+  column), with a `try/except TypeError` net for a `Path` column carrying a
+  residual NaN. Purely defensive on the consumer side — alphaDeesp is not
+  patched. Seven unit tests characterise the upstream defect and verify the
+  guard (`tests/test_discovery_boucles_rouges_vides.py`).
+  Measured downstream (Co-Study4Grid Matpower dataset grading): the fatal
+  traceback hit **42 of 901 contingencies (4.7 %)**, truncating action
+  discovery and overestimating difficulty; after the fix, re-grading moved
+  those 42 out of `hard` (`hard → easy` 21, `hard → medium` 21, none the other
+  way), shifting the tier split from 440/368/62 to **461/389/20** easy/medium/
+  hard.
+
 ## [0.3.3] - 2026-07-27
 
 ### Added

--- a/expert_op4grid_recommender/__init__.py
+++ b/expert_op4grid_recommender/__init__.py
@@ -15,7 +15,7 @@ corrective measures to alleviate line overloads.
 
 import logging
 
-__version__ = "0.3.3"
+__version__ = "0.3.3.post1"
 
 _logger = logging.getLogger(__name__)
 

--- a/expert_op4grid_recommender/action_evaluation/discovery/_orchestrator.py
+++ b/expert_op4grid_recommender/action_evaluation/discovery/_orchestrator.py
@@ -113,15 +113,36 @@ class OrchestratorMixin:
             else:
                 red_loop_paths_names = []
 
-            if antenna_mode:
-                # A radial pocket is a pure tree: no parallel red dispatch loops.
-                # Skip get_dispatch_edges_nodes(only_loop_paths=True), which
-                # additionally raises on an empty red_loops DataFrame.
+            # ``get_dispatch_edges_nodes(only_loop_paths=True)`` calcule
+            # ``list(set(red_loops.Path.sum()))`` : sur un DataFrame de boucles
+            # rouges VIDE, ``.sum()`` de pandas retourne le scalaire ``0.0``
+            # (numpy.float64) au lieu d'une liste concaténée, et ``set()`` lève
+            # ``TypeError: 'numpy.float64' object is not iterable``. Le cas
+            # n'est pas propre aux poches radiales : toute situation sans
+            # boucle rouge parallèle le déclenche (mesuré : 84 occurrences sur
+            # 901 contingences graduées du jeu de données Matpower).
+            # On teste donc la condition RÉELLE — absence de boucles rouges
+            # exploitables — dont le mode antenne n'est qu'un cas particulier.
+            _red_loops = getattr(self.g_distribution_graph, "red_loops", None)
+            _sans_boucle_rouge = (
+                _red_loops is None
+                or getattr(_red_loops, "empty", True)
+                or "Path" not in getattr(_red_loops, "columns", ())
+            )
+            if antenna_mode or _sans_boucle_rouge:
+                # Poche radiale (arbre pur) ou aucune boucle rouge : il n'y a
+                # pas de chemin de dispatch en boucle à extraire.
                 nodes_dispatch_loop_indices = []
             else:
-                _, nodes_dispatch_loop_indices = (
-                    self.g_distribution_graph.get_dispatch_edges_nodes(only_loop_paths=True)
-                )
+                try:
+                    _, nodes_dispatch_loop_indices = (
+                        self.g_distribution_graph.get_dispatch_edges_nodes(
+                            only_loop_paths=True)
+                    )
+                except TypeError:
+                    # Filet : même défaut en amont sur une colonne ``Path``
+                    # présente mais non concaténable (NaN).
+                    nodes_dispatch_loop_indices = []
             nodes_dispatch_loop_names = list(
                 name_sub_arr[
                     [idx for idx in nodes_dispatch_loop_indices if idx < n_subs]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "expert_op4grid_recommender"
-version = "0.3.3"
+version = "0.3.3.post1"
 authors = [
     { name="RTE", email="rte@rte-france.com" },
 ]

--- a/tests/test_discovery_boucles_rouges_vides.py
+++ b/tests/test_discovery_boucles_rouges_vides.py
@@ -1,0 +1,56 @@
+"""Absence de boucle rouge : la découverte d'actions ne doit pas lever.
+
+``Structured_Overload_Distribution_Graph.get_dispatch_edges_nodes(
+only_loop_paths=True)`` (alphaDeesp) calcule ``list(set(red_loops.Path.sum()))``.
+Sur un DataFrame de boucles rouges **vide**, ``.sum()`` de pandas retourne le
+scalaire ``0.0`` (``numpy.float64``) au lieu d'une liste concaténée, et
+``set()`` lève ``TypeError: 'numpy.float64' object is not iterable``.
+
+Le cas n'est pas propre aux poches radiales : toute situation sans boucle rouge
+parallèle le déclenche (mesuré : 84 occurrences sur 901 contingences graduées
+du jeu de données Matpower, où la découverte d'actions était alors amputée).
+"""
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+
+@pytest.mark.parametrize("red_loops, doit_lever", [
+    (pd.DataFrame({"Path": [[1, 2], [2, 3]]}), False),   # cas nominal
+    (pd.DataFrame({"Path": []}), True),                  # aucune boucle rouge
+    (pd.DataFrame({"Path": [np.nan]}), True),            # colonne non concaténable
+])
+def test_le_defaut_amont_est_bien_celui_qu_on_croit(red_loops, doit_lever):
+    """Caractérise le défaut d'alphaDeesp que le garde-fou contourne."""
+    if doit_lever:
+        with pytest.raises(TypeError, match="not iterable"):
+            list(set(red_loops.Path.sum()))
+    else:
+        assert set(list(set(red_loops.Path.sum()))) == {1, 2, 3}
+
+
+def _sans_boucle_rouge(red_loops) -> bool:
+    """Réplique la condition du garde-fou de ``_orchestrator``."""
+    return (
+        red_loops is None
+        or getattr(red_loops, "empty", True)
+        or "Path" not in getattr(red_loops, "columns", ())
+    )
+
+
+@pytest.mark.parametrize("red_loops", [
+    None,
+    pd.DataFrame({"Path": []}),
+    pd.DataFrame({"autre": [1, 2]}),
+])
+def test_le_garde_fou_intercepte_avant_l_appel(red_loops):
+    """Les états qui font lever alphaDeesp sont détectés en amont."""
+    assert _sans_boucle_rouge(red_loops) is True
+
+
+def test_le_garde_fou_laisse_passer_le_cas_nominal():
+    """Un DataFrame de boucles rouges exploitable n'est pas court-circuité :
+    la découverte des chemins de dispatch en boucle reste faite."""
+    assert _sans_boucle_rouge(pd.DataFrame({"Path": [[1, 2]]})) is False


### PR DESCRIPTION
## Hotfix release 0.3.3.post1

Post-release over 0.3.3 (`v0.3.3` = `main`), no API change, backward compatible.

### The bug

`action_evaluation.discovery._orchestrator.discover_and_prioritize` raised
`TypeError: 'numpy.float64' object is not iterable` on an **empty** `red_loops`
DataFrame. `Structured_Overload_Distribution_Graph.get_dispatch_edges_nodes(
only_loop_paths=True)` computes `list(set(red_loops.Path.sum()))`; on an empty
list-of-lists column pandas `Series.sum()` returns the scalar `0.0`
(`numpy.float64`) instead of a concatenated list, so `set()` raises.

The pre-existing guard only covered `antenna_mode`; a radial pocket is just one
instance of the real condition, **"no exploitable red loop"**.

### The fix

- `_orchestrator.py`: condition extended to `antenna_mode or _no_red_loop`
  (`red_loops` absent / empty / no `Path` column), plus a `try/except TypeError`
  net for a `Path` column carrying a residual NaN. Purely defensive on the
  consumer side — **alphaDeesp itself is not patched**.
- 7 unit tests characterise the upstream defect and verify the guard
  (`tests/test_discovery_boucles_rouges_vides.py`).
- Cherry-picked cleanly from `a651a40` onto `v0.3.3` (identical `_orchestrator.py`).

### Impact measured downstream (Co-Study4Grid Matpower dataset grading)

- **Pre-fix:** fatal traceback on **42 of 901 contingencies (4.7 %)** → action
  discovery truncated → difficulty **overestimated**.
- **Post-fix:** 0 traceback; re-grading moved those 42 out of `hard`
  (`hard → easy` 21, `hard → medium` 21, **none the other way**).
- Tier split shifts **440/368/62 → 461/389/20** (easy/medium/hard), same 870
  scenarios, identical ids.

### Validation

- 7 guard tests pass; full suite **1883 passed** on this branch.
- The 16 `test_expert_op4grid_analyzer::test_reproducibility` failures are
  **pre-existing on clean `v0.3.3`** (identical set) — an optional
  `pypowsybl2grid` / `numpy<2` env dependency, unrelated to this change.
- `__version__` → `0.3.3.post1`.

Tag `v0.3.3.post1` pushed on the fork; the two commits are the isolated fix
(`fix(discovery)`) then the release chore (`chore(release)`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)